### PR TITLE
Fix AADSTS50011: add production custom domain to Entra ID app redirect URIs

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -58,6 +58,7 @@ jobs:
           TF_VAR_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_INFRA }}
           TF_VAR_MIGRATION_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
           TF_VAR_backend_custom_domain: 'https://api.budget.keboo.dev'
+          TF_VAR_frontend_custom_domain: 'https://budget.keboo.dev'
 
       - name: Upload Terraform Plan
         uses: actions/upload-artifact@v7
@@ -120,3 +121,4 @@ jobs:
           TF_VAR_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_INFRA }}
           TF_VAR_MIGRATION_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
           TF_VAR_backend_custom_domain: 'https://api.budget.keboo.dev'
+          TF_VAR_frontend_custom_domain: 'https://budget.keboo.dev'

--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -25,4 +25,5 @@ module "prod" {
   database_admin_user_names               = var.database_admin_user_names
   entra_web_app_client_id                 = var.entra_web_app_client_id
   backend_custom_domain                   = var.backend_custom_domain
+  frontend_custom_domain                  = var.frontend_custom_domain
 }

--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -54,6 +54,23 @@ data "azuread_application" "webapp" {
   client_id = var.entra_web_app_client_id
 }
 
+# Manages the SPA redirect URIs on the webapp App Registration. This is
+# authoritative for the SPA redirect URI list (any URI not listed here will be
+# removed from the app), so every environment the frontend can be reached from
+# (local dev, the SWA's auto-generated default hostname, and the production
+# custom domain) must be included. Without the custom domain here, sign-in
+# from https://budget.keboo.dev fails with AADSTS50011 (redirect URI mismatch).
+resource "azuread_application_redirect_uris" "webapp_spa" {
+  application_id = data.azuread_application.webapp.id
+  type           = "SPA"
+
+  redirect_uris = compact([
+    "http://localhost:5173",
+    "https://${module.static_web_app.default_host_name}",
+    var.frontend_custom_domain,
+  ])
+}
+
 # The Entra ID group that is configured as the SQL Server's Azure AD administrator.
 # This group is managed outside of Terraform; membership below ensures the
 # service principals that need to administer the database (running Terraform

--- a/Infra/prod/variables.tf
+++ b/Infra/prod/variables.tf
@@ -86,3 +86,9 @@ variable "backend_custom_domain" {
   type        = string
   default     = ""
 }
+
+variable "frontend_custom_domain" {
+  description = "Custom domain URL for the frontend Static Web App (e.g. https://budget.keboo.dev). When set, it is added to the Entra ID App Registration's SPA redirect URIs so MSAL sign-in redirects succeed on the custom domain."
+  type        = string
+  default     = ""
+}

--- a/Infra/variables.tf
+++ b/Infra/variables.tf
@@ -105,3 +105,9 @@ variable "backend_custom_domain" {
   type        = string
   default     = ""
 }
+
+variable "frontend_custom_domain" {
+  description = "Custom domain URL for the frontend Static Web App (e.g. https://budget.keboo.dev). When set, it is added to the Entra ID App Registration's SPA redirect URIs so MSAL sign-in redirects succeed on the custom domain."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Problem
Production sign-in at https://budget.keboo.dev failed with:

```
AADSTS50011: The redirect URI 'https://budget.keboo.dev' specified in the
request does not match the redirect URIs configured for the application
'c0f5bb7e-cf2d-436f-b0a6-934dcec490b4'.
```

The Entra ID App Registration's SPA redirect URIs only included
`http://localhost:5173` and the Static Web App's auto-generated hostname
(`*.azurestaticapps.net`) — never the production custom domain.

## Fix
- Added a new `azuread_application_redirect_uris` Terraform resource (prod
  module) that manages the app registration's SPA redirect URI list,
  seeded with the existing localhost/default-hostname URIs plus a new
  `frontend_custom_domain` variable.
- Wired `frontend_custom_domain` through `Infra/variables.tf` →
  `Infra/main.tf` → `Infra/prod/variables.tf`, mirroring the existing
  `backend_custom_domain` pattern.
- Set `TF_VAR_frontend_custom_domain: 'https://budget.keboo.dev'` in both
  the plan and apply steps of `deploy-infrastructure.yml`.

Since the Entra ID app registration itself is intentionally managed
outside Terraform (per existing repo convention/docs) and only referenced
via a `data` source, this change adds a narrowly-scoped, additive resource
(`azuread_application_redirect_uris`) rather than converting the whole app
registration into a Terraform-managed resource — this keeps the change
low-risk while still making the redirect URI list reproducible via IaC
going forward.

## Immediate hotfix
Also applied the same redirect URI addition directly via the Microsoft
Graph API (`az rest PATCH .../applications/{id}`) to restore production
sign-in immediately, ahead of this PR merging. Verified via Playwright
that https://budget.keboo.dev/login → Sign in now reaches the real
Microsoft "Sign in" email/password prompt with no AADSTS error.

Merging this PR makes `deploy-infrastructure.yml`'s Terraform apply keep
that redirect URI list in sync going forward (authoritative source of
truth), instead of relying on the manual hotfix.