### PR TITLE
Fix dark/light theme colors so cards and headers stay visible

### DIFF
--- a/SimplyBudgetWeb.Web/src/plugins/vuetify.ts
+++ b/SimplyBudgetWeb.Web/src/plugins/vuetify.ts
@@ -25,7 +25,8 @@ export const vuetify = createVuetify({
       light: {
         dark: false,
         colors: {
-          background: '#ffffff',
+          // Off-white so surfaces (cards, app bar, etc.) stand out against the page.
+          background: '#f5f5f5',
           surface: '#ffffff',
         },
         variables: {
@@ -37,8 +38,10 @@ export const vuetify = createVuetify({
       dark: {
         dark: true,
         colors: {
-          background: '#121212',
-          surface: '#121212',
+          // Off-black background with a lighter surface color so cards, the
+          // app bar, and other surfaces are visually distinct from the page.
+          background: '#161616',
+          surface: '#242424',
         },
       },
     },


### PR DESCRIPTION
## Why

In dark mode the page background and card/surface color were both `#121212`, so cards, the app bar, and expansion panel headers had no visible contrast and effectively disappeared into the background. Light mode used pure white for both background and surface, which felt too stark.

## What changed

Updated the Vuetify theme definitions in `SimplyBudgetWeb.Web/src/plugins/vuetify.ts`:

- **Dark theme**: background changed to an off-black `#161616`, and surface (cards, app bar, expansion panels, etc.) changed to a lighter `#242424` so these elements are now visibly distinct from the page.
- **Light theme**: background changed to an off-white `#f5f5f5` for a softer look, while surface stays `#ffffff` so cards still stand out against the page.

## Verification

Ran the app locally (`pnpm run dev`) and checked computed styles in both themes via a browser session:
- Dark: page background `rgb(22,22,22)`, card background `rgb(36,36,36)` (visibly different).
- Light: page background `rgb(245,245,245)`, card background `rgb(255,255,255)` (visibly different).