### PR TITLE
Ensure EF Core migrations history table uses SimplyBudget schema

### DIFF
--- a/SimplyBudgetWeb.Core/DependencyInjection.cs
+++ b/SimplyBudgetWeb.Core/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using SimplyBudgetWeb.Data;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -16,7 +17,8 @@ public static class DependencyInjection
 
         void BuildDbOptions(DbContextOptionsBuilder options)
         {
-            options.UseAzureSql(connectionString);
+            options.UseAzureSql(connectionString, sqlOptions =>
+                sqlOptions.MigrationsHistoryTable(HistoryRepository.DefaultTableName, BudgetWebContext.Schema));
         }
         builder.Services.AddDbContextFactory<BudgetWebContext>(BuildDbOptions);
         builder.Services.AddDbContextPool<BudgetWebContext>(BuildDbOptions);

--- a/SimplyBudgetWeb.Data/BudgetWebContext.cs
+++ b/SimplyBudgetWeb.Data/BudgetWebContext.cs
@@ -12,9 +12,16 @@ namespace SimplyBudgetWeb.Data;
 public class BudgetWebContext(DbContextOptions<BudgetWebContext> options)
     : BudgetContext(WeakReferenceMessenger.Default, options)
 {
+    /// <summary>
+    /// The database schema used for all tables in this context, including
+    /// the EF Core migrations history table (see <see cref="BudgetWebContextDesignTimeFactory"/>
+    /// and <c>DependencyInjection.AddDatabase</c>).
+    /// </summary>
+    public const string Schema = "SimplyBudget";
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.HasDefaultSchema("SimplyBudget");
+        modelBuilder.HasDefaultSchema(Schema);
         base.OnModelCreating(modelBuilder);
     }
 }

--- a/SimplyBudgetWeb.Data/BudgetWebContextDesignTimeFactory.cs
+++ b/SimplyBudgetWeb.Data/BudgetWebContextDesignTimeFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace SimplyBudgetWeb.Data;
 
@@ -10,7 +11,8 @@ public class BudgetWebContextDesignTimeFactory : IDesignTimeDbContextFactory<Bud
         var optionsBuilder = new DbContextOptionsBuilder<BudgetWebContext>();
         // Connection string only used for migration generation, not applied to prod DB
         optionsBuilder.UseSqlServer(
-            "Server=localhost;Database=SimplyBudget;Trusted_Connection=True;TrustServerCertificate=True;");
+            "Server=localhost;Database=SimplyBudget;Trusted_Connection=True;TrustServerCertificate=True;",
+            sqlOptions => sqlOptions.MigrationsHistoryTable(HistoryRepository.DefaultTableName, BudgetWebContext.Schema));
         return new BudgetWebContext(optionsBuilder.Options);
     }
 }


### PR DESCRIPTION
## Summary
Ensures all database tables — including the EF Core migrations history table — live in the `SimplyBudget` schema rather than the default `dbo` schema.

## Findings
- All entity tables already use the `SimplyBudget` schema via `BudgetWebContext.OnModelCreating` (`modelBuilder.HasDefaultSchema("SimplyBudget")`).
- The app has **no dedicated auth/Identity EF tables** — authentication is delegated entirely to Entra ID via `Microsoft.Identity.Web` (JWT bearer), so there are no `AspNetUsers`/token-cache tables to migrate.
- The **`__EFMigrationsHistory`** table was the one exception: `HasDefaultSchema` does not affect it, so it was being created in `dbo` instead of `SimplyBudget`. Verified this with `dotnet ef migrations script`, which showed `CREATE TABLE [__EFMigrationsHistory]` (no schema) before this change.

## Changes
- Added a `BudgetWebContext.Schema` constant (`"SimplyBudget"`) for reuse.
- Configured `sqlOptions.MigrationsHistoryTable(HistoryRepository.DefaultTableName, BudgetWebContext.Schema)` in:
  - `SimplyBudgetWeb.Core/DependencyInjection.cs` (runtime `AddDatabase`, used by the app and the Aspire `ApplyMigrations`/`DatabaseMigrationService` paths)
  - `SimplyBudgetWeb.Data/BudgetWebContextDesignTimeFactory.cs` (design-time factory used by `dotnet ef` commands directly)

## Verification
- `dotnet ef migrations script --idempotent` now shows `CREATE TABLE [SimplyBudget].[__EFMigrationsHistory]`.
- `dotnet ef migrations has-pending-model-changes` reports no pending changes — this is a configuration-only fix, no new migration needed.
- `dotnet build` succeeds for `SimplyBudgetWeb`, `SimplyBudgetWeb.AppHost`, `SimplyBudgetWeb.Data`, and `SimplyBudgetWeb.Core`.
- `SimplyBudgetWeb.Core.Tests` (13 tests) pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>