### PR TITLE
Establishes dedicated RG for app resources

### DIFF
--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -12,6 +12,7 @@ module "prod" {
   tags        = local.default_tags
 
   existing_resource_group_name            = var.existing_resource_group_name
+  app_resource_group_name                 = var.app_resource_group_name
   existing_container_registry_name        = var.existing_container_registry_name
   existing_container_app_environment_name = var.existing_container_app_environment_name
   existing_sql_server_name                = var.existing_sql_server_name

--- a/Infra/outputs.tf
+++ b/Infra/outputs.tf
@@ -9,8 +9,13 @@ output "backend_container_app_name" {
 }
 
 output "resource_group_name" {
-  description = "The name of the resource group"
+  description = "The name of the dedicated SimplyBudget resource group containing the app's non-shared resources"
   value       = module.prod.resource_group_name
+}
+
+output "shared_resource_group_name" {
+  description = "The name of the existing shared resource group (KebooDev) referenced for shared infrastructure"
+  value       = module.prod.shared_resource_group_name
 }
 
 output "static_web_app_name" {

--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -20,8 +20,19 @@ locals {
   ]
 }
 
+# Shared infrastructure (Container App Environment, Container Registry, SQL Server/Database)
+# lives in the existing KebooDev resource group and is referenced, not managed, here.
 data "azurerm_resource_group" "resource_group" {
   name = var.existing_resource_group_name
+}
+
+# Dedicated resource group for SimplyBudget's non-shared infrastructure
+# (managed identity, container app, static web app, application insights).
+resource "azurerm_resource_group" "app" {
+  name     = var.app_resource_group_name
+  location = var.location
+
+  tags = local.tags
 }
 
 data "azurerm_client_config" "current" {}
@@ -32,8 +43,8 @@ data "azuread_service_principal" "provisioning_principal" {
 
 resource "azurerm_user_assigned_identity" "app_identity" {
   name                = "simplybudget-${lower(local.environment)}-mi"
-  location            = data.azurerm_resource_group.resource_group.location
-  resource_group_name = data.azurerm_resource_group.resource_group.name
+  location            = azurerm_resource_group.app.location
+  resource_group_name = azurerm_resource_group.app.name
 
   tags = local.tags
 }
@@ -179,7 +190,7 @@ module "backend_container_app" {
 
   name                            = local.backend_container_app_name
   container_app_environment_id    = data.azurerm_container_app_environment.existing.id
-  resource_group_name             = data.azurerm_resource_group.resource_group.name
+  resource_group_name             = azurerm_resource_group.app.name
   identity_id                     = azurerm_user_assigned_identity.app_identity.id
   container_registry_login_server = data.azurerm_container_registry.existing.login_server
 
@@ -202,11 +213,8 @@ module "static_web_app" {
 
   name = local.static_web_app_name
   resource_group = {
-    name = data.azurerm_resource_group.resource_group.name
-    # Azure Static Web Apps are only available in a limited set of regions
-    # (the resource group's region, westus3, is not one of them), so pin
-    # this to a supported region regardless of the resource group's location.
-    location = "westus2"
+    name     = azurerm_resource_group.app.name
+    location = azurerm_resource_group.app.location
   }
   sku = {
     tier = "Free"
@@ -219,9 +227,12 @@ module "static_web_app" {
 module "application_insights" {
   source = "../modules/app_insights"
 
-  environment    = local.environment
-  resource_group = data.azurerm_resource_group.resource_group
-  tags           = local.tags
+  environment = local.environment
+  resource_group = {
+    name     = azurerm_resource_group.app.name
+    location = azurerm_resource_group.app.location
+  }
+  tags = local.tags
 
   reader_ids = {}
 }

--- a/Infra/prod/outputs.tf
+++ b/Infra/prod/outputs.tf
@@ -13,7 +13,12 @@ output "backend_container_app_name" {
 }
 
 output "resource_group_name" {
-  description = "The name of the resource group"
+  description = "The name of the dedicated SimplyBudget resource group containing the app's non-shared resources"
+  value       = azurerm_resource_group.app.name
+}
+
+output "shared_resource_group_name" {
+  description = "The name of the existing shared resource group (KebooDev) referenced for shared infrastructure"
   value       = data.azurerm_resource_group.resource_group.name
 }
 

--- a/Infra/prod/variables.tf
+++ b/Infra/prod/variables.tf
@@ -15,7 +15,12 @@ variable "tags" {
 }
 
 variable "existing_resource_group_name" {
-  description = "Existing resource group where infrastructure already exists."
+  description = "Existing resource group where shared infrastructure already exists."
+  type        = string
+}
+
+variable "app_resource_group_name" {
+  description = "Name of the dedicated resource group created for SimplyBudget's non-shared infrastructure."
   type        = string
 }
 

--- a/Infra/variables.tf
+++ b/Infra/variables.tf
@@ -34,6 +34,12 @@ variable "existing_resource_group_name" {
   default     = "KebooDev"
 }
 
+variable "app_resource_group_name" {
+  description = "Name of the dedicated resource group created for SimplyBudget's non-shared infrastructure."
+  type        = string
+  default     = "SimplyBudget"
+}
+
 variable "existing_container_registry_name" {
   description = "Existing Azure Container Registry name."
   type        = string

--- a/README.md
+++ b/README.md
@@ -78,12 +78,19 @@ If you need to use the legacy `.sln` format, use the `--sln true` parameter when
 ## Infrastructure
 
 Terraform (`Infra/`) is configured to use existing shared Azure resources rather than provisioning new
-ones:
+ones, while SimplyBudget's own (non-shared) resources live in their own dedicated resource group:
 
+Shared, existing infrastructure (referenced via Terraform data sources, not managed here):
 - Resource Group: `KebooDev`
 - ACR: `keboodevacr.azurecr.io`
 - Container App Environment: `keboodev-env`
-- SQL Server: `keboodev-sql`, Database: `keboodevdb` (discovered via Terraform data sources)
+- SQL Server: `keboodev-sql`, Database: `keboodevdb`
+
+SimplyBudget-specific infrastructure (managed by this Terraform config):
+- Resource Group: `SimplyBudget` (`westus2`, configurable via `app_resource_group_name`/`location` in
+  `Infra/variables.tf`)
+- Managed identity, backend Container App, Application Insights, and the Azure Static Web App all live
+  in this resource group
 - Frontend hosting is provisioned as an Azure Static Web App, and backend CORS allows that origin
 - Frontend production builds use Terraform's `backend_url` output
 


### PR DESCRIPTION
Creates a new, dedicated Azure Resource Group (defaulting to "SimplyBudget") to host all SimplyBudget application-specific infrastructure. This change separates app resources from shared infrastructure, improving organization and management.

*   Deploys the managed identity, backend container app, static web app, and application insights into the new dedicated resource group.
*   Explicitly references existing shared infrastructure (Container App Environment, Container Registry, SQL Server) from the `KebooDev` resource group.
*   Updates `README.md` to reflect the new infrastructure partitioning.