### PR TITLE
Remove copyright footer from Layout.vue

### DIFF
--- a/SimplyBudgetWeb.Web/src/components/Layout.vue
+++ b/SimplyBudgetWeb.Web/src/components/Layout.vue
@@ -57,8 +57,4 @@ function toggleTheme() {
       <router-view />
     </v-container>
   </v-main>
-
-  <v-footer app class="justify-center">
-    <span class="text-body-2 text-medium-emphasis">&copy; {{ new Date().getFullYear() }} Simply Budget</span>
-  </v-footer>
 </template>


### PR DESCRIPTION
Removes the copyright footer (`© {year} Simply Budget`) that was rendered via `<v-footer>` at the bottom of every page, per request.

No other footer/copyright references were found elsewhere in the repo.