### PR TITLE
Fix backend revision stuck activating due to health check auth

### DIFF
--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -21,5 +21,6 @@ module "prod" {
   provisioning_client_id                  = var.CLIENT_ID
   migration_client_id                     = var.MIGRATION_CLIENT_ID
   sql_admin_group_name                    = var.sql_admin_group_name
+  app_users_group_name                    = var.app_users_group_name
   database_admin_user_names               = var.database_admin_user_names
 }

--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -55,6 +55,13 @@ data "azuread_group" "sql_admins" {
   security_enabled = true
 }
 
+# The Entra ID group whose members are authorized to use the application.
+# Its object ID is passed to the backend so it can validate the caller's 'groups' claim.
+data "azuread_group" "app_users" {
+  display_name     = var.app_users_group_name
+  security_enabled = true
+}
+
 resource "azuread_group_member" "provisioning_principal_sql_admin" {
   group_object_id  = data.azuread_group.sql_admins.object_id
   member_object_id = data.azuread_service_principal.provisioning_principal.object_id
@@ -240,10 +247,11 @@ module "backend_container_app" {
   container_registry_login_server = data.azurerm_container_registry.existing.login_server
 
   env_vars = {
-    AZURE_CLIENT_ID                       = azurerm_user_assigned_identity.app_identity.client_id
-    ConnectionStrings__Database           = local.database_connection_string
-    APPLICATIONINSIGHTS_CONNECTION_STRING = module.application_insights.application_insights.connection_string
-    AllowedOrigins__0                     = "https://${module.static_web_app.default_host_name}"
+    AZURE_CLIENT_ID                         = azurerm_user_assigned_identity.app_identity.client_id
+    ConnectionStrings__Database             = local.database_connection_string
+    APPLICATIONINSIGHTS_CONNECTION_STRING   = module.application_insights.application_insights.connection_string
+    AllowedOrigins__0                       = "https://${module.static_web_app.default_host_name}"
+    Authorization__SimplyBudgetUsersGroupId = data.azuread_group.app_users.object_id
   }
 
   depends_on = [

--- a/Infra/prod/variables.tf
+++ b/Infra/prod/variables.tf
@@ -64,6 +64,12 @@ variable "sql_admin_group_name" {
   type        = string
 }
 
+variable "app_users_group_name" {
+  description = "Display name of the existing Entra ID (Azure AD) security group whose members are authorized to use the SimplyBudget application. The backend authorizes requests by checking the caller's 'groups' claim against this group's object ID."
+  type        = string
+  default     = "SimplyBudgetUsers"
+}
+
 variable "database_admin_user_names" {
   description = "UPNs/email addresses of individual Entra ID (Azure AD) users who should be explicitly created as database users with db_owner rights. Even though members of the sql_admin_group already have administrative access via the server's Azure AD admin, the Azure Portal's Query Editor does not reliably resolve group-based admin membership, so an explicit contained user is created for each of these individuals."
   type        = list(string)

--- a/Infra/variables.tf
+++ b/Infra/variables.tf
@@ -82,6 +82,12 @@ variable "sql_admin_group_name" {
   default     = "KebooDevDBAdmins"
 }
 
+variable "app_users_group_name" {
+  description = "Display name of the existing Entra ID (Azure AD) security group whose members are authorized to use the SimplyBudget application."
+  type        = string
+  default     = "SimplyBudgetUsers"
+}
+
 variable "database_admin_user_names" {
   description = "UPNs/email addresses of individual Entra ID (Azure AD) users who should be explicitly created as database users with db_owner rights. Even though members of the sql_admin_group already have administrative access via the server's Azure AD admin, the Azure Portal's Query Editor does not reliably resolve group-based admin membership, so an explicit contained user is created for each of these individuals."
   type        = list(string)

--- a/SimplyBudgetWeb.ServiceDefaults/Extensions.cs
+++ b/SimplyBudgetWeb.ServiceDefaults/Extensions.cs
@@ -113,14 +113,18 @@ public static class Extensions
         // Adding health checks endpoints to applications in non-development environments has security implications.
         // See https://aka.ms/dotnet/aspire/healthchecks for details.
 
+        // These endpoints are probed directly by the hosting platform (e.g. Container Apps
+        // liveness/readiness/startup probes) without any auth token, so they must remain
+        // anonymous even though a global fallback authorization policy is configured.
+
         // All health checks must pass for app to be considered ready to accept traffic after starting
-        app.MapHealthChecks(HealthEndpointPath);
+        app.MapHealthChecks(HealthEndpointPath).AllowAnonymous();
 
         // Only health checks tagged with the "live" tag must pass for app to be considered alive
         app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
         {
             Predicate = r => r.Tags.Contains("live")
-        });
+        }).AllowAnonymous();
 
         return app;
     }


### PR DESCRIPTION
## Problem
The `simplybudget-prod-backend` Container App revision was stuck in \`Activating\` and never became \`Ready\`. Container logs showed every request to \`/health\` returning "Authorization failed" for the \`groups\` claim requirement.

## Root cause
\`Program.cs\` sets a global \`FallbackPolicy\` (\`SimplyBudgetUsers\`) requiring the caller's Entra ID \`groups\` claim to match a configured group object ID. This fallback policy applies to *every* endpoint without explicit auth metadata — including the \`/health\` and \`/alive\` endpoints mapped by \`MapDefaultEndpoints()\`.

Azure Container Apps' liveness/readiness/startup probes call these endpoints directly and unauthenticated, so they always got a 401 and the revision could never report itself healthy — it just kept restarting/never starting.

Separately, the container app's Terraform config never supplied \`Authorization__SimplyBudgetUsersGroupId\`, so the app was falling back to the placeholder value \`SET_GROUP_OBJECT_ID\` from \`appsettings.json\`. Even once probes could pass, real users' group claims would never match this placeholder, breaking authorization entirely.

## Fix
- \`SimplyBudgetWeb.ServiceDefaults/Extensions.cs\`: call \`.AllowAnonymous()\` on the \`/health\` and \`/alive\` health check endpoints so platform probes (which run on an internal-only port and carry no auth token) can reach them.
- \`Infra/*\`: look up the real \`SimplyBudgetUsers\` Entra ID group via a new \`data "azuread_group" "app_users"\` data source and pass its object ID to the container app as \`Authorization__SimplyBudgetUsersGroupId\`, replacing reliance on the unset placeholder.

## Validation
- \`dotnet build\` on \`SimplyBudgetWeb.ServiceDefaults\` and \`SimplyBudgetWeb\` succeeds.
- \`terraform validate\` and \`terraform fmt -check\` pass for the changed \`Infra\` files.
- Confirmed via \`az ad group show --group SimplyBudgetUsers\` that the group exists with object id \`388c5c22-20e0-472a-91fe-cb014e8b17f5\`, which Terraform will now wire in automatically.