### PR TITLE
Fix infra pipeline: static web app region + app insights import

### DIFF
--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -202,8 +202,11 @@ module "static_web_app" {
 
   name = local.static_web_app_name
   resource_group = {
-    name     = data.azurerm_resource_group.resource_group.name
-    location = data.azurerm_resource_group.resource_group.location
+    name = data.azurerm_resource_group.resource_group.name
+    # Azure Static Web Apps are only available in a limited set of regions
+    # (the resource group's region, westus3, is not one of them), so pin
+    # this to a supported region regardless of the resource group's location.
+    location = "westus2"
   }
   sku = {
     tier = "Free"


### PR DESCRIPTION
## Summary
The infra pipeline (`deploy-infrastructure.yml`) was failing on `terraform apply` with two errors:

1. **Static Web App region unsupported**: `LocationNotAvailableForResourceType` — the `simplybudget-prod-swa` Static Web App was being deployed into the `KebooDev` resource group's region (`westus3`), but Azure Static Web Apps only support `centralus, eastus2, westus2, westeurope, eastasia`. Fixed by pinning the static web app's location to `westus2` explicitly instead of inheriting the resource group's location.
2. **Application Insights already exists**: `simplybudgetweb-prod-appinsights` already existed in Azure (from a prior partially-successful run) but wasn't tracked in Terraform state. Fixed by running `terraform import` against the remote state to bring it under management (no code change required for this part — it's a one-time state operation, already applied).

## Verification
Ran `terraform plan` against the actual remote state after the import and location fix:
- Application Insights: **0 changes** (already imported, no drift).
- Static Web App: will be **created** with `location = "westus2"`.
- Plan: `2 to add, 0 to change, 0 to destroy` (static web app + backend container app, which never got created due to the original failures).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>