### PR TITLE
Fix accessibility regression in loading spinners

### DIFF
--- a/SimplyBudgetSharedTests/Data/ExpenseCategoryItemTests.cs
+++ b/SimplyBudgetSharedTests/Data/ExpenseCategoryItemTests.cs
@@ -66,7 +66,7 @@ public class ExpenseCategoryItemTests
     {
         var item = new ExpenseCategoryItem();
 
-        var ex = Assert.ThrowsException<ArgumentNullException>(() => item.IgnoreBudget = null);
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() => item.IgnoreBudget = null);
         Assert.AreEqual("value", ex.ParamName);
     }
 
@@ -75,7 +75,7 @@ public class ExpenseCategoryItemTests
     {
         var item = new ExpenseCategoryItem();
 
-        var ex = Assert.ThrowsException<ArgumentNullException>(() => item.IgnoreBudget = null);
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() => item.IgnoreBudget = null);
         Assert.AreEqual("value", ex.ParamName);
     }
 

--- a/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.tsx
+++ b/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.tsx
@@ -207,7 +207,7 @@ export default function AddTransactionDialog({ open, onClose, categories, onSucc
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
         <Button variant="contained" onClick={handleSubmit} disabled={submitting}>
-          {submitting ? <CircularProgress size={20} /> : 'Save'}
+          {submitting ? <CircularProgress size={20} aria-label="Saving transaction" /> : 'Save'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/SimplyBudgetWeb.Web/src/pages/Accounts.tsx
+++ b/SimplyBudgetWeb.Web/src/pages/Accounts.tsx
@@ -75,7 +75,7 @@ export default function Accounts() {
       </Box>
 
       {loading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress aria-label="Loading accounts" /></Box>
       ) : (
         <List>
           {accounts.map(account => (

--- a/SimplyBudgetWeb.Web/src/pages/Budget.tsx
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.tsx
@@ -76,7 +76,7 @@ export default function Budget() {
 
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-          <CircularProgress />
+          <CircularProgress aria-label="Loading budget" />
         </Box>
       ) : (
         <Box>

--- a/SimplyBudgetWeb.Web/src/pages/History.tsx
+++ b/SimplyBudgetWeb.Web/src/pages/History.tsx
@@ -103,7 +103,7 @@ export default function History() {
       </Paper>
 
       {loading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress aria-label="Loading history" /></Box>
       ) : (
         <List>
           {items.length === 0 && (

--- a/SimplyBudgetWeb.Web/src/pages/Import.tsx
+++ b/SimplyBudgetWeb.Web/src/pages/Import.tsx
@@ -74,7 +74,7 @@ export default function Import() {
           sx={{ mb: 2 }}
         />
         <Button variant="contained" onClick={handleParse} disabled={loading || !csvText.trim()}>
-          {loading ? <CircularProgress size={20} /> : 'Parse'}
+          {loading ? <CircularProgress size={20} aria-label="Parsing import data" /> : 'Parse'}
         </Button>
       </Paper>
 
@@ -133,7 +133,7 @@ export default function Import() {
             </Table>
           </Paper>
           <Button variant="contained" onClick={handleImport} disabled={submitting}>
-            {submitting ? <CircularProgress size={20} /> : 'Save Import'}
+            {submitting ? <CircularProgress size={20} aria-label="Saving import" /> : 'Save Import'}
           </Button>
         </>
       )}

--- a/SimplyBudgetWeb.Web/src/pages/Settings.tsx
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.tsx
@@ -140,7 +140,7 @@ export default function Settings() {
       </Box>
 
       {loading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>
+        <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress aria-label="Loading import rules" /></Box>
       ) : (
         <List>
           {rules.length === 0 && <ListItem><ListItemText primary="No rules defined." /></ListItem>}


### PR DESCRIPTION
## Summary
- add accessible labels to CircularProgress indicators used across pages and dialogs
- resolve CI UI accessibility failure (aria-progressbar-name) on landing page

## Validation
- dotnet test SimplyBudgetWeb.UITests/SimplyBudgetWeb.UITests.csproj --configuration Release