### PR TITLE
Fix production 500s: repair stale managed identity SQL user on identity recreation

### DIFF
--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -140,13 +140,22 @@ resource "terraform_data" "setup_database_principal" {
   triggers_replace = [
     data.azurerm_mssql_database.existing.id,
     azurerm_user_assigned_identity.app_identity.principal_id,
+    azurerm_user_assigned_identity.app_identity.client_id,
     azurerm_user_assigned_identity.app_identity.name,
     local.database_schema_name,
     join(",", local.db_permissions),
     var.provisioning_client_id,
     data.azuread_group.sql_admins.object_id,
     join(",", local.database_admin_user_names),
-    "v3" # Bumped from v2: explicitly create contained database users (db_owner) for
+    "v4" # Bumped from v3: repair a stale contained database user left behind
+    # when azurerm_user_assigned_identity.app_identity is destroyed and
+    # recreated (e.g. by a prior `terraform apply`). Recreating the identity
+    # changes its Client ID/Object ID but keeps its name, so the old
+    # "IF NOT EXISTS ... WHERE name = ..." guard silently skipped recreating
+    # the user, leaving it bound to the deleted identity's SID and causing
+    # every DB-backed request to fail with "Login failed for user
+    # '<token-identified principal>'" (500s).
+    # Bumped from v2: explicitly create contained database users (db_owner) for
     # individual admins, since the Azure Portal Query Editor does not reliably
     # resolve access granted only via the sql_admins group membership.
   ]
@@ -212,10 +221,20 @@ resource "terraform_data" "setup_database_principal" {
 
         $identityName = '${azurerm_user_assigned_identity.app_identity.name}'
         $identityObjectId = '${azurerm_user_assigned_identity.app_identity.principal_id}'
+        $identityClientId = '${azurerm_user_assigned_identity.app_identity.client_id}'
         $schemaName = '${local.database_schema_name}'
 
         $queryParts = @(
           "IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '$schemaName') BEGIN EXEC('CREATE SCHEMA [$schemaName]'); END;",
+          # Azure SQL derives a managed identity's login SID from its Client ID
+          # (AppId), not its Object ID/Principal ID. If the identity was
+          # destroyed and recreated (e.g. by a prior `terraform apply`), the
+          # existing user row still has the old identity's SID even though the
+          # name matches, so tokens from the current identity are rejected
+          # with "Login failed for user '<token-identified principal>'". Drop
+          # the stale user before recreating it so it's rebound to the
+          # current Client ID.
+          "IF EXISTS (SELECT 1 FROM sys.database_principals WHERE name = '$identityName' AND sid <> CAST(CAST('$identityClientId' AS uniqueidentifier) AS varbinary(16))) BEGIN DROP USER [$identityName]; END;",
           "IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = '$identityName') BEGIN CREATE USER [$identityName] FROM EXTERNAL PROVIDER WITH OBJECT_ID = '$identityObjectId'; END;",
           "ALTER USER [$identityName] WITH DEFAULT_SCHEMA = [$schemaName];"
         )


### PR DESCRIPTION
## Problem

The production backend (`api.budget.keboo.dev`) was returning 500s for every DB-backed endpoint (`GET /api/expense-categories`, `GET /api/budget`, etc.). Container app logs showed:

```
Microsoft.Data.SqlClient.SqlException (0x80131904): Login failed for user '<token-identified principal>'.
```

## Root cause

Investigated via Azure CLI (`az containerapp logs show`, `az sql server ...`) plus a direct AAD-token query against `keboodevdb`:

- The `simplybudget-prod-mi` managed identity currently has Object ID `453b42c0-...` / Client ID `446c52f7-...`.
- The contained database user `simplybudget-prod-mi` in `keboodevdb` had a SID that decoded to a completely different (and no longer existing) AAD object — evidence the identity was destroyed and recreated (e.g. by a `terraform apply` that replaced `azurerm_user_assigned_identity.app_identity`), which produced a new Client ID/Object ID while keeping the same identity **name**.
- Azure SQL authenticates a managed identity's login token by matching the contained user's SID against the identity's **Client ID** (AppId), not its Object ID/Principal ID.
- The provisioning script in `Infra/prod/main.tf` only created the user `IF NOT EXISTS (... WHERE name = ...)`. Since a user with that name already existed (just with a stale SID), it was never repaired — silently leaving the deployment broken after any apply that recreates the identity.

## Fix

- `Infra/prod/main.tf`: before the existing "create if missing" step, drop the contained user if one with the same name exists but its SID no longer matches the identity's current Client ID, so it gets recreated (and its `db_datareader`/`db_datawriter`/`db_ddladmin` roles + `EXECUTE` grant restored) against the live identity.
- Added the identity's `client_id` to the `terraform_data.setup_database_principal` triggers so the provisioner reruns whenever it changes.

## Verification

- Restored production immediately by manually applying the same drop/recreate/re-grant sequence against `keboodevdb` via an AAD access token.
- Confirmed via `az containerapp logs show` that subsequent requests reach the authorization middleware (`401` for unauthenticated calls) instead of failing with `500`/SQL login errors.
- `terraform validate` passes for `Infra/prod`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>