### PR TITLE
Fix CORS: include frontend custom domain in backend AllowedOrigins

### DIFF
--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -271,15 +271,23 @@ module "backend_container_app" {
   identity_id                     = azurerm_user_assigned_identity.app_identity.id
   container_registry_login_server = data.azurerm_container_registry.existing.login_server
 
-  env_vars = {
-    AZURE_CLIENT_ID                         = azurerm_user_assigned_identity.app_identity.client_id
-    ConnectionStrings__Database             = local.database_connection_string
-    APPLICATIONINSIGHTS_CONNECTION_STRING   = module.application_insights.application_insights.connection_string
-    AllowedOrigins__0                       = "https://${module.static_web_app.default_host_name}"
-    AzureAd__TenantId                       = data.azurerm_client_config.current.tenant_id
-    AzureAd__ClientId                       = data.azuread_application.webapp.client_id
-    Authorization__SimplyBudgetUsersGroupId = data.azuread_group.app_users.object_id
-  }
+  # AllowedOrigins must cover every hostname the frontend can be served from
+  # (the SWA's auto-generated default hostname and the production custom
+  # domain), mirroring the azuread_application_redirect_uris.webapp_spa list
+  # above. Without the custom domain here, requests from
+  # https://budget.keboo.dev fail CORS with "missing allowed origin".
+  env_vars = merge(
+    {
+      AZURE_CLIENT_ID                         = azurerm_user_assigned_identity.app_identity.client_id
+      ConnectionStrings__Database             = local.database_connection_string
+      APPLICATIONINSIGHTS_CONNECTION_STRING   = module.application_insights.application_insights.connection_string
+      AllowedOrigins__0                       = "https://${module.static_web_app.default_host_name}"
+      AzureAd__TenantId                       = data.azurerm_client_config.current.tenant_id
+      AzureAd__ClientId                       = data.azuread_application.webapp.client_id
+      Authorization__SimplyBudgetUsersGroupId = data.azuread_group.app_users.object_id
+    },
+    var.frontend_custom_domain != "" ? { AllowedOrigins__1 = var.frontend_custom_domain } : {}
+  )
 
   depends_on = [
     module.application_insights,

--- a/README.md
+++ b/README.md
@@ -177,4 +177,10 @@ state via a root-module `import` block in `Infra/main.tf` since it
 already existed in Entra ID) — a mismatched redirect URI here results in
 an `AADSTS50011` sign-in error.
 
+The backend's CORS `AllowedOrigins` must be kept in sync with the same set
+of hostnames (Terraform sets `AllowedOrigins__0`/`AllowedOrigins__1` env
+vars on the backend Container App in `Infra/prod/main.tf`) — an origin
+missing from this list results in a CORS "missing allowed origin" error
+in the browser instead.
+
 


### PR DESCRIPTION
## Problem
Prod frontend requests to the backend API fail CORS with "missing allowed origin" in dev tools.

## Root cause
`Infra/prod/main.tf` only set `AllowedOrigins__0` on the backend Container App to the Static Web App's auto-generated `default_host_name` (`*.azurestaticapps.net`). It never included `var.frontend_custom_domain` (the production custom domain, e.g. `https://budget.keboo.dev`), so any request from the real prod frontend URL was rejected by CORS.

This is the same class of bug already fixed for Entra ID redirect URIs in #104 — every environment the frontend can be reached from (local dev, SWA default hostname, and the prod custom domain) needs to be included wherever origins/redirect URIs are configured.

## Fix
Add `AllowedOrigins__1 = var.frontend_custom_domain` to the backend Container App's `env_vars`, conditionally (only when the variable is set), alongside the existing `AllowedOrigins__0`.

## Validation
- `terraform init -backend=false && terraform validate` succeeds.
- `terraform fmt` clean.

## Deployment
Requires `terraform apply` in `Infra/prod` to take effect (updates the Container App's env vars and restarts it with the corrected CORS allow-list).