### PR TITLE
Add full data export/import portability for web and desktop

### DIFF
--- a/SimplyBudgetDesktop/ViewModels/SettingsViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/SettingsViewModel.cs
@@ -2,13 +2,16 @@
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using MaterialDesignThemes.Wpf;
+using Microsoft.Win32;
 using Microsoft.EntityFrameworkCore;
 using SimplyBudget.Messaging;
 using SimplyBudget.Properties;
 using SimplyBudgetShared.Data;
+using SimplyBudgetShared.DataTransfer;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Text.Json;
 using System.Windows.Data;
 using System.Windows.Input;
 
@@ -16,6 +19,11 @@ namespace SimplyBudget.ViewModels;
 
 public partial class SettingsViewModel : CollectionViewModelBase<ExpenseCategoryRuleViewModel>
 {
+    private static readonly JsonSerializerOptions DataExportJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
     private List<int> RemovedRuleIds { get; } = new();
     private Func<BudgetContext> ContextFactory { get; }
     private IMessenger Messenger { get; }
@@ -89,6 +97,31 @@ public partial class SettingsViewModel : CollectionViewModelBase<ExpenseCategory
         Messenger.Send(new StorageLocationChanged());
         MessageQueue.Enqueue("Saved");
         await ReloadItemsAsync();
+    }
+
+    [RelayCommand]
+    private async Task OnExportData()
+    {
+        var dialog = new SaveFileDialog
+        {
+            AddExtension = true,
+            OverwritePrompt = true,
+            DefaultExt = ".json",
+            Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+            FileName = $"simplybudget-desktop-export-{DateTime.Now:yyyyMMdd-HHmmss}.json"
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        using var context = ContextFactory();
+        var exportPackage = await BudgetDataPortabilityService.ExportAsync(context, source: "desktop");
+        await File.WriteAllBytesAsync(
+            dialog.FileName,
+            JsonSerializer.SerializeToUtf8Bytes(exportPackage, DataExportJsonOptions));
+        MessageQueue.Enqueue("Data export saved.");
     }
 
     [ObservableProperty]

--- a/SimplyBudgetDesktop/Views/SettingsView.xaml
+++ b/SimplyBudgetDesktop/Views/SettingsView.xaml
@@ -55,13 +55,20 @@
 
     </Grid>
 
-    <Button Content="_Save" 
-            Command="{Binding SaveCommand}" 
-            HorizontalAlignment="Left" 
-            VerticalAlignment="Center"
-            Grid.Row="1"
-            Grid.Column="1"
-            Width="100"/>
+    <StackPanel Grid.Row="1"
+                Grid.Column="1"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center">
+      <Button Content="_Save"
+              Command="{Binding SaveCommand}"
+              HorizontalAlignment="Left"
+              Width="100"
+              Margin="0,0,0,8" />
+      <Button Content="Export Data"
+              Command="{Binding ExportDataCommand}"
+              HorizontalAlignment="Left"
+              Width="100" />
+    </StackPanel>
 
     <DataGrid Grid.Row="2" Grid.ColumnSpan="2"
               ItemsSource="{Binding Items}"

--- a/SimplyBudgetShared/DataTransfer/BudgetDataExportPackage.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataExportPackage.cs
@@ -1,0 +1,70 @@
+namespace SimplyBudgetShared.DataTransfer;
+
+public sealed class BudgetDataExportPackage
+{
+    public const int CurrentFormatVersion = 1;
+
+    public int FormatVersion { get; set; } = CurrentFormatVersion;
+
+    public DateTime ExportedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public string? Source { get; set; }
+
+    public List<BudgetDataExportAccount> Accounts { get; set; } = [];
+
+    public List<BudgetDataExportCategory> Categories { get; set; } = [];
+
+    public List<BudgetDataExportItem> Items { get; set; } = [];
+
+    public List<BudgetDataExportItemDetail> ItemDetails { get; set; } = [];
+
+    public List<BudgetDataExportRule> Rules { get; set; } = [];
+
+    public List<BudgetDataExportMetadata> Metadata { get; set; } = [];
+}
+
+public record BudgetDataExportAccount(
+    int Id,
+    string? Name,
+    DateTime ValidatedDate,
+    bool IsDefault
+);
+
+public record BudgetDataExportCategory(
+    int Id,
+    string? Name,
+    string? CategoryName,
+    int? AccountId,
+    int BudgetedAmount,
+    int BudgetedPercentage,
+    int CurrentBalance,
+    int? Cap,
+    bool IsHidden
+);
+
+public record BudgetDataExportItem(
+    int Id,
+    DateTime Date,
+    string? Description
+);
+
+public record BudgetDataExportItemDetail(
+    int Id,
+    int ExpenseCategoryItemId,
+    int ExpenseCategoryId,
+    int Amount,
+    bool IgnoreBudget
+);
+
+public record BudgetDataExportRule(
+    int Id,
+    string? Name,
+    string? RuleRegex,
+    int? ExpenseCategoryId
+);
+
+public record BudgetDataExportMetadata(
+    int Id,
+    string? Key,
+    string? Value
+);

--- a/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
@@ -1,0 +1,220 @@
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetShared.Data;
+
+namespace SimplyBudgetShared.DataTransfer;
+
+public static class BudgetDataPortabilityService
+{
+    public static async Task<BudgetDataExportPackage> ExportAsync(
+        BudgetContext context,
+        string source,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+
+        return new BudgetDataExportPackage
+        {
+            ExportedAtUtc = DateTime.UtcNow,
+            Source = source,
+            Accounts = await context.Accounts
+                .AsNoTracking()
+                .OrderBy(x => x.ID)
+                .Select(x => new BudgetDataExportAccount(x.ID, x.Name, x.ValidatedDate, x.IsDefault))
+                .ToListAsync(cancellationToken),
+            Categories = await context.ExpenseCategories
+                .AsNoTracking()
+                .OrderBy(x => x.ID)
+                .Select(x => new BudgetDataExportCategory(
+                    x.ID,
+                    x.Name,
+                    x.CategoryName,
+                    x.AccountID,
+                    x.BudgetedAmount,
+                    x.BudgetedPercentage,
+                    x.CurrentBalance,
+                    x.Cap,
+                    x.IsHidden))
+                .ToListAsync(cancellationToken),
+            Items = await context.ExpenseCategoryItems
+                .AsNoTracking()
+                .OrderBy(x => x.ID)
+                .Select(x => new BudgetDataExportItem(x.ID, x.Date, x.Description))
+                .ToListAsync(cancellationToken),
+            ItemDetails = await context.ExpenseCategoryItemDetails
+                .AsNoTracking()
+                .OrderBy(x => x.ID)
+                .Select(x => new BudgetDataExportItemDetail(
+                    x.ID,
+                    x.ExpenseCategoryItemId,
+                    x.ExpenseCategoryId,
+                    x.Amount,
+                    x.IgnoreBudget))
+                .ToListAsync(cancellationToken),
+            Rules = await context.ExpenseCategoryRules
+                .AsNoTracking()
+                .OrderBy(x => x.ID)
+                .Select(x => new BudgetDataExportRule(x.ID, x.Name, x.RuleRegex, x.ExpenseCategoryID))
+                .ToListAsync(cancellationToken),
+            Metadata = await context.Metadatas
+                .AsNoTracking()
+                .OrderBy(x => x.ID)
+                .Select(x => new BudgetDataExportMetadata(x.ID, x.Key, x.Value))
+                .ToListAsync(cancellationToken)
+        };
+    }
+
+    public static async Task ImportAsync(
+        BudgetContext context,
+        BudgetDataExportPackage exportPackage,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(exportPackage);
+
+        if (exportPackage.FormatVersion > BudgetDataExportPackage.CurrentFormatVersion)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported export format version '{exportPackage.FormatVersion}'.");
+        }
+
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+
+        await context.ExpenseCategoryItemDetails.ExecuteDeleteAsync(cancellationToken);
+        await context.ExpenseCategoryItems.ExecuteDeleteAsync(cancellationToken);
+        await context.ExpenseCategoryRules.ExecuteDeleteAsync(cancellationToken);
+        await context.ExpenseCategories.ExecuteDeleteAsync(cancellationToken);
+        await context.Accounts.ExecuteDeleteAsync(cancellationToken);
+        await context.Metadatas.ExecuteDeleteAsync(cancellationToken);
+        context.ChangeTracker.Clear();
+
+        var accountSeed = (exportPackage.Accounts ?? []).OrderBy(x => x.Id).ToList();
+        var importedAccounts = accountSeed.Select(x => new Account
+        {
+            Name = x.Name,
+            ValidatedDate = x.ValidatedDate,
+        }).ToList();
+        context.Accounts.AddRange(importedAccounts);
+        await context.SaveChangesAsync(cancellationToken);
+
+        var accountIdMap = accountSeed
+            .Zip(importedAccounts)
+            .ToDictionary(x => x.First.Id, x => x.Second.ID);
+
+        if (importedAccounts.Count > 0)
+        {
+            var preferredDefault = accountSeed.FirstOrDefault(x => x.IsDefault)?.Id ?? accountSeed[0].Id;
+            if (!accountIdMap.TryGetValue(preferredDefault, out var mappedDefaultId))
+            {
+                mappedDefaultId = importedAccounts[0].ID;
+            }
+
+            var defaultAccount = await context.Accounts.FindAsync([mappedDefaultId], cancellationToken)
+                ?? throw new InvalidOperationException("Failed to locate imported default account.");
+            await context.SetAsDefaultAsync(defaultAccount);
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        var categorySeed = (exportPackage.Categories ?? []).OrderBy(x => x.Id).ToList();
+        var importedCategories = categorySeed.Select(x => new ExpenseCategory
+        {
+            Name = x.Name,
+            CategoryName = x.CategoryName,
+            AccountID = ResolveOptionalReference(accountIdMap, x.AccountId, "account"),
+            BudgetedAmount = x.BudgetedAmount,
+            BudgetedPercentage = x.BudgetedPercentage,
+            CurrentBalance = 0,
+            Cap = x.Cap,
+            IsHidden = x.IsHidden
+        }).ToList();
+        context.ExpenseCategories.AddRange(importedCategories);
+        await context.SaveChangesAsync(cancellationToken);
+
+        var categoryIdMap = categorySeed
+            .Zip(importedCategories)
+            .ToDictionary(x => x.First.Id, x => x.Second.ID);
+
+        var itemSeed = (exportPackage.Items ?? []).OrderBy(x => x.Id).ToList();
+        var importedItems = itemSeed.Select(x => new ExpenseCategoryItem
+        {
+            Date = x.Date,
+            Description = x.Description
+        }).ToList();
+        context.ExpenseCategoryItems.AddRange(importedItems);
+        await context.SaveChangesAsync(cancellationToken);
+
+        var itemIdMap = itemSeed
+            .Zip(importedItems)
+            .ToDictionary(x => x.First.Id, x => x.Second.ID);
+
+        var importedDetails = (exportPackage.ItemDetails ?? [])
+            .OrderBy(x => x.Id)
+            .Select(x => new ExpenseCategoryItemDetail
+            {
+                ExpenseCategoryItemId = ResolveRequiredReference(itemIdMap, x.ExpenseCategoryItemId, "item"),
+                ExpenseCategoryId = ResolveRequiredReference(categoryIdMap, x.ExpenseCategoryId, "category"),
+                Amount = x.Amount,
+                IgnoreBudget = x.IgnoreBudget
+            })
+            .ToList();
+        context.ExpenseCategoryItemDetails.AddRange(importedDetails);
+        await context.SaveChangesAsync(cancellationToken);
+
+        var importedRules = (exportPackage.Rules ?? [])
+            .OrderBy(x => x.Id)
+            .Select(x => new ExpenseCategoryRule
+            {
+                Name = x.Name,
+                RuleRegex = x.RuleRegex,
+                ExpenseCategoryID = ResolveOptionalReference(categoryIdMap, x.ExpenseCategoryId, "category")
+            })
+            .ToList();
+        context.ExpenseCategoryRules.AddRange(importedRules);
+
+        var importedMetadata = (exportPackage.Metadata ?? [])
+            .OrderBy(x => x.Id)
+            .Select(x => new Metadata
+            {
+                Key = x.Key,
+                Value = x.Value
+            })
+            .ToList();
+        context.Metadatas.AddRange(importedMetadata);
+        await context.SaveChangesAsync(cancellationToken);
+
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    private static int ResolveRequiredReference(
+        IReadOnlyDictionary<int, int> idMap,
+        int sourceId,
+        string entityName)
+    {
+        if (idMap.TryGetValue(sourceId, out var mappedId))
+        {
+            return mappedId;
+        }
+
+        throw new InvalidOperationException(
+            $"The export references {entityName} id '{sourceId}' but it was not found.");
+    }
+
+    private static int? ResolveOptionalReference(
+        IReadOnlyDictionary<int, int> idMap,
+        int? sourceId,
+        string entityName)
+    {
+        if (sourceId is null)
+        {
+            return null;
+        }
+
+        if (idMap.TryGetValue(sourceId.Value, out var mappedId))
+        {
+            return mappedId;
+        }
+
+        throw new InvalidOperationException(
+            $"The export references {entityName} id '{sourceId}' but it was not found.");
+    }
+}

--- a/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
@@ -108,11 +108,22 @@ public static class BudgetDataPortabilityService
             {
                 mappedDefaultId = importedAccounts[0].ID;
             }
+            
+            await context.Accounts
+                .ExecuteUpdateAsync(
+                    updates => updates.SetProperty(account => account.IsDefault, false),
+                    cancellationToken);
 
-            var defaultAccount = await context.Accounts.FindAsync([mappedDefaultId], cancellationToken)
-                ?? throw new InvalidOperationException("Failed to locate imported default account.");
-            await context.SetAsDefaultAsync(defaultAccount);
-            await context.SaveChangesAsync(cancellationToken);
+            var updatedRows = await context.Accounts
+                .Where(account => account.ID == mappedDefaultId)
+                .ExecuteUpdateAsync(
+                    updates => updates.SetProperty(account => account.IsDefault, true),
+                    cancellationToken);
+
+            if (updatedRows != 1)
+            {
+                throw new InvalidOperationException("Failed to locate imported default account.");
+            }
         }
 
         var categorySeed = (exportPackage.Categories ?? []).OrderBy(x => x.Id).ToList();

--- a/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
+++ b/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
@@ -1,0 +1,210 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq.AutoMock;
+using SimplyBudgetShared.Data;
+using SimplyBudgetShared.DataTransfer;
+
+namespace SimplyBudgetSharedTests.Data;
+
+[TestClass]
+public class BudgetDataPortabilityServiceTests
+{
+    [TestMethod]
+    public async Task ExportAsync_IncludesAllBudgetData()
+    {
+        // Arrange
+        AutoMocker mocker = new();
+        using var factory = mocker.WithDbScope();
+
+        var checking = new Account { Name = "Checking", ValidatedDate = new DateTime(2026, 1, 1) };
+        var savings = new Account { Name = "Savings", ValidatedDate = new DateTime(2026, 1, 2) };
+
+        using var setupContext = factory.Create();
+        setupContext.Accounts.AddRange(checking, savings);
+        await setupContext.SaveChangesAsync();
+        savings = await setupContext.SetAsDefaultAsync(savings);
+        await setupContext.SaveChangesAsync();
+
+        var groceries = new ExpenseCategory
+        {
+            Name = "Groceries",
+            CategoryName = "Food",
+            AccountID = checking.ID,
+            BudgetedAmount = 500_00
+        };
+        setupContext.ExpenseCategories.Add(groceries);
+        await setupContext.SaveChangesAsync();
+
+        await setupContext.AddIncome("Paycheck", new DateTime(2026, 2, 1), (1_500_00, groceries.ID));
+        setupContext.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+        {
+            Name = "Grocery Rule",
+            RuleRegex = "GROCERY",
+            ExpenseCategoryID = groceries.ID
+        });
+        setupContext.Metadatas.Add(new Metadata { Key = "Version", Value = "test" });
+        await setupContext.SaveChangesAsync();
+
+        // Act
+        BudgetDataExportPackage exportPackage = await BudgetDataPortabilityService.ExportAsync(
+            setupContext,
+            source: "desktop-test");
+
+        // Assert
+        Assert.AreEqual(BudgetDataExportPackage.CurrentFormatVersion, exportPackage.FormatVersion);
+        Assert.AreEqual("desktop-test", exportPackage.Source);
+        Assert.AreEqual(2, exportPackage.Accounts.Count);
+        Assert.AreEqual(1, exportPackage.Categories.Count);
+        Assert.AreEqual(1, exportPackage.Items.Count);
+        Assert.AreEqual(1, exportPackage.ItemDetails.Count);
+        Assert.AreEqual(1, exportPackage.Rules.Count);
+        Assert.AreEqual(1, exportPackage.Metadata.Count);
+        Assert.IsTrue(exportPackage.Accounts.Single(x => x.Name == "Savings").IsDefault);
+    }
+
+    [TestMethod]
+    public async Task ImportAsync_ReplacesExistingDataAndPreservesRelationships()
+    {
+        // Arrange
+        AutoMocker mocker = new();
+        using var factory = mocker.WithDbScope();
+
+        using (var seedContext = factory.Create())
+        {
+            seedContext.Accounts.Add(new Account { Name = "Old Account", ValidatedDate = DateTime.Today });
+            await seedContext.SaveChangesAsync();
+        }
+
+        var exportPackage = new BudgetDataExportPackage
+        {
+            Source = "desktop",
+            Accounts =
+            [
+                new BudgetDataExportAccount(10, "Checking", new DateTime(2026, 3, 1), false),
+                new BudgetDataExportAccount(20, "Savings", new DateTime(2026, 3, 2), true)
+            ],
+            Categories =
+            [
+                new BudgetDataExportCategory(100, "Groceries", "Food", 10, 500_00, 0, 0, null, false),
+                new BudgetDataExportCategory(200, "Emergency Fund", "Savings", 20, 0, 10, 0, null, false)
+            ],
+            Items =
+            [
+                new BudgetDataExportItem(1000, new DateTime(2026, 3, 5), "Paycheck"),
+                new BudgetDataExportItem(2000, new DateTime(2026, 3, 7), "Market")
+            ],
+            ItemDetails =
+            [
+                new BudgetDataExportItemDetail(5000, 1000, 100, 2_000_00, false),
+                new BudgetDataExportItemDetail(6000, 1000, 200, 1_000_00, false),
+                new BudgetDataExportItemDetail(7000, 2000, 100, -500_00, false)
+            ],
+            Rules =
+            [
+                new BudgetDataExportRule(9000, "Market Rule", "MARKET", 100)
+            ],
+            Metadata =
+            [
+                new BudgetDataExportMetadata(9100, "Version", "1")
+            ]
+        };
+
+        // Act
+        using (var importContext = factory.Create())
+        {
+            await BudgetDataPortabilityService.ImportAsync(importContext, exportPackage);
+        }
+
+        // Assert
+        using var assertContext = factory.Create();
+        var accounts = await assertContext.Accounts.OrderBy(x => x.Name).ToListAsync();
+        Assert.AreEqual(2, accounts.Count);
+        Assert.AreEqual("Checking", accounts[0].Name);
+        Assert.AreEqual("Savings", accounts[1].Name);
+        Assert.IsTrue(accounts.Single(x => x.Name == "Savings").IsDefault);
+        Assert.IsNull(await assertContext.Accounts.SingleOrDefaultAsync(x => x.Name == "Old Account"));
+
+        var categories = await assertContext.ExpenseCategories.OrderBy(x => x.Name).ToListAsync();
+        Assert.AreEqual(2, categories.Count);
+        var groceries = categories.Single(x => x.Name == "Groceries");
+        var emergency = categories.Single(x => x.Name == "Emergency Fund");
+
+        Assert.AreEqual(1500_00, groceries.CurrentBalance);
+        Assert.AreEqual(1000_00, emergency.CurrentBalance);
+
+        var rules = await assertContext.ExpenseCategoryRules
+            .Include(x => x.ExpenseCategory)
+            .ToListAsync();
+        Assert.AreEqual(1, rules.Count);
+        Assert.AreEqual("Groceries", rules[0].ExpenseCategory?.Name);
+
+        Assert.AreEqual(1, await assertContext.Metadatas.CountAsync());
+        Assert.AreEqual(2, await assertContext.ExpenseCategoryItems.CountAsync());
+        Assert.AreEqual(3, await assertContext.ExpenseCategoryItemDetails.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task ImportAsync_WithUnsupportedFormatVersion_Throws()
+    {
+        // Arrange
+        AutoMocker mocker = new();
+        using var factory = mocker.WithDbScope();
+        using var context = factory.Create();
+
+        var exportPackage = new BudgetDataExportPackage
+        {
+            FormatVersion = BudgetDataExportPackage.CurrentFormatVersion + 1
+        };
+
+        // Act / Assert
+        try
+        {
+            await BudgetDataPortabilityService.ImportAsync(context, exportPackage);
+            Assert.Fail("Expected import to throw for an unsupported format version.");
+        }
+        catch (InvalidOperationException)
+        {
+            // expected
+        }
+    }
+
+    [TestMethod]
+    public async Task ImportAsync_WithNullCollections_TreatsThemAsEmpty()
+    {
+        // Arrange
+        AutoMocker mocker = new();
+        using var factory = mocker.WithDbScope();
+
+        using (var setupContext = factory.Create())
+        {
+            setupContext.Accounts.Add(new Account { Name = "Old Data", ValidatedDate = DateTime.Today });
+            await setupContext.SaveChangesAsync();
+        }
+
+        var exportPackage = new BudgetDataExportPackage
+        {
+            Source = "desktop",
+            Accounts = null!,
+            Categories = null!,
+            Items = null!,
+            ItemDetails = null!,
+            Rules = null!,
+            Metadata = null!
+        };
+
+        // Act
+        using (var importContext = factory.Create())
+        {
+            await BudgetDataPortabilityService.ImportAsync(importContext, exportPackage);
+        }
+
+        // Assert
+        using var assertContext = factory.Create();
+        Assert.AreEqual(0, await assertContext.Accounts.CountAsync());
+        Assert.AreEqual(0, await assertContext.ExpenseCategories.CountAsync());
+        Assert.AreEqual(0, await assertContext.ExpenseCategoryItems.CountAsync());
+        Assert.AreEqual(0, await assertContext.ExpenseCategoryItemDetails.CountAsync());
+        Assert.AreEqual(0, await assertContext.ExpenseCategoryRules.CountAsync());
+        Assert.AreEqual(0, await assertContext.Metadatas.CountAsync());
+    }
+}

--- a/SimplyBudgetWeb.Core.Tests/Controllers/DataPortabilityControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/DataPortabilityControllerTests.cs
@@ -1,0 +1,198 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetShared.Data;
+using SimplyBudgetShared.DataTransfer;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class DataPortabilityControllerTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Test]
+    public async Task Export_ReturnsJsonFileWithFullPayload()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var account = new Account { Name = "Checking", ValidatedDate = new DateTime(2026, 6, 1) };
+            context.Accounts.Add(account);
+            await context.SaveChangesAsync();
+            account = await context.SetAsDefaultAsync(account);
+            await context.SaveChangesAsync();
+
+            var category = new ExpenseCategory
+            {
+                Name = "Groceries",
+                CategoryName = "Food",
+                AccountID = account.ID,
+                BudgetedAmount = 500_00
+            };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            await context.AddIncome("Paycheck", new DateTime(2026, 6, 2), (1_000_00, category.ID));
+
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Rule 1",
+                RuleRegex = "PAYCHECK",
+                ExpenseCategoryID = category.ID
+            });
+            context.Metadatas.Add(new Metadata { Key = "Version", Value = "1" });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new DataPortabilityController(context);
+
+        IActionResult actionResult = await controller.Export(CancellationToken.None);
+        if (actionResult is not FileContentResult fileResult)
+        {
+            throw new Exception($"Expected {nameof(FileContentResult)} but got {actionResult.GetType().Name}.");
+        }
+
+        if (fileResult.ContentType != "application/json")
+        {
+            throw new Exception($"Unexpected content type: '{fileResult.ContentType}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(fileResult.FileDownloadName) ||
+            !fileResult.FileDownloadName.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new Exception("Expected export to have a .json download file name.");
+        }
+
+        var payload = JsonSerializer.Deserialize<BudgetDataExportPackage>(fileResult.FileContents, JsonOptions)
+            ?? throw new Exception("Failed to deserialize export payload.");
+
+        if (payload.Source != "web")
+        {
+            throw new Exception($"Expected source 'web', got '{payload.Source}'.");
+        }
+
+        if (payload.Accounts.Count != 1 ||
+            payload.Categories.Count != 1 ||
+            payload.Items.Count != 1 ||
+            payload.ItemDetails.Count != 1 ||
+            payload.Rules.Count != 1 ||
+            payload.Metadata.Count != 1)
+        {
+            throw new Exception("Export payload did not include all expected data sets.");
+        }
+    }
+
+    [Test]
+    public async Task Import_WithNullPayload_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new DataPortabilityController(context);
+
+        IActionResult actionResult = await controller.Import(null, CancellationToken.None);
+        if (actionResult is not BadRequestObjectResult)
+        {
+            throw new Exception($"Expected {nameof(BadRequestObjectResult)} but got {actionResult.GetType().Name}.");
+        }
+    }
+
+    [Test]
+    public async Task Import_ReplacesExistingDataAndReturnsNoContent()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.Accounts.Add(new Account { Name = "Old Account", ValidatedDate = DateTime.Today });
+            await context.SaveChangesAsync();
+        });
+
+        var payload = new BudgetDataExportPackage
+        {
+            Source = "desktop",
+            Accounts =
+            [
+                new BudgetDataExportAccount(1, "Checking", new DateTime(2026, 4, 1), false),
+                new BudgetDataExportAccount(2, "Savings", new DateTime(2026, 4, 2), true)
+            ],
+            Categories =
+            [
+                new BudgetDataExportCategory(10, "Groceries", "Food", 1, 500_00, 0, 0, null, false),
+                new BudgetDataExportCategory(20, "Emergency Fund", "Savings", 2, 0, 10, 0, null, false)
+            ],
+            Items =
+            [
+                new BudgetDataExportItem(100, new DateTime(2026, 4, 5), "Paycheck")
+            ],
+            ItemDetails =
+            [
+                new BudgetDataExportItemDetail(1000, 100, 10, 1_000_00, false),
+                new BudgetDataExportItemDetail(2000, 100, 20, 500_00, false)
+            ],
+            Rules =
+            [
+                new BudgetDataExportRule(3000, "Paycheck rule", "PAYCHECK", 10)
+            ],
+            Metadata =
+            [
+                new BudgetDataExportMetadata(4000, "Version", "1")
+            ]
+        };
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new DataPortabilityController(context);
+            IActionResult result = await controller.Import(payload, CancellationToken.None);
+            if (result is not NoContentResult)
+            {
+                throw new Exception($"Expected {nameof(NoContentResult)} but got {result.GetType().Name}.");
+            }
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            if (await context.Accounts.CountAsync() != 2)
+            {
+                throw new Exception("Expected imported accounts to replace existing accounts.");
+            }
+
+            if (await context.Accounts.AnyAsync(x => x.Name == "Old Account"))
+            {
+                throw new Exception("Expected previous account data to be removed.");
+            }
+
+            var defaultAccount = await context.Accounts.SingleOrDefaultAsync(x => x.IsDefault);
+            if (defaultAccount?.Name != "Savings")
+            {
+                throw new Exception("Expected imported default account to be preserved.");
+            }
+
+            var categories = await context.ExpenseCategories.OrderBy(x => x.Name).ToListAsync();
+            if (categories.Count != 2)
+            {
+                throw new Exception("Expected imported categories to be present.");
+            }
+
+            var groceries = categories.Single(x => x.Name == "Groceries");
+            var emergency = categories.Single(x => x.Name == "Emergency Fund");
+            if (groceries.CurrentBalance != 1_000_00 || emergency.CurrentBalance != 500_00)
+            {
+                throw new Exception("Expected category balances to be rebuilt from imported item details.");
+            }
+
+            if (await context.ExpenseCategoryRules.CountAsync() != 1 ||
+                await context.Metadatas.CountAsync() != 1)
+            {
+                throw new Exception("Expected rules and metadata to be imported.");
+            }
+        });
+    }
+}

--- a/SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj
+++ b/SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SimplyBudgetWeb.Core\SimplyBudgetWeb.Core.csproj" />
+    <ProjectReference Include="..\SimplyBudgetWeb\SimplyBudgetWeb.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SimplyBudgetWeb.Web/src/pages/Import.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Import.vue
@@ -2,7 +2,11 @@
 import { ref, onMounted } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
-import type { ImportItemDto, ExpenseCategoryDto } from '@/types'
+import type {
+  ImportItemDto,
+  ExpenseCategoryDto,
+  BudgetDataExportPackageDto,
+} from '@/types'
 import { formatCents } from '@/utils/currency'
 
 const snackbar = useSnackbarStore()
@@ -12,6 +16,10 @@ const items = ref<ImportItemDto[]>([])
 const categories = ref<ExpenseCategoryDto[]>([])
 const loading = ref(false)
 const submitting = ref(false)
+const exportingData = ref(false)
+const importingData = ref(false)
+const importFile = ref<File | null>(null)
+const importFileInput = ref<HTMLInputElement | null>(null)
 
 async function fetchCategories() {
   try {
@@ -55,12 +63,86 @@ async function handleImport() {
   }
 }
 
+function onImportFileSelected(event: Event) {
+  const input = event.target as HTMLInputElement
+  importFile.value = input.files?.item(0) ?? null
+}
+
+async function handleExportAllData() {
+  exportingData.value = true
+  try {
+    const result = await apiClient.download('/api/data-portability/export')
+    const fileName = result.fileName ?? `simplybudget-export-${new Date().toISOString().replace(/[:.]/g, '-')}.json`
+    const url = URL.createObjectURL(result.blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = fileName
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+    snackbar.enqueueSnackbar('Data export downloaded', { variant: 'success' })
+  } catch {
+    snackbar.enqueueSnackbar('Failed to export data', { variant: 'error' })
+  } finally {
+    exportingData.value = false
+  }
+}
+
+async function handleImportAllData() {
+  if (!importFile.value) return
+
+  importingData.value = true
+  try {
+    const fileContent = await importFile.value.text()
+    const payload = JSON.parse(fileContent) as BudgetDataExportPackageDto
+    await apiClient.post('/api/data-portability/import', payload)
+    importFile.value = null
+    if (importFileInput.value) {
+      importFileInput.value.value = ''
+    }
+    snackbar.enqueueSnackbar('Data import completed', { variant: 'success' })
+  } catch {
+    snackbar.enqueueSnackbar('Failed to import data export', { variant: 'error' })
+  } finally {
+    importingData.value = false
+  }
+}
+
 onMounted(() => { void fetchCategories() })
 </script>
 
 <template>
   <div>
     <h5 class="text-h5 mb-4">Import Transactions</h5>
+
+    <v-card class="pa-4 mb-4">
+      <h6 class="text-h6 mb-2">Full Data Transfer</h6>
+      <p class="text-body-2 mb-4">
+        Export all accounts, categories, transactions, rules, and metadata into a JSON file, or import a previous export.
+      </p>
+      <div class="d-flex flex-wrap align-center" style="gap: 12px;">
+        <v-btn color="primary" :loading="exportingData" :disabled="exportingData || importingData" @click="handleExportAllData">
+          Export All Data
+        </v-btn>
+        <input
+          ref="importFileInput"
+          type="file"
+          accept=".json,application/json"
+          :disabled="importingData || exportingData"
+          @change="onImportFileSelected"
+        />
+        <v-btn
+          color="secondary"
+          :loading="importingData"
+          :disabled="importingData || exportingData || !importFile"
+          @click="handleImportAllData"
+        >
+          Import Export File
+        </v-btn>
+      </div>
+      <p v-if="importFile" class="text-body-2 mt-3 mb-0">Selected file: {{ importFile.name }}</p>
+    </v-card>
 
     <v-card class="pa-4 mb-4">
       <v-textarea

--- a/SimplyBudgetWeb.Web/src/services/apiClient.ts
+++ b/SimplyBudgetWeb.Web/src/services/apiClient.ts
@@ -7,11 +7,23 @@ export function setTokenProvider(fn: () => Promise<string>) {
 class ApiClient {
   private baseUrl = __API_BASE_URL__ || ''
 
+  private parseFileName(contentDisposition: string | null): string | null {
+    if (!contentDisposition) return null
+
+    const encodedMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i)
+    if (encodedMatch?.[1]) {
+      return decodeURIComponent(encodedMatch[1].trim())
+    }
+
+    const basicMatch = contentDisposition.match(/filename="?([^"]+)"?/i)
+    return basicMatch?.[1]?.trim() ?? null
+  }
+
   private async getHeaders(): Promise<HeadersInit> {
     if (getTokenFn) {
       try {
         const token = await getTokenFn()
-        return { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' }
+        return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
       } catch { /* fall through */ }
     }
     return { 'Content-Type': 'application/json' }
@@ -38,6 +50,20 @@ class ApiClient {
     if (response.status === 204) return undefined as T
     const text = await response.text()
     return text ? JSON.parse(text) : undefined as T
+  }
+
+  async download(url: string): Promise<{ blob: Blob; fileName: string | null }> {
+    const headers = await this.getHeaders()
+    const response = await fetch(this.baseUrl + url, { headers })
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(error || `HTTP error! status: ${response.status}`)
+    }
+
+    return {
+      blob: await response.blob(),
+      fileName: this.parseFileName(response.headers.get('content-disposition')),
+    }
   }
 
   async put<T = void>(url: string, data?: unknown): Promise<T> {

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -97,3 +97,61 @@ export interface TransferRequest {
   fromCategoryId: number
   toCategoryId: number
 }
+
+export interface BudgetDataExportPackageDto {
+  formatVersion: number
+  exportedAtUtc: string
+  source: string | null
+  accounts: BudgetDataExportAccountDto[]
+  categories: BudgetDataExportCategoryDto[]
+  items: BudgetDataExportItemDto[]
+  itemDetails: BudgetDataExportItemDetailDto[]
+  rules: BudgetDataExportRuleDto[]
+  metadata: BudgetDataExportMetadataDto[]
+}
+
+export interface BudgetDataExportAccountDto {
+  id: number
+  name: string | null
+  validatedDate: string
+  isDefault: boolean
+}
+
+export interface BudgetDataExportCategoryDto {
+  id: number
+  name: string | null
+  categoryName: string | null
+  accountId: number | null
+  budgetedAmount: number
+  budgetedPercentage: number
+  currentBalance: number
+  cap: number | null
+  isHidden: boolean
+}
+
+export interface BudgetDataExportItemDto {
+  id: number
+  date: string
+  description: string | null
+}
+
+export interface BudgetDataExportItemDetailDto {
+  id: number
+  expenseCategoryItemId: number
+  expenseCategoryId: number
+  amount: number
+  ignoreBudget: boolean
+}
+
+export interface BudgetDataExportRuleDto {
+  id: number
+  name: string | null
+  ruleRegex: string | null
+  expenseCategoryId: number | null
+}
+
+export interface BudgetDataExportMetadataDto {
+  id: number
+  key: string | null
+  value: string | null
+}

--- a/SimplyBudgetWeb/Controllers/DataPortabilityController.cs
+++ b/SimplyBudgetWeb/Controllers/DataPortabilityController.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using SimplyBudgetShared.DataTransfer;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Controllers;
+
+[ApiController]
+[Route("api/data-portability")]
+public class DataPortabilityController(BudgetWebContext context) : ControllerBase
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    [HttpGet("export")]
+    public async Task<IActionResult> Export(CancellationToken cancellationToken)
+    {
+        var exportPackage = await BudgetDataPortabilityService.ExportAsync(context, source: "web", cancellationToken);
+        var fileName = $"simplybudget-export-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json";
+        var payload = JsonSerializer.SerializeToUtf8Bytes(exportPackage, JsonOptions);
+        return File(payload, "application/json", fileName);
+    }
+
+    [HttpPost("import")]
+    public async Task<IActionResult> Import([FromBody] BudgetDataExportPackage? exportPackage, CancellationToken cancellationToken)
+    {
+        if (exportPackage is null)
+        {
+            return BadRequest("A data export payload is required.");
+        }
+
+        await BudgetDataPortabilityService.ImportAsync(context, exportPackage, cancellationToken);
+        return NoContent();
+    }
+}


### PR DESCRIPTION
## Why
Users need a reliable way to move budgeting data between the desktop and web apps. This adds a shared portability format so data can be exported from either app and imported into the web app without manual migration.

## What changed
- Added a shared portability model and service in `SimplyBudgetShared`:
  - `BudgetDataExportPackage` DTOs for accounts, categories, items, item details, rules, and metadata.
  - `BudgetDataPortabilityService` to export full data and import with ID remapping, replacement semantics, and default-account restoration.
- Added web API endpoints in `SimplyBudgetWeb`:
  - `GET /api/data-portability/export`
  - `POST /api/data-portability/import`
- Added web UI support in `SimplyBudgetWeb.Web/src/pages/Import.vue`:
  - Full data export download action.
  - Full data import from JSON file.
  - Updated API client with download/file-name handling and added portability DTO types.
- Added desktop export support in WPF settings:
  - New `Export Data` action in `SettingsView` and `SettingsViewModel` that writes JSON exports from the desktop SQLite-backed data.

## Test coverage added
- `SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs`
  - export shape/data coverage
  - import replacement and relationship mapping coverage
  - unsupported format version handling
  - null collection import handling
- `SimplyBudgetWeb.Core.Tests/Controllers/DataPortabilityControllerTests.cs`
  - export response contract and payload coverage
  - null payload bad-request coverage
  - import no-content response and end-to-end data replacement coverage

## Notes for reviewers
- Import is intentionally a full replace operation for portability/migration scenarios.
- `SimplyBudgetWeb.Core.Tests` now references `SimplyBudgetWeb` so controller tests can directly exercise `DataPortabilityController`.