### PR TITLE
Fix O(n²) hang in BudgetContext.SaveChangesAsync causing data import failures

### DIFF
--- a/SimplyBudgetShared/Data/BudgetContext.cs
+++ b/SimplyBudgetShared/Data/BudgetContext.cs
@@ -135,22 +135,30 @@ public class BudgetContext : DbContext
         }
 
         var seen = new HashSet<T>(comparer);
+        var pending = new List<T>();
 
-        bool loop;
+        // Each round collects every not-yet-seen item in a single pass over `items()`.
+        // Processing an item (e.g. via IBeforeCreate/IBeforeRemove) may cause additional
+        // entities to become tracked/changed, which subsequent rounds will pick up.
+        // Doing this in batches (rather than restarting the full scan after every single
+        // new item) keeps this roughly O(n * rounds) instead of O(n^2) for large batches.
         do
         {
-            loop = false;
+            pending.Clear();
             foreach (var item in items())
             {
                 if (seen.Add(item))
                 {
-                    yield return item;
-                    loop = true;
-                    break;
+                    pending.Add(item);
                 }
             }
+
+            foreach (var item in pending)
+            {
+                yield return item;
+            }
         }
-        while (loop);
+        while (pending.Count > 0);
     }
 
     private class EntityComparer : IEqualityComparer<EntityEntry>


### PR DESCRIPTION
## Problem

The full data-portability import (`BudgetDataPortabilityService.ImportAsync`) was failing/hanging in production when importing a real desktop export containing 12,216 items and 19,940 item details.

## Root cause

`BudgetContext.SaveChangesAsync` uses a private `PumpItems<T>` helper to walk changed `ChangeTracker` entries (so it can invoke `IBeforeCreate`/`IBeforeRemove` hooks and fire change notifications), including for entities added as a *side effect* of processing another entity (e.g. adding an `ExpenseCategoryItemDetail` marks its `ExpenseCategory` as `Modified` via `BeforeCreate`).

The old implementation rescanned the **entire** `ChangeTracker.Entries()` list from scratch every time it found a single new changed entry, then restarted the scan from the top. For a batch of `n` changed entities this is O(n²) — for the bulk import (tens of thousands of entities added in single `SaveChangesAsync` calls), this took **>7 minutes and never completed** in local repro, which is almost certainly why this appeared as an import failure in prod (request/gateway timeout).

## Fix

`PumpItems` now collects **all** not-yet-seen changed entries in a single pass per "round", yields them all, and only loops again if new entries appeared during that round (still correctly handling cascading `IBeforeCreate`/`IBeforeRemove` side effects). This is O(n · rounds) instead of O(n²), where `rounds` is small (bounded by cascade depth, not entity count).

## Verification

- Reproduced the original hang against the real desktop export file that was failing in prod (2 accounts, 50 categories, 12,216 items, 19,940 item details) — import never completed after 7+ minutes on `main`.
- With the fix, the same import completes in **~8 seconds**, with identical resulting data (row counts and rebuilt category balances match).
- Existing tests pass: `BudgetDataPortabilityServiceTests` (4/4) and all related `BudgetContext`/notification/balance tests (39/39).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>