### PR TITLE
Fix FAB being obscured by page content

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -121,7 +121,7 @@ function onDialogSuccess() {
       icon="mdi-plus"
       color="primary"
       aria-label="Add Transaction"
-      style="position: fixed; bottom: 32px; right: 32px;"
+      style="position: fixed; bottom: 32px; right: 32px; z-index: 100;"
       @click="dialogOpen = true"
     />
 

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -143,7 +143,7 @@ function onDialogSuccess() {
       icon="mdi-plus"
       color="primary"
       aria-label="Add Transaction"
-      style="position: fixed; bottom: 32px; right: 32px;"
+      style="position: fixed; bottom: 32px; right: 32px; z-index: 100;"
       @click="dialogOpen = true"
     />
 


### PR DESCRIPTION
## Why

The "Add Transaction" floating action button on the Budget and History pages is fixed-position but has no `z-index`, so it can render behind in-flow page content (cards, expansion panels, lists) and get visually cut off.

## Fix

Add `z-index: 100` alongside `position: fixed` on the FAB in `Budget.vue` and `History.vue` so it consistently stacks above regular page content.