### PR TITLE
Manage SQL Server Entra admin as KebooDevDBAdmins group

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -56,6 +56,7 @@ jobs:
           TF_VAR_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_INFRA }}
           TF_VAR_TENANT_ID: ${{ secrets.ARM_TENANT_ID_INFRA }}
           TF_VAR_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_INFRA }}
+          TF_VAR_MIGRATION_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
 
       - name: Upload Terraform Plan
         uses: actions/upload-artifact@v7
@@ -116,3 +117,4 @@ jobs:
           TF_VAR_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_INFRA }}
           TF_VAR_TENANT_ID: ${{ secrets.ARM_TENANT_ID_INFRA }}
           TF_VAR_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_INFRA }}
+          TF_VAR_MIGRATION_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}

--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -19,4 +19,6 @@ module "prod" {
   existing_sql_database_name              = var.existing_sql_database_name
   database_schema_name                    = var.database_schema_name
   provisioning_client_id                  = var.CLIENT_ID
+  migration_client_id                     = var.MIGRATION_CLIENT_ID
+  sql_admin_group_name                    = var.sql_admin_group_name
 }

--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -21,4 +21,5 @@ module "prod" {
   provisioning_client_id                  = var.CLIENT_ID
   migration_client_id                     = var.MIGRATION_CLIENT_ID
   sql_admin_group_name                    = var.sql_admin_group_name
+  database_admin_user_names               = var.database_admin_user_names
 }

--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -18,6 +18,7 @@ locals {
     "db_datawriter",
     "db_ddladmin"
   ]
+  database_admin_user_names = var.database_admin_user_names
 }
 
 # Shared infrastructure (Container App Environment, Container Registry, SQL Server/Database)
@@ -112,7 +113,10 @@ resource "terraform_data" "setup_database_principal" {
     join(",", local.db_permissions),
     var.provisioning_client_id,
     data.azuread_group.sql_admins.object_id,
-    "v2" # Bumped from v1: SQL Entra admin is now the sql_admins group, not the provisioning principal
+    join(",", local.database_admin_user_names),
+    "v3" # Bumped from v2: explicitly create contained database users (db_owner) for
+    # individual admins, since the Azure Portal Query Editor does not reliably
+    # resolve access granted only via the sql_admins group membership.
   ]
 
   provisioner "local-exec" {
@@ -190,6 +194,18 @@ resource "terraform_data" "setup_database_principal" {
         }
 
         $queryParts += "GRANT EXECUTE TO [$identityName];"
+
+        # Explicitly create a contained database user (with db_owner rights) for each
+        # individual admin. Members of the sql_admins group already have administrative
+        # access via the server's Azure AD admin, but the Azure Portal's Query Editor does
+        # not reliably resolve access granted only through group membership, so an explicit
+        # user mapping is required for that experience to work.
+        $adminUsers = ConvertFrom-Json '${jsonencode(local.database_admin_user_names)}'
+        foreach ($adminUser in $adminUsers) {
+          $queryParts += "IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = '$adminUser') BEGIN CREATE USER [$adminUser] FROM EXTERNAL PROVIDER; END;"
+          $queryParts += "IF NOT EXISTS (SELECT 1 FROM sys.database_role_members drm JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id JOIN sys.database_principals m ON drm.member_principal_id = m.principal_id WHERE r.name = 'db_owner' AND m.name = '$adminUser') BEGIN ALTER ROLE db_owner ADD MEMBER [$adminUser]; END;"
+        }
+
         $sql = $queryParts -join " "
 
         Invoke-Sqlcmd -ConnectionString '${local.base_database_connection_string}' -AccessToken $token -Query $sql

--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -41,6 +41,29 @@ data "azuread_service_principal" "provisioning_principal" {
   client_id = var.provisioning_client_id
 }
 
+data "azuread_service_principal" "migration_principal" {
+  client_id = var.migration_client_id
+}
+
+# The Entra ID group that is configured as the SQL Server's Azure AD administrator.
+# This group is managed outside of Terraform; membership below ensures the
+# service principals that need to administer the database (running Terraform
+# and applying EF Core migrations) inherit that access.
+data "azuread_group" "sql_admins" {
+  display_name     = var.sql_admin_group_name
+  security_enabled = true
+}
+
+resource "azuread_group_member" "provisioning_principal_sql_admin" {
+  group_object_id  = data.azuread_group.sql_admins.object_id
+  member_object_id = data.azuread_service_principal.provisioning_principal.object_id
+}
+
+resource "azuread_group_member" "migration_principal_sql_admin" {
+  group_object_id  = data.azuread_group.sql_admins.object_id
+  member_object_id = data.azuread_service_principal.migration_principal.object_id
+}
+
 resource "azurerm_user_assigned_identity" "app_identity" {
   name                = "simplybudget-${lower(local.environment)}-mi"
   location            = azurerm_resource_group.app.location
@@ -76,6 +99,11 @@ data "azurerm_mssql_database" "existing" {
 }
 
 resource "terraform_data" "setup_database_principal" {
+  depends_on = [
+    azuread_group_member.provisioning_principal_sql_admin,
+    azuread_group_member.migration_principal_sql_admin
+  ]
+
   triggers_replace = [
     data.azurerm_mssql_database.existing.id,
     azurerm_user_assigned_identity.app_identity.principal_id,
@@ -83,7 +111,8 @@ resource "terraform_data" "setup_database_principal" {
     local.database_schema_name,
     join(",", local.db_permissions),
     var.provisioning_client_id,
-    "v1"
+    data.azuread_group.sql_admins.object_id,
+    "v2" # Bumped from v1: SQL Entra admin is now the sql_admins group, not the provisioning principal
   ]
 
   provisioner "local-exec" {
@@ -113,8 +142,8 @@ resource "terraform_data" "setup_database_principal" {
 
         Start-Sleep -Seconds 5
 
-        $provisioningPrincipalName = '${data.azuread_service_principal.provisioning_principal.display_name}'
-        $provisioningPrincipalObjectId = '${data.azuread_service_principal.provisioning_principal.object_id}'
+        $sqlAdminGroupName = '${data.azuread_group.sql_admins.display_name}'
+        $sqlAdminGroupObjectId = '${data.azuread_group.sql_admins.object_id}'
 
         $currentAdminObjectId = az sql server ad-admin list `
           --resource-group '${data.azurerm_resource_group.resource_group.name}' `
@@ -124,12 +153,12 @@ resource "terraform_data" "setup_database_principal" {
           --only-show-errors 2>$null
 
         $currentAdminObjectId = "$currentAdminObjectId".Trim()
-        if (-not $currentAdminObjectId -or $currentAdminObjectId -ne $provisioningPrincipalObjectId) {
+        if (-not $currentAdminObjectId -or $currentAdminObjectId -ne $sqlAdminGroupObjectId) {
           $adminOutput = az sql server ad-admin create `
             --resource-group '${data.azurerm_resource_group.resource_group.name}' `
             --server '${local.sql_server_name}' `
-            --display-name $provisioningPrincipalName `
-            --object-id $provisioningPrincipalObjectId `
+            --display-name $sqlAdminGroupName `
+            --object-id $sqlAdminGroupObjectId `
             --only-show-errors 2>&1
 
           if ($LASTEXITCODE -ne 0) {

--- a/Infra/prod/variables.tf
+++ b/Infra/prod/variables.tf
@@ -53,3 +53,13 @@ variable "provisioning_client_id" {
   description = "Client ID of the service principal that runs Terraform apply."
   type        = string
 }
+
+variable "migration_client_id" {
+  description = "Client ID of the service principal used by the application build/deploy pipeline to run EF Core migrations against the database via Azure AD authentication."
+  type        = string
+}
+
+variable "sql_admin_group_name" {
+  description = "Display name of the existing Entra ID (Azure AD) group configured as the SQL Server's Azure AD administrator. Members of this group (including the Terraform and migration service principals) receive administrative access to the database."
+  type        = string
+}

--- a/Infra/prod/variables.tf
+++ b/Infra/prod/variables.tf
@@ -63,3 +63,9 @@ variable "sql_admin_group_name" {
   description = "Display name of the existing Entra ID (Azure AD) group configured as the SQL Server's Azure AD administrator. Members of this group (including the Terraform and migration service principals) receive administrative access to the database."
   type        = string
 }
+
+variable "database_admin_user_names" {
+  description = "UPNs/email addresses of individual Entra ID (Azure AD) users who should be explicitly created as database users with db_owner rights. Even though members of the sql_admin_group already have administrative access via the server's Azure AD admin, the Azure Portal's Query Editor does not reliably resolve group-based admin membership, so an explicit contained user is created for each of these individuals."
+  type        = list(string)
+  default     = []
+}

--- a/Infra/variables.tf
+++ b/Infra/variables.tf
@@ -4,6 +4,12 @@ variable "CLIENT_ID" {
   default     = ""
 }
 
+variable "MIGRATION_CLIENT_ID" {
+  description = "Client ID of the service principal used by the application build/deploy pipeline to run EF Core migrations against the database via Azure AD authentication."
+  type        = string
+  default     = ""
+}
+
 variable "TENANT_ID" {
   type        = string
   description = "Value of the tenant id of the service principal"
@@ -68,4 +74,10 @@ variable "database_schema_name" {
   description = "Default SQL schema used by the app and managed identity."
   type        = string
   default     = "SimplyBudget"
+}
+
+variable "sql_admin_group_name" {
+  description = "Display name of the existing Entra ID (Azure AD) group configured as the SQL Server's Azure AD administrator."
+  type        = string
+  default     = "KebooDevDBAdmins"
 }

--- a/Infra/variables.tf
+++ b/Infra/variables.tf
@@ -81,3 +81,9 @@ variable "sql_admin_group_name" {
   type        = string
   default     = "KebooDevDBAdmins"
 }
+
+variable "database_admin_user_names" {
+  description = "UPNs/email addresses of individual Entra ID (Azure AD) users who should be explicitly created as database users with db_owner rights. Even though members of the sql_admin_group already have administrative access via the server's Azure AD admin, the Azure Portal's Query Editor does not reliably resolve group-based admin membership, so an explicit contained user is created for each of these individuals."
+  type        = list(string)
+  default     = ["kitokeboo@gmail.com"]
+}


### PR DESCRIPTION
## Summary
The Azure SQL Server's Entra ID (Azure AD) administrator was manually changed from the single Terraform provisioning service principal to the `KebooDevDBAdmins` security group. This updates Terraform to match and maintain that state going forward.

## Why
Previously, `Infra/prod/main.tf`'s `setup_database_principal` provisioner reconciled the SQL Server's Entra admin to always be the single Terraform/infra service principal (`SimplyBudget-GitHubActionsInfra`). Since the admin is now a group instead, the next `terraform apply` would have reset it back to the old single principal, undoing the manual change — and the app build/deploy pipeline's migration service principal (`SimplyBudget-GitHubActions`, used to run EF Core migrations via `Authentication=Active Directory Default`) was never a member of either, so it likely lacked sufficient DB permissions.

## Changes
- Added a `sql_admin_group_name` variable (defaults to `"KebooDevDBAdmins"`) and a `data "azuread_group" "sql_admins"` lookup for the existing group.
- Added a `migration_client_id` variable identifying the migration/app-pipeline service principal, and added both it and the provisioning service principal as members of the admin group via `azuread_group_member`, so both retain database admin rights through group membership.
- Updated the `setup_database_principal` provisioner's reconciliation logic to compare/set the SQL Server's Entra admin against the group's object ID (instead of the single provisioning principal), and bumped its trigger version to force a one-time reconciliation on the next apply.
- Wired a new `TF_VAR_MIGRATION_CLIENT_ID` (sourced from the existing `ARM_CLIENT_ID` secret already used by the app build/deploy pipeline — no new secret needed) into `deploy-infrastructure.yml`'s plan/apply jobs.

## Verification
- Confirmed via `az cli` that the `KebooDevDBAdmins` group exists (object id `548eee45-e315-4d55-9cf0-dbe2e6ebfd5d`) and is already set as the SQL Server's Entra admin.
- Confirmed the Terraform/infra service principal (`SimplyBudget-GitHubActionsInfra`) already has the `Group.ReadWrite.All` and `Directory.ReadWrite.All` Microsoft Graph application permissions needed to manage group membership.
- `terraform init -backend=false` + `terraform validate` — configuration is valid.
- `terraform fmt -check -diff` on all edited files — no formatting issues.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>