### PR TITLE
Fix missing Entra ID tenant/client/group config in deployed frontend and backend

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -169,6 +169,8 @@ jobs:
       static_web_app_api_key: ${{ steps.terraform-outputs.outputs.static_web_app_api_key }}
       database_connection_string: ${{ steps.terraform-outputs.outputs.database_connection_string }}
       applicationinsights_connection_string: ${{ steps.terraform-outputs.outputs.applicationinsights_connection_string }}
+      entra_client_id: ${{ steps.terraform-outputs.outputs.entra_client_id }}
+      entra_tenant_id: ${{ steps.terraform-outputs.outputs.entra_tenant_id }}
       deploy_ready: ${{ steps.deployment-readiness.outputs.deploy_ready }}
       deploy_readiness_reason: ${{ steps.deployment-readiness.outputs.deploy_readiness_reason }}
     steps:
@@ -209,6 +211,8 @@ jobs:
           echo "backend_url=$(terraform output -raw backend_url)" >> $GITHUB_OUTPUT
           echo "database_connection_string=$(terraform output -raw database_connection_string)" >> $GITHUB_OUTPUT
           echo "applicationinsights_connection_string=$(terraform output -raw applicationinsights_connection_string)" >> $GITHUB_OUTPUT
+          echo "entra_client_id=$(terraform output -raw entra_client_id)" >> $GITHUB_OUTPUT
+          echo "entra_tenant_id=$(terraform output -raw entra_tenant_id)" >> $GITHUB_OUTPUT
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -358,6 +362,8 @@ jobs:
           BACKEND_URL: ${{ needs.get-infrastructure-outputs.outputs.backend_url }}
           # BACKEND_URL: 'TODO' # This should be set to the backend_url, if you use the generated ACA endpoint you may run into issues with cross origin issues.
           APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ needs.get-infrastructure-outputs.outputs.applicationinsights_connection_string }}
+          ENTRA_CLIENT_ID: ${{ needs.get-infrastructure-outputs.outputs.entra_client_id }}
+          ENTRA_TENANT_ID: ${{ needs.get-infrastructure-outputs.outputs.entra_tenant_id }}
 
       - name: Deploy to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@v1

--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -23,4 +23,5 @@ module "prod" {
   sql_admin_group_name                    = var.sql_admin_group_name
   app_users_group_name                    = var.app_users_group_name
   database_admin_user_names               = var.database_admin_user_names
+  entra_web_app_client_id                 = var.entra_web_app_client_id
 }

--- a/Infra/outputs.tf
+++ b/Infra/outputs.tf
@@ -50,3 +50,13 @@ output "database_connection_string" {
   value       = module.prod.database_connection_string
   sensitive   = true
 }
+
+output "entra_client_id" {
+  description = "Client (application) ID of the Entra ID App Registration used for MSAL sign-in and API authorization"
+  value       = module.prod.entra_client_id
+}
+
+output "entra_tenant_id" {
+  description = "Entra ID (Azure AD) tenant ID that the application is registered in"
+  value       = module.prod.entra_tenant_id
+}

--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -46,6 +46,14 @@ data "azuread_service_principal" "migration_principal" {
   client_id = var.migration_client_id
 }
 
+# The Entra ID App Registration used for end-user sign-in (MSAL SPA) and API
+# authorization. This app is provisioned and managed outside of Terraform
+# (see repository docs), so it is referenced here as a data source rather than
+# a managed resource.
+data "azuread_application" "webapp" {
+  client_id = var.entra_web_app_client_id
+}
+
 # The Entra ID group that is configured as the SQL Server's Azure AD administrator.
 # This group is managed outside of Terraform; membership below ensures the
 # service principals that need to administer the database (running Terraform
@@ -251,6 +259,8 @@ module "backend_container_app" {
     ConnectionStrings__Database             = local.database_connection_string
     APPLICATIONINSIGHTS_CONNECTION_STRING   = module.application_insights.application_insights.connection_string
     AllowedOrigins__0                       = "https://${module.static_web_app.default_host_name}"
+    AzureAd__TenantId                       = data.azurerm_client_config.current.tenant_id
+    AzureAd__ClientId                       = data.azuread_application.webapp.client_id
     Authorization__SimplyBudgetUsersGroupId = data.azuread_group.app_users.object_id
   }
 

--- a/Infra/prod/outputs.tf
+++ b/Infra/prod/outputs.tf
@@ -54,3 +54,13 @@ output "applicationinsights_connection_string" {
   value       = module.application_insights.application_insights.connection_string
   sensitive   = true
 }
+
+output "entra_client_id" {
+  description = "Client (application) ID of the Entra ID App Registration used for MSAL sign-in and API authorization"
+  value       = data.azuread_application.webapp.client_id
+}
+
+output "entra_tenant_id" {
+  description = "Entra ID (Azure AD) tenant ID that the application is registered in"
+  value       = data.azurerm_client_config.current.tenant_id
+}

--- a/Infra/prod/variables.tf
+++ b/Infra/prod/variables.tf
@@ -75,3 +75,8 @@ variable "database_admin_user_names" {
   type        = list(string)
   default     = []
 }
+
+variable "entra_web_app_client_id" {
+  description = "Client (application) ID of the existing Entra ID App Registration used for end-user sign-in (MSAL SPA) and API authorization (exposes the 'access_as_user' scope). Managed outside of Terraform."
+  type        = string
+}

--- a/Infra/variables.tf
+++ b/Infra/variables.tf
@@ -93,3 +93,9 @@ variable "database_admin_user_names" {
   type        = list(string)
   default     = ["kitokeboo@gmail.com"]
 }
+
+variable "entra_web_app_client_id" {
+  description = "Client (application) ID of the existing Entra ID App Registration used for end-user sign-in (MSAL SPA) and API authorization. Managed outside of Terraform."
+  type        = string
+  default     = "c0f5bb7e-cf2d-436f-b0a6-934dcec490b4"
+}

--- a/SimplyBudgetWeb.Web/src/authConfig.ts
+++ b/SimplyBudgetWeb.Web/src/authConfig.ts
@@ -2,8 +2,8 @@ import { Configuration, LogLevel } from '@azure/msal-browser'
 
 export const msalConfig: Configuration = {
   auth: {
-    clientId: '__ENTRA_CLIENT_ID__',
-    authority: 'https://login.microsoftonline.com/__ENTRA_TENANT_ID__',
+    clientId: __ENTRA_CLIENT_ID__,
+    authority: `https://login.microsoftonline.com/${__ENTRA_TENANT_ID__}`,
     redirectUri: window.location.origin,
   },
   cache: {
@@ -24,5 +24,5 @@ export const loginRequest = {
 }
 
 export const apiScopes = {
-  scopes: [`api://__ENTRA_CLIENT_ID__/access_as_user`],
+  scopes: [`api://${__ENTRA_CLIENT_ID__}/access_as_user`],
 }

--- a/SimplyBudgetWeb.Web/src/env.d.ts
+++ b/SimplyBudgetWeb.Web/src/env.d.ts
@@ -9,3 +9,5 @@ declare module '*.vue' {
 
 declare const __API_BASE_URL__: string
 declare const __APPLICATIONINSIGHTS_CONNECTION_STRING__: string
+declare const __ENTRA_CLIENT_ID__: string
+declare const __ENTRA_TENANT_ID__: string

--- a/SimplyBudgetWeb.Web/vite.config.ts
+++ b/SimplyBudgetWeb.Web/vite.config.ts
@@ -102,6 +102,8 @@ export default defineConfig({
   define: {
     '__API_BASE_URL__': JSON.stringify(backendUrl),
     '__APPLICATIONINSIGHTS_CONNECTION_STRING__': JSON.stringify(process.env.APPLICATIONINSIGHTS_CONNECTION_STRING || ''),
+    '__ENTRA_CLIENT_ID__': JSON.stringify(process.env.ENTRA_CLIENT_ID || ''),
+    '__ENTRA_TENANT_ID__': JSON.stringify(process.env.ENTRA_TENANT_ID || ''),
   },
   server: {
     host: process.env.VITE_HOST_URL || 'localhost',


### PR DESCRIPTION
## Problem

The frontend and backend Entra ID (Azure AD) auth configuration never received real deployed values:

- **Frontend bug**: `authConfig.ts` embedded `__ENTRA_CLIENT_ID__` / `__ENTRA_TENANT_ID__` placeholders **inside string literals** (e.g. `clientId: '__ENTRA_CLIENT_ID__'`). Vite's `define` only replaces bare identifier references, never text inside string literals, so these could never be substituted — and `vite.config.ts` didn't even define them.
- **Backend gap**: The `simplybudget-prod-backend` Container App never had `AzureAd__TenantId`, `AzureAd__ClientId`, or `Authorization__SimplyBudgetUsersGroupId` env vars set anywhere in Terraform, so `appsettings.json`'s `SET_TENANT_ID`/`SET_CLIENT_ID`/`SET_GROUP_OBJECT_ID` placeholders were never overridden in production.

## Investigation (via Azure CLI)

- Confirmed the deployed tenant: `keboo.dev` (`043a9423-4a81-43ca-af56-558108fb8f06`).
- Found the existing `SimplyBudgetUsers` Entra security group (`388c5c22-20e0-472a-91fe-cb014e8b17f5`) that the backend's authorization policy is meant to check against.
- Found **no** Entra ID App Registration existed yet for end-user sign-in (only the two CI/CD service principals `SimplyBudget-GitHubActions`/`-Infra` existed). Provisioned a new one, `SimplyBudget-WebApp` (`c0f5bb7e-cf2d-436f-b0a6-934dcec490b4`), configured as:
  - SPA redirect URIs: the production Static Web App URL + `http://localhost:5173` for local dev
  - Exposes the `access_as_user` API scope (matching what `authConfig.ts`/`apiScopes` already expected)
  - `groupMembershipClaims: SecurityGroup` (so the group claim used by the backend's authorization policy is emitted)

## Fix

- **Terraform** (`Infra/prod/main.tf` + variables/outputs): reference the new app registration and the `SimplyBudgetUsers` group as `data` sources (consistent with how other pre-existing/externally-managed resources are handled in this repo) and wire `AzureAd__TenantId`, `AzureAd__ClientId`, `Authorization__SimplyBudgetUsersGroupId` into the backend Container App's env vars. Added `entra_client_id`/`entra_tenant_id` Terraform outputs.
- **CI** (`build-and-deploy.yml`): thread the new Terraform outputs as `ENTRA_CLIENT_ID`/`ENTRA_TENANT_ID` env vars into the frontend production build step.
- **Frontend** (`vite.config.ts`, `env.d.ts`, `authConfig.ts`): define/declare the `__ENTRA_CLIENT_ID__`/`__ENTRA_TENANT_ID__` globals and fix `authConfig.ts` to reference them as identifiers instead of embedding them in string literals.

## Verification

- Applied the three env vars directly to the live `simplybudget-prod-backend` Container App via `az containerapp update` (so production is fixed immediately, ahead of the next Terraform apply) and confirmed via container logs that the backend now evaluates the `SimplyBudgetUsers` group claim correctly, and that `/alive` returns `200`.
- Ran a local production-style frontend build (`pnpm run build` with `ENTRA_CLIENT_ID`/`ENTRA_TENANT_ID` set) and confirmed the real tenant/client GUIDs are baked into the output bundle and the old placeholder strings are completely gone.
- `pnpm run lint` and `dotnet build` both pass.
- `terraform validate` passes (validated locally with a local backend override; the repo's real Azure backend requires the CI OIDC credentials).