### PR TITLE
Retry Azure SQL cold-start availability errors in Terraform setup

### DIFF
--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -148,7 +148,9 @@ resource "terraform_data" "setup_database_principal" {
     var.provisioning_client_id,
     data.azuread_group.sql_admins.object_id,
     join(",", local.database_admin_user_names),
-    "v5" # Bumped from v4: add resilient SQL warm-up/retry logic for free-tier cold starts
+    "v6" # Bumped from v5: treat Azure SQL "database is not currently available"
+    # cold-start message as transient so retry/backoff is applied.
+    # Bumped from v4: add resilient SQL warm-up/retry logic for free-tier cold starts
     # and use a longer connection timeout for Terraform-driven principal setup.
     # Bumped from v3: repair a stale contained database user left behind
     # when azurerm_user_assigned_identity.app_identity is destroyed and
@@ -267,7 +269,7 @@ resource "terraform_data" "setup_database_principal" {
             return $false
           }
 
-          return $ErrorMessage -match '(?i)timeout|timed out|transport-level error|service is currently busy|temporarily unavailable|error 40197|error 40501|error 40613|error 49918|error 49919|error 49920|client with ip address|login failed for user ''<token-identified principal>'''
+          return $ErrorMessage -match '(?i)timeout|timed out|transport-level error|service is currently busy|temporarily unavailable|not currently available|retry the connection later|please retry|please try again|error 40197|error 40501|error 40613|error 49918|error 49919|error 49920|client with ip address|login failed for user ''<token-identified principal>'''
         }
 
         for ($attempt = 1; $attempt -le $maxSqlAttempts; $attempt++) {


### PR DESCRIPTION
## Why
The previous retry logic still failed on the free-tier cold-start path because the Azure SQL error message from the failed run was `Database '... is not currently available. Please retry the connection later.` and that text was not treated as transient.

## What changed
- Expanded `Test-IsTransientSqlStartupError` to classify these cold-start messages as retryable:
  - `not currently available`
  - `retry the connection later`
  - `please retry` / `please try again`
- Bumped `terraform_data.setup_database_principal` trigger version from `v5` to `v6` so the updated retry behavior is applied on next `terraform apply`.

## Notes
This keeps fail-fast behavior for non-transient failures, but correctly applies the existing exponential backoff flow to the observed free-tier wake-up error.