### PR TITLE
Fix Entra ID authentication for SQL connections

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
 
     <!-- Database -->
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">

--- a/SimplyBudgetWeb.Data/SimplyBudgetWeb.Data.csproj
+++ b/SimplyBudgetWeb.Data/SimplyBudgetWeb.Data.csproj
@@ -11,6 +11,11 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <!-- Required for "Authentication=Active Directory Default" / Entra ID connection strings.
+         Microsoft.Data.SqlClient 6+ moved Azure AD authentication providers into this
+         separate package; without it, ActiveDirectoryDefault connections fail with
+         "Cannot find an authentication provider for 'ActiveDirectoryDefault'". -->
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Microsoft.Data.SqlClient versions 6+ moved Azure AD authentication providers into a separate package. Without the `Microsoft.Data.SqlClient.Extensions.Azure` package, connections using 'Authentication=Active Directory Default' fail with 'Cannot find an authentication provider'.

This change adds the required package to resolve such connection failures.
