### PR TITLE
Pin Microsoft.Data.SqlClient to match Extensions.Azure version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,12 @@
 
     <!-- Database -->
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.11" />
+    <!-- Microsoft.EntityFrameworkCore.SqlServer 10.0.9 only requires Microsoft.Data.SqlClient
+         >= 6.1.1, which predates the Azure AD provider split and is binary-incompatible with
+         Microsoft.Data.SqlClient.Extensions.Azure 7.0.2 (mixing them causes an
+         AmbiguousMatchException in SqlAuthenticationProviderManager). Pin SqlClient itself to
+         7.0.2 so both packages are from the same release line. -->
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />

--- a/SimplyBudgetWeb.Data/SimplyBudgetWeb.Data.csproj
+++ b/SimplyBudgetWeb.Data/SimplyBudgetWeb.Data.csproj
@@ -11,6 +11,11 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <!-- Microsoft.EntityFrameworkCore.SqlServer only requires Microsoft.Data.SqlClient
+         >= 6.1.1 transitively. Pin it explicitly to the same release line as
+         Extensions.Azure below to avoid an AmbiguousMatchException in
+         SqlAuthenticationProviderManager caused by mismatched versions. -->
+    <PackageReference Include="Microsoft.Data.SqlClient" />
     <!-- Required for "Authentication=Active Directory Default" / Entra ID connection strings.
          Microsoft.Data.SqlClient 6+ moved Azure AD authentication providers into this
          separate package; without it, ActiveDirectoryDefault connections fail with


### PR DESCRIPTION
## Summary
Fixes the `AmbiguousMatchException` seen in CI when the EF migration bundle opens a connection using `Authentication=Active Directory Default` (run https://github.com/Keboo/SimplyBudget/actions/runs/31867093433/job/94970210236).

## Root cause
`Microsoft.EntityFrameworkCore.SqlServer` only requires `Microsoft.Data.SqlClient >= 6.1.1` transitively. That version predates the Azure AD authentication provider split and is binary-incompatible with `Microsoft.Data.SqlClient.Extensions.Azure` 7.0.2 (added in #92). Mixing the two causes `SqlAuthenticationProviderManager`'s static constructor to throw `AmbiguousMatchException` when resolving the `ActiveDirectoryDefault` provider.

## Fix
- Pin `Microsoft.Data.SqlClient` to `7.0.2` in `Directory.Packages.props` — same release line as `Microsoft.Data.SqlClient.Extensions.Azure`.
- Add an explicit `<PackageReference Include="Microsoft.Data.SqlClient" />` in `SimplyBudgetWeb.Data.csproj` so the pinned version wins over the transitive `6.1.1` resolved from `Microsoft.EntityFrameworkCore.SqlServer`.

## Verification
- `dotnet build SimplyBudgetWeb.slnx -c Release` — 0 errors.
- Confirmed the resolved `Microsoft.Data.SqlClient.dll` in build output is version `7.0.2.26175`.
- Rebuilt the self-contained `efbundle` exactly as CI does (`dotnet ef migrations bundle --self-contained --no-build --configuration Release ...`) and ran it against a fake Azure SQL `Authentication=Active Directory Default` connection string — the `AmbiguousMatchException` no longer occurs; it now fails only on DNS resolution (expected for a nonexistent host).
- `SimplyBudgetWeb.Core.Tests`: 13/13 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>