### PR TITLE
Fix Terraform apply failure: import blocks must be in the root module

### DIFF
--- a/Infra/main.tf
+++ b/Infra/main.tf
@@ -27,3 +27,15 @@ module "prod" {
   backend_custom_domain                   = var.backend_custom_domain
   frontend_custom_domain                  = var.frontend_custom_domain
 }
+
+# The app's SPA redirect URI collection already exists in Entra ID as soon as
+# the app itself exists (it was previously set outside Terraform, and was
+# also hotfixed directly via the Graph API to restore production sign-in),
+# so it must be imported into state rather than created, otherwise apply
+# fails with "A resource with the ID ... already exists". Import blocks are
+# only allowed in the root module, hence this lives here rather than in
+# prod/main.tf alongside the resource itself.
+import {
+  to = module.prod.azuread_application_redirect_uris.webapp_spa
+  id = "${module.prod.entra_application_id}/redirectUris/SPA"
+}

--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -71,15 +71,6 @@ resource "azuread_application_redirect_uris" "webapp_spa" {
   ])
 }
 
-# The app's SPA redirect URI collection already exists in Entra ID as soon as
-# the app itself exists (it was previously set outside Terraform), so it must
-# be imported into state rather than created, otherwise apply fails with
-# "A resource with the ID ... already exists".
-import {
-  to = azuread_application_redirect_uris.webapp_spa
-  id = "${data.azuread_application.webapp.id}/redirectUris/SPA"
-}
-
 # The Entra ID group that is configured as the SQL Server's Azure AD administrator.
 # This group is managed outside of Terraform; membership below ensures the
 # service principals that need to administer the database (running Terraform

--- a/Infra/prod/outputs.tf
+++ b/Infra/prod/outputs.tf
@@ -64,3 +64,8 @@ output "entra_tenant_id" {
   description = "Entra ID (Azure AD) tenant ID that the application is registered in"
   value       = data.azurerm_client_config.current.tenant_id
 }
+
+output "entra_application_id" {
+  description = "Terraform resource ID (\"/applications/{object-id}\") of the Entra ID App Registration, for use in root-module import blocks that target resources inside this module (import blocks are only allowed in the root module)."
+  value       = data.azuread_application.webapp.id
+}

--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ you're running the frontend from (e.g. `http://localhost:5173` for
 `aspire run`). Production's SPA redirect URIs (localhost, the Static Web
 App's default hostname, and the `frontend_custom_domain` custom domain)
 are managed via Terraform (`Infra/prod/main.tf`'s
-`azuread_application_redirect_uris.webapp_spa` resource) — a mismatched
-redirect URI here results in an `AADSTS50011` sign-in error.
+`azuread_application_redirect_uris.webapp_spa` resource, imported into
+state via a root-module `import` block in `Infra/main.tf` since it
+already existed in Entra ID) — a mismatched redirect URI here results in
+an `AADSTS50011` sign-in error.
 
 


### PR DESCRIPTION
Follow-up to #105. The apply job failed again:

```
Error: Invalid import configuration
An import block was detected in "module.prod". Import blocks are only allowed in the root module.
```

Moves the `import` block to `Infra/main.tf` (root module), targeting `module.prod.azuread_application_redirect_uris.webapp_spa`. Exposes a new `entra_application_id` output on the prod module so the root import block can reference the app registration's object ID.