### PR TITLE
Fix deployment readiness step exit handling

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -244,6 +244,7 @@ jobs:
             if ($LASTEXITCODE -ne 0) {
               $deployReady = $false
               $reasons += "Container App '$backendContainerAppName' was not found in resource group '$resourceGroupName'"
+              $LASTEXITCODE = 0
             }
           }
 


### PR DESCRIPTION
## Summary
- keep deployment-readiness checks in Build and Deploy workflow
- reset LASTEXITCODE after expected container-app lookup failures so the check can report warnings without failing the workflow
- continue skipping deploy jobs when prerequisites are unavailable