### PR TITLE
Fix Aspire SDK mismatch and Terraform state-lock retries

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: Infra
-        run: terraform init
+        run: terraform init -lock-timeout=5m
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: Infra
-        run: terraform init
+        run: terraform init -lock-timeout=5m
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_INFRA }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_INFRA }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: Infra
-        run: terraform init
+        run: terraform init -lock-timeout=5m
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_INFRA }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_INFRA }}

--- a/SimplyBudgetWeb.AppHost/SimplyBudgetWeb.AppHost.csproj
+++ b/SimplyBudgetWeb.AppHost/SimplyBudgetWeb.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.1">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- align Aspire.AppHost.Sdk with upgraded Aspire hosting packages
- add Terraform init lock timeout in deploy workflows to handle transient state lock contention

## Why
Recent runs failed due an AppHost SDK/package mismatch and immediate Terraform lock failures during concurrent deploy operations.