### PR TITLE
Fix Terraform apply failure: import existing SPA redirect URI resource

### DIFF
--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -71,6 +71,15 @@ resource "azuread_application_redirect_uris" "webapp_spa" {
   ])
 }
 
+# The app's SPA redirect URI collection already exists in Entra ID as soon as
+# the app itself exists (it was previously set outside Terraform), so it must
+# be imported into state rather than created, otherwise apply fails with
+# "A resource with the ID ... already exists".
+import {
+  to = azuread_application_redirect_uris.webapp_spa
+  id = "${data.azuread_application.webapp.id}/redirectUris/SPA"
+}
+
 # The Entra ID group that is configured as the SQL Server's Azure AD administrator.
 # This group is managed outside of Terraform; membership below ensures the
 # service principals that need to administer the database (running Terraform

--- a/README.md
+++ b/README.md
@@ -167,4 +167,12 @@ If left unset, they default to an empty string and the app will still start,
 but MSAL sends an empty `client_id` to Entra ID, resulting in an
 `AADSTS900144` sign-in error when you try to sign in.
 
+The App Registration must also have a SPA redirect URI matching wherever
+you're running the frontend from (e.g. `http://localhost:5173` for
+`aspire run`). Production's SPA redirect URIs (localhost, the Static Web
+App's default hostname, and the `frontend_custom_domain` custom domain)
+are managed via Terraform (`Infra/prod/main.tf`'s
+`azuread_application_redirect_uris.webapp_spa` resource) — a mismatched
+redirect URI here results in an `AADSTS50011` sign-in error.
+
 


### PR DESCRIPTION
Follow-up to #104. The `deploy-infrastructure` apply job failed because the app registration's SPA redirect URI collection already existed in Entra ID (it was set outside Terraform previously, and also just hotfixed via the Graph API). Adds an `import` block so Terraform adopts the existing resource into state instead of trying to create it, which was causing:

```
Error: A resource with the ID "/applications/.../redirectUris/SPA" already exists - to be managed via Terraform this resource needs to be imported into the State.
```
