### PR TITLE
Fix MSTest v4 assert API usage

### DIFF
--- a/SimplyBudgetSharedTests/Data/ExpenseCategoryItemTests.cs
+++ b/SimplyBudgetSharedTests/Data/ExpenseCategoryItemTests.cs
@@ -66,7 +66,7 @@ public class ExpenseCategoryItemTests
     {
         var item = new ExpenseCategoryItem();
 
-        var ex = Assert.ThrowsException<ArgumentNullException>(() => item.IgnoreBudget = null);
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() => item.IgnoreBudget = null);
         Assert.AreEqual("value", ex.ParamName);
     }
 
@@ -75,7 +75,7 @@ public class ExpenseCategoryItemTests
     {
         var item = new ExpenseCategoryItem();
 
-        var ex = Assert.ThrowsException<ArgumentNullException>(() => item.IgnoreBudget = null);
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() => item.IgnoreBudget = null);
         Assert.AreEqual("value", ex.ParamName);
     }
 


### PR DESCRIPTION
## Summary
- replace removed Assert.ThrowsException<T> calls with Assert.ThrowsExactly<T> in shared tests

## Why
MSTest v4 removed ThrowsException, which was breaking the .NET workflow after Dependabot updates.