### PR TITLE
Add pending expenses feature (web app only)

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/AssigneesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/AssigneesControllerTests.cs
@@ -1,0 +1,146 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class AssigneesControllerTests
+{
+    [Test]
+    public async Task GetAll_ReturnsAssigneesOrderedByName()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenseAssignees.AddRange(
+                new PendingExpenseAssignee { Name = "Zoe" },
+                new PendingExpenseAssignee { Name = "Alice" });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new AssigneesController(context);
+
+        var result = await controller.GetAll();
+
+        await Assert.That(result.Length).IsEqualTo(2);
+        await Assert.That(result[0].Name).IsEqualTo("Alice");
+        await Assert.That(result[1].Name).IsEqualTo("Zoe");
+    }
+
+    [Test]
+    public async Task Create_AddsNewAssignee()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new AssigneesController(context);
+
+        var result = await controller.Create(new AssigneeRequest("Jordan"));
+
+        var created = ((CreatedAtActionResult)result.Result!).Value as AssigneeDto;
+        await Assert.That(created).IsNotNull();
+        await Assert.That(created!.Name).IsEqualTo("Jordan");
+        await Assert.That(created.Id).IsGreaterThan(0);
+
+        await Assert.That(await context.PendingExpenseAssignees.CountAsync()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Create_TrimsName()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new AssigneesController(context);
+
+        var result = await controller.Create(new AssigneeRequest("  Jordan  "));
+
+        var created = ((CreatedAtActionResult)result.Result!).Value as AssigneeDto;
+        await Assert.That(created!.Name).IsEqualTo("Jordan");
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task Create_WithBlankName_ReturnsBadRequest(string? name)
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new AssigneesController(context);
+
+        var result = await controller.Create(new AssigneeRequest(name));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+    }
+
+    [Test]
+    public async Task Create_WithDuplicateName_ReturnsConflict()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenseAssignees.Add(new PendingExpenseAssignee { Name = "Jordan" });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new AssigneesController(context);
+
+        var result = await controller.Create(new AssigneeRequest("Jordan"));
+
+        await Assert.That(result.Result).IsTypeOf<ConflictObjectResult>();
+        await Assert.That(await context.PendingExpenseAssignees.CountAsync()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Delete_RemovesAssignee()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int assigneeId = await mocker.InDbScopeAsync(async context =>
+        {
+            var assignee = new PendingExpenseAssignee { Name = "Jordan" };
+            context.PendingExpenseAssignees.Add(assignee);
+            await context.SaveChangesAsync();
+            return assignee.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new AssigneesController(context);
+            var result = await controller.Delete(assigneeId);
+            await Assert.That(result).IsTypeOf<NoContentResult>();
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            await Assert.That(await context.PendingExpenseAssignees.CountAsync()).IsEqualTo(0);
+        });
+    }
+
+    [Test]
+    public async Task Delete_WithUnknownId_ReturnsNotFound()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new AssigneesController(context);
+
+        var result = await controller.Delete(999);
+
+        await Assert.That(result).IsTypeOf<NotFoundResult>();
+    }
+}

--- a/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class ImportControllerTests
+{
+    private const string StcuHeader = @"""Transaction ID"",""Posting Date"",""Effective Date"",""Transaction Type"",""Amount"",""Check Number"",""Reference Number"",""Description"",""Transaction Category"",""Type"",""Balance"",""Memo"",""Extended Description""";
+
+    private static string BuildCsv(string row) => StcuHeader + Environment.NewLine + row;
+
+    [Test]
+    public async Task Parse_AppliesMatchingRuleSuggestion()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Entertainment" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Google Play",
+                RuleRegex = "GOOGLE Play",
+                ExpenseCategoryID = category.ID
+            });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var csv = BuildCsv(@"""1"",""11/23/2020"",""11/23/2020"",""Debit"",""-21.77000"","""",""1"",""Purchase GOOGLE Play"",""Entertainment"",""Debit Card"",""1"","""",""Purchase GOOGLE Play""");
+        var result = await controller.Parse(new ImportRequest(csv));
+
+        var items = ((OkObjectResult)result.Result!).Value as ImportItemDto[];
+        await Assert.That(items!.Length).IsEqualTo(1);
+        await Assert.That(items[0].Amount).IsEqualTo(21_77);
+        await Assert.That(items[0].IsDebit).IsTrue();
+        await Assert.That(items[0].SuggestedCategoryName).IsEqualTo("Entertainment");
+    }
+
+    [Test]
+    public async Task Parse_WithNoMatchingRule_LeavesSuggestionNull()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var csv = BuildCsv(@"""1"",""11/20/2020"",""11/20/2020"",""Credit"",""1234.56000"","""",""1"",""PAYROLL"","""",""ACH"",""1"","""",""PAYROLL""");
+        var result = await controller.Parse(new ImportRequest(csv));
+
+        var items = ((OkObjectResult)result.Result!).Value as ImportItemDto[];
+        await Assert.That(items!.Length).IsEqualTo(1);
+        await Assert.That(items[0].IsDebit).IsFalse();
+        await Assert.That(items[0].Amount).IsEqualTo(123456);
+        await Assert.That(items[0].SuggestedCategoryId).IsNull();
+    }
+
+    [Test]
+    public async Task Save_CreatesPendingExpensesForItemsNotMarkedDone()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var items = new[]
+        {
+            new ImportItemDto(new DateTime(2026, 1, 1), "Costco", 45_00, true, categoryId, "Groceries", IsDone: false),
+            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, null, null, IsDone: true),
+        };
+
+        var result = await controller.Save(items);
+
+        await Assert.That(((StatusCodeResult)result).StatusCode).IsEqualTo(201);
+        var saved = await context.PendingExpenses.ToListAsync();
+        await Assert.That(saved.Count).IsEqualTo(1);
+        await Assert.That(saved[0].Description).IsEqualTo("Costco");
+        await Assert.That(saved[0].Amount).IsEqualTo(45_00);
+        await Assert.That(saved[0].SuggestedCategoryId).IsEqualTo(categoryId);
+    }
+
+    [Test]
+    public async Task Save_WithAllItemsMarkedDone_CreatesNoPendingExpenses()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var items = new[]
+        {
+            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, null, null, IsDone: true),
+        };
+
+        await controller.Save(items);
+
+        await Assert.That(await context.PendingExpenses.CountAsync()).IsEqualTo(0);
+    }
+}

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -1,0 +1,420 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class PendingExpensesControllerTests
+{
+    [Test]
+    public async Task GetAll_ReturnsItemsOrderedByDateAscending_OldestFirst()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 3, 1), Description = "Newest", Amount = 100 },
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Oldest", Amount = 200 },
+                new PendingExpense { Date = new DateTime(2026, 2, 1), Description = "Middle", Amount = 300 });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetAll(search: null, assigneeId: null);
+
+        await Assert.That(result.Length).IsEqualTo(3);
+        await Assert.That(result[0].Description).IsEqualTo("Oldest");
+        await Assert.That(result[1].Description).IsEqualTo("Middle");
+        await Assert.That(result[2].Description).IsEqualTo("Newest");
+    }
+
+    [Test]
+    public async Task GetAll_IsNotLimitedToASingleMonth()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2024, 1, 1), Description = "Very old", Amount = 100 },
+                new PendingExpense { Date = new DateTime(2026, 6, 1), Description = "Recent", Amount = 200 });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetAll(search: null, assigneeId: null);
+
+        await Assert.That(result.Length).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetAll_FiltersBySearch()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco groceries", Amount = 100 },
+                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Gas station", Amount = 200 });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetAll(search: "Costco", assigneeId: null);
+
+        await Assert.That(result.Length).IsEqualTo(1);
+        await Assert.That(result[0].Description).IsEqualTo("Costco groceries");
+    }
+
+    [Test]
+    public async Task GetAll_FiltersByAssignee()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int assigneeId = await mocker.InDbScopeAsync(async context =>
+        {
+            var assignee = new PendingExpenseAssignee { Name = "Jordan" };
+            context.PendingExpenseAssignees.Add(assignee);
+            await context.SaveChangesAsync();
+
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Assigned", Amount = 100, AssigneeId = assignee.ID },
+                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Unassigned", Amount = 200 });
+            await context.SaveChangesAsync();
+            return assignee.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetAll(search: null, assigneeId: assigneeId);
+
+        await Assert.That(result.Length).IsEqualTo(1);
+        await Assert.That(result[0].Description).IsEqualTo("Assigned");
+        await Assert.That(result[0].AssigneeName).IsEqualTo("Jordan");
+    }
+
+    [Test]
+    public async Task GetById_WithUnknownId_ReturnsNotFound()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetById(999);
+
+        await Assert.That(result.Result).IsTypeOf<NotFoundResult>();
+    }
+
+    [Test]
+    public async Task Update_SetsAssigneeAndNotes()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        var (pendingId, assigneeId) = await mocker.InDbScopeAsync(async context =>
+        {
+            var assignee = new PendingExpenseAssignee { Name = "Jordan" };
+            var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
+            context.PendingExpenseAssignees.Add(assignee);
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+            return (pending.ID, assignee.ID);
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new PendingExpensesController(context);
+            var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(assigneeId, "Needs review"));
+
+            var dto = (result.Value as PendingExpenseDto) ?? ((OkObjectResult)result.Result!).Value as PendingExpenseDto;
+            await Assert.That(dto!.AssigneeId).IsEqualTo(assigneeId);
+            await Assert.That(dto.AssigneeName).IsEqualTo("Jordan");
+            await Assert.That(dto.Notes).IsEqualTo("Needs review");
+        }
+
+        // Verify the change was actually persisted (not just reflected on the in-memory DTO).
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var pending = await context.PendingExpenses.SingleAsync(x => x.ID == pendingId);
+            await Assert.That(pending.AssigneeId).IsEqualTo(assigneeId);
+            await Assert.That(pending.Notes).IsEqualTo("Needs review");
+        });
+    }
+
+    [Test]
+    public async Task Update_CanClearAssignee()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int pendingId = await mocker.InDbScopeAsync(async context =>
+        {
+            var assignee = new PendingExpenseAssignee { Name = "Jordan" };
+            context.PendingExpenseAssignees.Add(assignee);
+            var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+            pending.AssigneeId = assignee.ID;
+            await context.SaveChangesAsync();
+            return pending.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new PendingExpensesController(context);
+            var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(null, null));
+
+            var dto = (result.Value as PendingExpenseDto) ?? ((OkObjectResult)result.Result!).Value as PendingExpenseDto;
+            await Assert.That(dto!.AssigneeId).IsNull();
+            await Assert.That(dto.AssigneeName).IsNull();
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var pending = await context.PendingExpenses.SingleAsync(x => x.ID == pendingId);
+            await Assert.That(pending.AssigneeId).IsNull();
+        });
+    }
+
+    [Test]
+    public async Task Update_WithUnknownAssignee_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int pendingId = await mocker.InDbScopeAsync(async context =>
+        {
+            var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+            return pending.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(999, null));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+    }
+
+    [Test]
+    public async Task Update_WithUnknownPendingExpense_ReturnsNotFound()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.Update(999, new PendingExpenseUpdateRequest(null, "notes"));
+
+        await Assert.That(result.Result).IsTypeOf<NotFoundResult>();
+    }
+
+    [Test]
+    public async Task Delete_RemovesPendingExpense()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int pendingId = await mocker.InDbScopeAsync(async context =>
+        {
+            var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+            return pending.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new PendingExpensesController(context);
+            var result = await controller.Delete(pendingId);
+            await Assert.That(result).IsTypeOf<NoContentResult>();
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            await Assert.That(await context.PendingExpenses.CountAsync()).IsEqualTo(0);
+        });
+    }
+
+    [Test]
+    public async Task Convert_WithNoItems_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int pendingId = await mocker.InDbScopeAsync(async context =>
+        {
+            var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+            return pending.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.Convert(pendingId, new ConvertPendingExpenseRequest("Costco", DateTime.Today, []));
+
+        await Assert.That(result).IsTypeOf<BadRequestObjectResult>();
+    }
+
+    [Test]
+    public async Task Convert_WithUnknownId_ReturnsNotFound()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.Convert(999, new ConvertPendingExpenseRequest("Costco", DateTime.Today,
+            [new ConvertPendingExpenseItemRequest(1, 100)]));
+
+        await Assert.That(result).IsTypeOf<NotFoundResult>();
+    }
+
+    [Test]
+    public async Task Convert_Debit_CreatesExpenseTransactionAndRemovesPendingExpense()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var category = new ExpenseCategory { Name = "Groceries", CurrentBalance = 1_000_00 };
+            context.ExpenseCategories.Add(category);
+            var pending = new PendingExpense
+            {
+                Date = new DateTime(2026, 1, 5),
+                Description = "Costco",
+                Amount = 45_00,
+                IsDebit = true
+            };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+
+            var controller = new PendingExpensesController(context);
+            var result = await controller.Convert(pending.ID, new ConvertPendingExpenseRequest(
+                "Costco", new DateTime(2026, 1, 5), [new ConvertPendingExpenseItemRequest(category.ID, 45_00)]));
+
+            await Assert.That(result).IsTypeOf<StatusCodeResult>();
+            await Assert.That(((StatusCodeResult)result).StatusCode).IsEqualTo(201);
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            await Assert.That(await context.PendingExpenses.CountAsync()).IsEqualTo(0);
+
+            var item = await context.ExpenseCategoryItems
+                .Include(x => x.Details)
+                .SingleAsync();
+            await Assert.That(item.Description).IsEqualTo("Costco");
+            await Assert.That(item.Details!.Single().Amount).IsEqualTo(-45_00);
+
+            var category = await context.ExpenseCategories.SingleAsync();
+            await Assert.That(category.CurrentBalance).IsEqualTo(1_000_00 - 45_00);
+        });
+    }
+
+    [Test]
+    public async Task Convert_Debit_CanSplitAcrossMultipleCategories()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var groceries = new ExpenseCategory { Name = "Groceries", CurrentBalance = 500_00 };
+            var household = new ExpenseCategory { Name = "Household", CurrentBalance = 200_00 };
+            context.ExpenseCategories.AddRange(groceries, household);
+            var pending = new PendingExpense
+            {
+                Date = new DateTime(2026, 1, 5),
+                Description = "Costco",
+                Amount = 100_00,
+                IsDebit = true
+            };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+
+            var controller = new PendingExpensesController(context);
+            await controller.Convert(pending.ID, new ConvertPendingExpenseRequest(
+                "Costco", new DateTime(2026, 1, 5),
+                [
+                    new ConvertPendingExpenseItemRequest(groceries.ID, 70_00),
+                    new ConvertPendingExpenseItemRequest(household.ID, 30_00),
+                ]));
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var item = await context.ExpenseCategoryItems
+                .Include(x => x.Details)
+                .SingleAsync();
+            await Assert.That(item.Details!.Count).IsEqualTo(2);
+            await Assert.That(item.Details!.Sum(x => x.Amount)).IsEqualTo(-100_00);
+
+            var groceries = await context.ExpenseCategories.SingleAsync(x => x.Name == "Groceries");
+            var household = await context.ExpenseCategories.SingleAsync(x => x.Name == "Household");
+            await Assert.That(groceries.CurrentBalance).IsEqualTo(500_00 - 70_00);
+            await Assert.That(household.CurrentBalance).IsEqualTo(200_00 - 30_00);
+        });
+    }
+
+    [Test]
+    public async Task Convert_Credit_CreatesIncomeTransaction()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var category = new ExpenseCategory { Name = "Refunds", CurrentBalance = 0 };
+            context.ExpenseCategories.Add(category);
+            var pending = new PendingExpense
+            {
+                Date = new DateTime(2026, 1, 5),
+                Description = "Refund",
+                Amount = 20_00,
+                IsDebit = false
+            };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+
+            var controller = new PendingExpensesController(context);
+            await controller.Convert(pending.ID, new ConvertPendingExpenseRequest(
+                "Refund", new DateTime(2026, 1, 5), [new ConvertPendingExpenseItemRequest(category.ID, 20_00)]));
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var item = await context.ExpenseCategoryItems
+                .Include(x => x.Details)
+                .SingleAsync();
+            await Assert.That(item.Details!.Single().Amount).IsEqualTo(20_00);
+
+            var category = await context.ExpenseCategories.SingleAsync();
+            await Assert.That(category.CurrentBalance).IsEqualTo(20_00);
+        });
+    }
+}

--- a/SimplyBudgetWeb.Data/BudgetWebContext.cs
+++ b/SimplyBudgetWeb.Data/BudgetWebContext.cs
@@ -19,9 +19,35 @@ public class BudgetWebContext(DbContextOptions<BudgetWebContext> options)
     /// </summary>
     public const string Schema = "SimplyBudget";
 
+    /// <summary>
+    /// Web-only tables: pending expenses (and their assignees) are not part of the shared
+    /// <see cref="BudgetContext"/> because they do not apply to the desktop client.
+    /// </summary>
+    public DbSet<PendingExpense> PendingExpenses => Set<PendingExpense>();
+    public DbSet<PendingExpenseAssignee> PendingExpenseAssignees => Set<PendingExpenseAssignee>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.HasDefaultSchema(Schema);
         base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<PendingExpense>()
+            .HasIndex(x => x.Date);
+
+        modelBuilder.Entity<PendingExpense>()
+            .HasOne(x => x.Assignee)
+            .WithMany(x => x.PendingExpenses)
+            .HasForeignKey(x => x.AssigneeId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<PendingExpense>()
+            .HasOne(x => x.SuggestedCategory)
+            .WithMany()
+            .HasForeignKey(x => x.SuggestedCategoryId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<PendingExpenseAssignee>()
+            .HasIndex(x => x.Name)
+            .IsUnique();
     }
 }

--- a/SimplyBudgetWeb.Data/Migrations/20260818221537_AddPendingExpenses.Designer.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260818221537_AddPendingExpenses.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetWeb.Data;
 
@@ -11,9 +12,11 @@ using SimplyBudgetWeb.Data;
 namespace SimplyBudgetWeb.Data.Migrations
 {
     [DbContext(typeof(BudgetWebContext))]
-    partial class BudgetWebContextModelSnapshot : ModelSnapshot
+    [Migration("20260818221537_AddPendingExpenses")]
+    partial class AddPendingExpenses
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SimplyBudgetWeb.Data/Migrations/20260818221537_AddPendingExpenses.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260818221537_AddPendingExpenses.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetWeb.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPendingExpenses : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PendingExpenseAssignee",
+                schema: "SimplyBudget",
+                columns: table => new
+                {
+                    ID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PendingExpenseAssignee", x => x.ID);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PendingExpense",
+                schema: "SimplyBudget",
+                columns: table => new
+                {
+                    ID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Amount = table.Column<int>(type: "int", nullable: false),
+                    IsDebit = table.Column<bool>(type: "bit", nullable: false),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AssigneeId = table.Column<int>(type: "int", nullable: true),
+                    SuggestedCategoryId = table.Column<int>(type: "int", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PendingExpense", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_PendingExpense_ExpenseCategory_SuggestedCategoryId",
+                        column: x => x.SuggestedCategoryId,
+                        principalSchema: "SimplyBudget",
+                        principalTable: "ExpenseCategory",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_PendingExpense_PendingExpenseAssignee_AssigneeId",
+                        column: x => x.AssigneeId,
+                        principalSchema: "SimplyBudget",
+                        principalTable: "PendingExpenseAssignee",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingExpense_AssigneeId",
+                schema: "SimplyBudget",
+                table: "PendingExpense",
+                column: "AssigneeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingExpense_Date",
+                schema: "SimplyBudget",
+                table: "PendingExpense",
+                column: "Date");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingExpense_SuggestedCategoryId",
+                schema: "SimplyBudget",
+                table: "PendingExpense",
+                column: "SuggestedCategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingExpenseAssignee_Name",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PendingExpense",
+                schema: "SimplyBudget");
+
+            migrationBuilder.DropTable(
+                name: "PendingExpenseAssignee",
+                schema: "SimplyBudget");
+        }
+    }
+}

--- a/SimplyBudgetWeb.Data/PendingExpense.cs
+++ b/SimplyBudgetWeb.Data/PendingExpense.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using SimplyBudgetShared.Data;
+
+namespace SimplyBudgetWeb.Data;
+
+/// <summary>
+/// A receipt/transaction that has occurred but has not yet been categorized (or split) into
+/// a real <see cref="ExpenseCategoryItem"/>. This is a web-only concept (not shared with the
+/// desktop client): pending expenses are typically created in bulk from a CSV import and are
+/// worked off one at a time from the "Pending Expenses" page until they are converted into
+/// real expense items.
+/// </summary>
+[Table("PendingExpense")]
+public class PendingExpense : BaseItem
+{
+    private DateTime _date;
+    public DateTime Date
+    {
+        get => _date;
+        set => _date = value.Date; // Ensure that we only capture the date
+    }
+
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Always a positive number of cents. Whether this represents money leaving or entering
+    /// an account is tracked separately via <see cref="IsDebit"/>.
+    /// </summary>
+    public int Amount { get; set; }
+
+    public bool IsDebit { get; set; } = true;
+
+    /// <summary>
+    /// Free-form notes an assignee (or anyone else) can leave for additional context while the
+    /// expense is still pending categorization.
+    /// </summary>
+    public string? Notes { get; set; }
+
+    public int? AssigneeId { get; set; }
+    public PendingExpenseAssignee? Assignee { get; set; }
+
+    /// <summary>
+    /// Best-guess expense category (e.g. from an import rule match), used to pre-populate the
+    /// category when this pending expense is later converted into a real expense item.
+    /// </summary>
+    public int? SuggestedCategoryId { get; set; }
+    public ExpenseCategory? SuggestedCategory { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/SimplyBudgetWeb.Data/PendingExpenseAssignee.cs
+++ b/SimplyBudgetWeb.Data/PendingExpenseAssignee.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using SimplyBudgetShared.Data;
+
+namespace SimplyBudgetWeb.Data;
+
+/// <summary>
+/// A person a <see cref="PendingExpense"/> can optionally be assigned to.
+/// This is a web-only concept (not shared with the desktop client).
+/// </summary>
+[Table("PendingExpenseAssignee")]
+public class PendingExpenseAssignee : BaseItem
+{
+    public string Name { get; set; } = string.Empty;
+
+    public List<PendingExpense>? PendingExpenses { get; set; }
+}

--- a/SimplyBudgetWeb.UITests/AppNavigationTests.cs
+++ b/SimplyBudgetWeb.UITests/AppNavigationTests.cs
@@ -5,7 +5,7 @@ public class AppNavigationTests : UITestBase
     [Test]
     public async Task AnonymousUserIsRedirectedToLoginFromCoreRoutes()
     {
-        var routes = new[] { "budget", "history", "accounts", "settings", "import" };
+        var routes = new[] { "budget", "history", "pending-expenses", "accounts", "settings", "import" };
 
         foreach (var route in routes)
         {

--- a/SimplyBudgetWeb.UITests/UITestBase.cs
+++ b/SimplyBudgetWeb.UITests/UITestBase.cs
@@ -22,6 +22,13 @@ namespace SimplyBudgetWeb.UITests;
 public abstract class UITestBase : IAsyncDisposable
 {
     protected const int TestTimeoutMs = 120_000;
+
+    // StartAspireHost below performs up to three sequential steps (build, start, wait-for-
+    // frontend-healthy), each individually allowed up to AspireDefaultTimeout. The hook-level
+    // timeout must therefore comfortably exceed the sum of those steps, not match a single one
+    // of them, or a slow-but-otherwise-healthy container pull (e.g. a cold Docker image cache
+    // on a CI runner) can trip the outer timeout even though no individual step actually hung.
+    private const int AspireHostStartupTimeoutMs = 480_000;
     private static TimeSpan AspireDefaultTimeout { get; set; } = TimeSpan.FromMinutes(2);
     private static DistributedApplication? _aspireAppHost = null;
 
@@ -74,7 +81,7 @@ public abstract class UITestBase : IAsyncDisposable
     protected static CancellationToken CancellationToken =>
         TestContext.Current?.Execution.CancellationToken ?? CancellationToken.None;
 
-    [Before(TestSession), Timeout(TestTimeoutMs)]
+    [Before(TestSession), Timeout(AspireHostStartupTimeoutMs)]
     public static async Task StartAspireHost(CancellationToken cancellationToken)
     {
         // Check if an external frontend URL is provided

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { apiClient } from '@/services/apiClient'
+import { useSnackbarStore } from '@/stores/snackbar'
+import type { ExpenseCategoryDto, PendingExpenseDto, ConvertPendingExpenseRequest } from '@/types'
+import { formatCents } from '@/utils/currency'
+
+const props = defineProps<{
+  modelValue: boolean
+  pendingExpense: PendingExpenseDto | null
+  categories: ExpenseCategoryDto[]
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  success: []
+}>()
+
+const snackbar = useSnackbarStore()
+
+interface LineItem {
+  expenseCategoryId: number | null
+  amount: string
+}
+
+const emptyLine = (): LineItem => ({ expenseCategoryId: null, amount: '' })
+
+const description = ref('')
+const date = ref('')
+const lines = ref<LineItem[]>([emptyLine()])
+const submitting = ref(false)
+
+function centsToDollars(cents: number) {
+  return (cents / 100).toFixed(2)
+}
+
+function dollarsToCents(s: string) {
+  return Math.round((parseFloat(s) || 0) * 100)
+}
+
+// Pre-fill the form whenever a new pending expense is opened for conversion:
+// a single line item defaulting to the suggested category (if any) and the
+// full amount, ready for the user to edit or split across categories.
+watch(
+  () => props.pendingExpense,
+  pe => {
+    if (!pe) return
+    description.value = pe.description ?? ''
+    date.value = pe.date.split('T')[0]
+    lines.value = [{
+      expenseCategoryId: pe.suggestedCategoryId ?? null,
+      amount: centsToDollars(pe.amount),
+    }]
+  },
+  { immediate: true },
+)
+
+const remainingCents = computed(() => {
+  if (!props.pendingExpense) return 0
+  const allocated = lines.value.reduce((sum, l) => sum + dollarsToCents(l.amount || '0'), 0)
+  return props.pendingExpense.amount - allocated
+})
+
+function addLine() {
+  lines.value.push(emptyLine())
+}
+
+function removeLine(index: number) {
+  lines.value = lines.value.filter((_, i) => i !== index)
+}
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+async function submit() {
+  if (!props.pendingExpense) return
+  submitting.value = true
+  try {
+    const payload: ConvertPendingExpenseRequest = {
+      description: description.value,
+      date: date.value,
+      items: lines.value
+        .filter(l => l.expenseCategoryId !== null && l.amount !== '')
+        .map(l => ({
+          expenseCategoryId: l.expenseCategoryId as number,
+          amount: dollarsToCents(l.amount),
+        })),
+    }
+    await apiClient.post(`/api/pending-expenses/${props.pendingExpense.id}/convert`, payload)
+    snackbar.enqueueSnackbar('Pending expense converted', { variant: 'success' })
+    emit('success')
+    close()
+  } catch (e: unknown) {
+    snackbar.enqueueSnackbar(e instanceof Error ? e.message : 'Failed to convert pending expense', { variant: 'error' })
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <v-dialog :model-value="props.modelValue" max-width="600" @update:model-value="(val: boolean) => !val && close()">
+    <v-card v-if="pendingExpense">
+      <v-card-title>Convert Pending Expense</v-card-title>
+      <v-card-text>
+        <div class="d-flex flex-column" style="gap: 16px;">
+          <v-text-field label="Description" v-model="description" />
+          <v-text-field label="Date" type="date" v-model="date" />
+
+          <span class="text-subtitle-2">
+            {{ pendingExpense.isDebit ? 'Split expense across categories' : 'Split income across categories' }}
+            (total {{ formatCents(pendingExpense.amount) }})
+          </span>
+          <div v-for="(item, index) in lines" :key="index" class="d-flex align-center mb-2" style="gap: 8px;">
+            <v-select
+              label="Category"
+              :items="props.categories"
+              item-title="name"
+              item-value="id"
+              v-model="item.expenseCategoryId"
+              style="flex: 2;"
+              density="compact"
+            />
+            <v-text-field
+              label="Amount ($)"
+              type="number"
+              step="0.01"
+              min="0"
+              v-model="item.amount"
+              style="flex: 1;"
+              density="compact"
+            />
+            <v-btn v-if="lines.length > 1" icon="mdi-minus" size="small" variant="text" aria-label="Remove line" @click="removeLine(index)" />
+          </div>
+          <v-btn size="small" prepend-icon="mdi-plus" variant="text" @click="addLine">Add Line</v-btn>
+
+          <span
+            class="text-body-2"
+            :class="remainingCents === 0 ? 'text-success' : 'text-warning'"
+          >
+            Remaining to allocate: {{ formatCents(remainingCents) }}
+          </span>
+        </div>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn @click="close">Cancel</v-btn>
+        <v-btn color="primary" :loading="submitting" @click="submit">Convert</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/SimplyBudgetWeb.Web/src/components/Layout.vue
+++ b/SimplyBudgetWeb.Web/src/components/Layout.vue
@@ -15,6 +15,7 @@ const isDark = computed(() => theme.global.name.value === 'dark')
 const navItems = [
   { title: 'Budget', to: '/budget', icon: 'mdi-cash-multiple' },
   { title: 'History', to: '/history', icon: 'mdi-history' },
+  { title: 'Pending Expenses', to: '/pending-expenses', icon: 'mdi-receipt-text-clock' },
   { title: 'Accounts', to: '/accounts', icon: 'mdi-bank' },
   { title: 'Settings', to: '/settings', icon: 'mdi-cog' },
   { title: 'Import', to: '/import', icon: 'mdi-file-import' },

--- a/SimplyBudgetWeb.Web/src/pages/Import.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Import.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type {
@@ -10,6 +11,7 @@ import type {
 import { formatCents } from '@/utils/currency'
 
 const snackbar = useSnackbarStore()
+const router = useRouter()
 
 const csvText = ref('')
 const items = ref<ImportItemDto[]>([])
@@ -31,7 +33,7 @@ async function handleParse() {
   if (!csvText.value.trim()) return
   loading.value = true
   try {
-    const data = await apiClient.post<ImportItemDto[]>('/api/import/parse', { csv: csvText.value })
+    const data = await apiClient.post<ImportItemDto[]>('/api/import/parse', { csvContent: csvText.value })
     items.value = data ?? []
     snackbar.enqueueSnackbar(`Parsed ${data?.length ?? 0} items`, { variant: 'success' })
   } catch {
@@ -53,9 +55,10 @@ async function handleImport() {
   submitting.value = true
   try {
     await apiClient.post('/api/import/save', items.value)
-    snackbar.enqueueSnackbar('Import saved', { variant: 'success' })
+    snackbar.enqueueSnackbar('Import saved as pending expenses', { variant: 'success' })
     items.value = []
     csvText.value = ''
+    await router.push('/pending-expenses')
   } catch {
     snackbar.enqueueSnackbar('Failed to save import', { variant: 'error' })
   } finally {

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -1,0 +1,233 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { apiClient } from '@/services/apiClient'
+import { useSnackbarStore } from '@/stores/snackbar'
+import type { PendingExpenseDto, AssigneeDto, ExpenseCategoryDto } from '@/types'
+import { formatCents } from '@/utils/currency'
+import ConvertPendingExpenseDialog from '@/components/ConvertPendingExpenseDialog.vue'
+
+const snackbar = useSnackbarStore()
+
+const search = ref('')
+const assigneeId = ref<number | null>(null)
+const items = ref<PendingExpenseDto[]>([])
+const assignees = ref<AssigneeDto[]>([])
+const categories = ref<ExpenseCategoryDto[]>([])
+const loading = ref(false)
+const discardItem = ref<PendingExpenseDto | null>(null)
+const convertItem = ref<PendingExpenseDto | null>(null)
+const convertDialogOpen = ref(false)
+const newAssigneeName = ref('')
+const addAssigneeOpen = ref(false)
+
+// "All" plus the real filter options; used for both the toolbar filter and the
+// per-item assignee picker (which additionally needs an "Unassigned" option).
+const assigneeFilterOptions = computed(() => [{ id: null, name: 'All' }, ...assignees.value])
+const assigneeAssignOptions = computed(() => [{ id: null, name: 'Unassigned' }, ...assignees.value])
+
+async function fetchAssignees() {
+  try {
+    assignees.value = await apiClient.get<AssigneeDto[]>('/api/assignees') ?? []
+  } catch { /* ignore */ }
+}
+
+async function fetchCategories() {
+  try {
+    categories.value = await apiClient.get<ExpenseCategoryDto[]>('/api/expense-categories') ?? []
+  } catch { /* ignore */ }
+}
+
+async function fetchPendingExpenses() {
+  loading.value = true
+  try {
+    const params = new URLSearchParams()
+    if (search.value) params.set('search', search.value)
+    if (assigneeId.value !== null) params.set('assigneeId', String(assigneeId.value))
+    const query = params.toString()
+    items.value = await apiClient.get<PendingExpenseDto[]>(`/api/pending-expenses${query ? `?${query}` : ''}`) ?? []
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load pending expenses', { variant: 'error' })
+  } finally {
+    loading.value = false
+  }
+}
+
+async function updateAssignee(item: PendingExpenseDto, newAssigneeId: number | null) {
+  try {
+    await apiClient.put(`/api/pending-expenses/${item.id}`, {
+      assigneeId: newAssigneeId,
+      notes: item.notes,
+    })
+    void fetchPendingExpenses()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to update assignee', { variant: 'error' })
+  }
+}
+
+async function updateNotes(item: PendingExpenseDto) {
+  try {
+    await apiClient.put(`/api/pending-expenses/${item.id}`, {
+      assigneeId: item.assigneeId,
+      notes: item.notes,
+    })
+  } catch {
+    snackbar.enqueueSnackbar('Failed to update notes', { variant: 'error' })
+  }
+}
+
+async function handleDiscard() {
+  if (!discardItem.value) return
+  try {
+    await apiClient.delete(`/api/pending-expenses/${discardItem.value.id}`)
+    snackbar.enqueueSnackbar('Pending expense discarded', { variant: 'success' })
+    discardItem.value = null
+    void fetchPendingExpenses()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to discard pending expense', { variant: 'error' })
+  }
+}
+
+async function handleAddAssignee() {
+  if (!newAssigneeName.value.trim()) return
+  try {
+    await apiClient.post('/api/assignees', { name: newAssigneeName.value })
+    snackbar.enqueueSnackbar('Assignee added', { variant: 'success' })
+    newAssigneeName.value = ''
+    addAssigneeOpen.value = false
+    void fetchAssignees()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to add assignee', { variant: 'error' })
+  }
+}
+
+function openConvert(item: PendingExpenseDto) {
+  convertItem.value = item
+  convertDialogOpen.value = true
+}
+
+function onConvertSuccess() {
+  convertDialogOpen.value = false
+  void fetchPendingExpenses()
+}
+
+watch([search, assigneeId], fetchPendingExpenses)
+
+onMounted(() => {
+  void fetchAssignees()
+  void fetchCategories()
+  void fetchPendingExpenses()
+})
+</script>
+
+<template>
+  <div>
+    <h5 class="text-h5 mb-4">Pending Expenses</h5>
+
+    <v-card class="pa-4 mb-4 d-flex flex-wrap align-center" style="gap: 16px;">
+      <v-text-field label="Search" v-model="search" density="compact" style="max-width: 200px;" hide-details />
+
+      <v-select
+        label="Assignee"
+        :items="assigneeFilterOptions"
+        item-title="name"
+        item-value="id"
+        v-model="assigneeId"
+        density="compact"
+        style="max-width: 200px;"
+        hide-details
+      />
+
+      <v-btn variant="outlined" size="small" prepend-icon="mdi-account-plus" @click="addAssigneeOpen = true">
+        Add Assignee
+      </v-btn>
+    </v-card>
+
+    <div v-if="loading" class="d-flex justify-center pa-8">
+      <v-progress-circular indeterminate aria-label="Loading pending expenses" />
+    </div>
+    <v-list v-else>
+      <v-list-item v-if="items.length === 0">
+        <v-list-item-title>No pending expenses found.</v-list-item-title>
+      </v-list-item>
+      <v-card v-for="item in items" :key="item.id" class="mb-2">
+        <v-list-item style="cursor: pointer;" @click="openConvert(item)">
+          <v-list-item-title>
+            <div class="d-flex justify-space-between align-center">
+              <span>
+                {{ new Date(item.date).toLocaleDateString() }} — {{ item.description }}
+                <v-chip size="small" class="ml-2">{{ item.isDebit ? 'Debit' : 'Credit' }}</v-chip>
+                <v-chip v-if="item.suggestedCategoryName" size="small" variant="outlined" class="ml-1">
+                  Suggested: {{ item.suggestedCategoryName }}
+                </v-chip>
+              </span>
+              <span class="font-weight-bold">{{ formatCents(item.amount) }}</span>
+            </div>
+          </v-list-item-title>
+          <template #append>
+            <v-btn
+              icon="mdi-delete"
+              variant="text"
+              color="error"
+              aria-label="Discard pending expense"
+              @click.stop="discardItem = item"
+            />
+          </template>
+        </v-list-item>
+        <v-card-text class="d-flex flex-wrap align-center" style="gap: 16px;" @click.stop>
+          <v-select
+            label="Assignee"
+            :items="assigneeAssignOptions"
+            item-title="name"
+            item-value="id"
+            :model-value="item.assigneeId"
+            density="compact"
+            style="max-width: 220px;"
+            hide-details
+            @update:model-value="(val: number | null) => updateAssignee(item, val)"
+          />
+          <v-text-field
+            label="Notes"
+            v-model="item.notes"
+            density="compact"
+            style="flex: 1; min-width: 200px;"
+            hide-details
+            @blur="updateNotes(item)"
+          />
+        </v-card-text>
+      </v-card>
+    </v-list>
+
+    <ConvertPendingExpenseDialog
+      v-model="convertDialogOpen"
+      :pending-expense="convertItem"
+      :categories="categories"
+      @success="onConvertSuccess"
+    />
+
+    <v-dialog v-model="addAssigneeOpen" max-width="480">
+      <v-card>
+        <v-card-title>Add Assignee</v-card-title>
+        <v-card-text>
+          <v-text-field label="Name" v-model="newAssigneeName" @keyup.enter="handleAddAssignee" />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="addAssigneeOpen = false">Cancel</v-btn>
+          <v-btn color="primary" @click="handleAddAssignee">Add</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog :model-value="!!discardItem" max-width="480" @update:model-value="(val: boolean) => !val && (discardItem = null)">
+      <v-card>
+        <v-card-title>Confirm Discard</v-card-title>
+        <v-card-text>Discard pending expense "{{ discardItem?.description }}"? This cannot be undone.</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="discardItem = null">Cancel</v-btn>
+          <v-btn color="error" @click="handleDiscard">Discard</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>

--- a/SimplyBudgetWeb.Web/src/router/index.ts
+++ b/SimplyBudgetWeb.Web/src/router/index.ts
@@ -6,6 +6,7 @@ import History from '@/pages/History.vue'
 import Accounts from '@/pages/Accounts.vue'
 import Settings from '@/pages/Settings.vue'
 import Import from '@/pages/Import.vue'
+import PendingExpenses from '@/pages/PendingExpenses.vue'
 import { useAuthStore } from '@/stores/auth'
 
 // Pages are imported eagerly (not lazy) so the initial navigation resolves
@@ -25,6 +26,7 @@ const router = createRouter({
         { path: 'accounts', name: 'accounts', component: Accounts },
         { path: 'settings', name: 'settings', component: Settings },
         { path: 'import', name: 'import', component: Import },
+        { path: 'pending-expenses', name: 'pending-expenses', component: PendingExpenses },
         { path: ':pathMatch(.*)*', redirect: '/budget' },
       ],
     },

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -79,6 +79,40 @@ export interface ImportItemDto {
   isDone: boolean
 }
 
+export interface AssigneeDto {
+  id: number
+  name: string | null
+}
+
+export interface PendingExpenseDto {
+  id: number
+  date: string
+  description: string | null
+  amount: number
+  isDebit: boolean
+  notes: string | null
+  assigneeId: number | null
+  assigneeName: string | null
+  suggestedCategoryId: number | null
+  suggestedCategoryName: string | null
+}
+
+export interface PendingExpenseUpdateRequest {
+  assigneeId: number | null
+  notes: string | null
+}
+
+export interface ConvertPendingExpenseItemRequest {
+  expenseCategoryId: number
+  amount: number
+}
+
+export interface ConvertPendingExpenseRequest {
+  description: string
+  date: string
+  items: ConvertPendingExpenseItemRequest[]
+}
+
 export interface TransactionItemRequest {
   expenseCategoryId: number
   amount: number

--- a/SimplyBudgetWeb/Controllers/AssigneesController.cs
+++ b/SimplyBudgetWeb/Controllers/AssigneesController.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Controllers;
+
+/// <summary>
+/// Manages the people that a <see cref="PendingExpense"/> can optionally be assigned to.
+/// This is a web-only concept and does not exist in the desktop client.
+/// </summary>
+[ApiController]
+[Route("api/assignees")]
+public class AssigneesController(BudgetWebContext context) : ControllerBase
+{
+    [HttpGet]
+    public async Task<AssigneeDto[]> GetAll()
+    {
+        var assignees = await context.PendingExpenseAssignees
+            .OrderBy(x => x.Name)
+            .ToListAsync();
+        return assignees.Select(ToDto).ToArray();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<AssigneeDto>> Create([FromBody] AssigneeRequest request)
+    {
+        var name = request.Name?.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return BadRequest("Name is required.");
+        }
+
+        var existing = await context.PendingExpenseAssignees
+            .FirstOrDefaultAsync(x => x.Name == name);
+        if (existing is not null)
+        {
+            return Conflict(ToDto(existing));
+        }
+
+        var assignee = new PendingExpenseAssignee { Name = name };
+        context.PendingExpenseAssignees.Add(assignee);
+        await context.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetAll), new { }, ToDto(assignee));
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var assignee = await context.PendingExpenseAssignees.FindAsync(id);
+        if (assignee is null) return NotFound();
+
+        context.PendingExpenseAssignees.Remove(assignee);
+        await context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    private static AssigneeDto ToDto(PendingExpenseAssignee a) => new(
+        Id: a.ID,
+        Name: a.Name
+    );
+}
+
+public record AssigneeDto(int Id, string Name);
+
+public record AssigneeRequest(string? Name);

--- a/SimplyBudgetWeb/Controllers/ImportController.cs
+++ b/SimplyBudgetWeb/Controllers/ImportController.cs
@@ -42,6 +42,32 @@ public class ImportController(BudgetWebContext context) : ControllerBase
 
         return Ok(result.ToArray());
     }
+
+    /// <summary>
+    /// Saves parsed import items as pending expenses so they can be reviewed, assigned, and
+    /// categorized/split into real expense items later from the Pending Expenses page. Items the
+    /// user has checked off as already handled (<see cref="ImportItemDto.IsDone"/>) are skipped.
+    /// </summary>
+    [HttpPost("save")]
+    public async Task<IActionResult> Save([FromBody] ImportItemDto[] items)
+    {
+        var pendingExpenses = items
+            .Where(i => !i.IsDone)
+            .Select(i => new PendingExpense
+            {
+                Date = i.Date,
+                Description = i.Description,
+                Amount = i.Amount,
+                IsDebit = i.IsDebit,
+                SuggestedCategoryId = i.SuggestedCategoryId,
+            })
+            .ToList();
+
+        context.PendingExpenses.AddRange(pendingExpenses);
+        await context.SaveChangesAsync();
+
+        return StatusCode(201);
+    }
 }
 
 public record ImportRequest(string CsvContent);

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -1,0 +1,157 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Controllers;
+
+/// <summary>
+/// Manages pending expenses: receipts/transactions that have occurred but have not yet been
+/// categorized (or split) into a real expense item. This is a web-only concept and does not
+/// exist in the desktop client.
+/// </summary>
+[ApiController]
+[Route("api/pending-expenses")]
+public class PendingExpensesController(BudgetWebContext context) : ControllerBase
+{
+    [HttpGet]
+    public async Task<PendingExpenseDto[]> GetAll(
+        [FromQuery] string? search,
+        [FromQuery] int? assigneeId)
+    {
+        var query = context.PendingExpenses
+            .Include(x => x.Assignee)
+            .Include(x => x.SuggestedCategory)
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(search))
+            query = query.Where(x => x.Description != null && x.Description.Contains(search));
+
+        if (assigneeId.HasValue)
+            query = query.Where(x => x.AssigneeId == assigneeId.Value);
+
+        // Oldest first: pending expenses are worked off like a queue, not limited to a month.
+        var items = await query
+            .OrderBy(x => x.Date)
+            .ThenBy(x => x.ID)
+            .ToListAsync();
+
+        return items.Select(ToDto).ToArray();
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<PendingExpenseDto>> GetById(int id)
+    {
+        var pending = await context.PendingExpenses
+            .Include(x => x.Assignee)
+            .Include(x => x.SuggestedCategory)
+            .FirstOrDefaultAsync(x => x.ID == id);
+        if (pending is null) return NotFound();
+
+        return ToDto(pending);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ActionResult<PendingExpenseDto>> Update(int id, [FromBody] PendingExpenseUpdateRequest request)
+    {
+        // AsTracking() guarantees this entity is change-tracked (and its mutations below actually
+        // saved) even if the context's default query tracking behavior has been set to NoTracking.
+        var pending = await context.PendingExpenses
+            .AsTracking()
+            .Include(x => x.Assignee)
+            .Include(x => x.SuggestedCategory)
+            .FirstOrDefaultAsync(x => x.ID == id);
+        if (pending is null) return NotFound();
+
+        if (request.AssigneeId.HasValue &&
+            !await context.PendingExpenseAssignees.AnyAsync(x => x.ID == request.AssigneeId.Value))
+        {
+            return BadRequest($"Assignee {request.AssigneeId} not found.");
+        }
+
+        pending.AssigneeId = request.AssigneeId;
+        pending.Notes = request.Notes;
+        await context.SaveChangesAsync();
+
+        // AssigneeId may have changed since the initial .Include(x => x.Assignee) load, and
+        // Reference(...).LoadAsync() is normally a no-op once a navigation is marked as loaded.
+        // Reset the loaded flag so it re-queries using the (possibly new/cleared) AssigneeId.
+        context.Entry(pending).Reference(x => x.Assignee).IsLoaded = false;
+        await context.Entry(pending).Reference(x => x.Assignee).LoadAsync();
+
+        return ToDto(pending);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var pending = await context.PendingExpenses.FindAsync(id);
+        if (pending is null) return NotFound();
+
+        context.PendingExpenses.Remove(pending);
+        await context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Converts a pending expense into a real expense item (or income item, if it represents a
+    /// credit), optionally split across multiple categories, and removes it from the pending list.
+    /// </summary>
+    [HttpPost("{id}/convert")]
+    public async Task<IActionResult> Convert(int id, [FromBody] ConvertPendingExpenseRequest request)
+    {
+        var pending = await context.PendingExpenses.FindAsync(id);
+        if (pending is null) return NotFound();
+
+        if (request.Items is null || request.Items.Length == 0)
+            return BadRequest("At least one category item is required.");
+
+        var items = request.Items.Select(i => (i.Amount, i.ExpenseCategoryId)).ToArray();
+
+        if (pending.IsDebit)
+        {
+            await context.AddTransaction(request.Description, request.Date, items);
+        }
+        else
+        {
+            await context.AddIncome(request.Description, request.Date, items);
+        }
+
+        context.PendingExpenses.Remove(pending);
+        await context.SaveChangesAsync();
+
+        return StatusCode(201);
+    }
+
+    private static PendingExpenseDto ToDto(PendingExpense p) => new(
+        Id: p.ID,
+        Date: p.Date,
+        Description: p.Description,
+        Amount: p.Amount,
+        IsDebit: p.IsDebit,
+        Notes: p.Notes,
+        AssigneeId: p.AssigneeId,
+        AssigneeName: p.Assignee?.Name,
+        SuggestedCategoryId: p.SuggestedCategoryId,
+        SuggestedCategoryName: p.SuggestedCategory?.Name
+    );
+}
+
+public record PendingExpenseDto(
+    int Id,
+    DateTime Date,
+    string? Description,
+    int Amount,
+    bool IsDebit,
+    string? Notes,
+    int? AssigneeId,
+    string? AssigneeName,
+    int? SuggestedCategoryId,
+    string? SuggestedCategoryName
+);
+
+public record PendingExpenseUpdateRequest(int? AssigneeId, string? Notes);
+
+public record ConvertPendingExpenseItemRequest(int ExpenseCategoryId, int Amount);
+
+public record ConvertPendingExpenseRequest(string Description, DateTime Date, ConvertPendingExpenseItemRequest[] Items);


### PR DESCRIPTION
## Why

Right now every imported/entered transaction has to be categorized (or split) immediately. In practice receipts often arrive before anyone has decided how to categorize them, and there's no place to park them, optionally hand them off to someone, or jot a note while that decision is made. This adds a "pending expense" concept to the web app to fill that gap: a receipt of something that has already happened, waiting to be turned into a real, categorized expense item.

This is a web-only feature; the desktop client is intentionally untouched.

## What changed

**Backend**
- New `PendingExpense` / `PendingExpenseAssignee` entities (added only to `BudgetWebContext`, not the shared desktop `BudgetContext`) plus an EF Core migration. A pending expense stores the date, description, amount/`IsDebit`, an optional note, an optional assignee, and an optional suggested category (carried over from CSV rule-matching).
- `AssigneesController`: simple CRUD for the people a pending expense can be assigned to (there's no app-level "user" concept since auth is Entra ID/group-based, so this is a lightweight standalone list).
- `PendingExpensesController`: list (search + assignee filter, ordered oldest-first with no month boundary), update (assignee/notes), delete, and convert-to-real-expense, which supports splitting a single pending expense across multiple categories via the same `AddTransaction`/`AddIncome` helpers used elsewhere.
- `ImportController`: new `POST /api/import/save` turns parsed CSV rows that aren't marked "done" into pending expenses instead of finalized transactions.

**Frontend**
- New top-level **Pending Expenses** page (added to the nav and router): search box and assignee filter matching the History page's conventions, inline assignee/notes editing per row, an "add assignee" affordance, discard, and clicking a row opens a convert dialog.
- `ConvertPendingExpenseDialog`: pre-fills the suggested category and full amount, and lets the user split the pending expense across one or more categories before finalizing it (modeled on `AddTransactionDialog`'s line-item UI).
- `Import.vue`: fixed a pre-existing bug where the parse request sent `{ csv }` but the backend expected `CsvContent`, and wired `handleImport` to navigate to `/pending-expenses` after a successful save, per the requirement that a successful import lands the user on the new page.

## Notable details / things to double-check in review

- Pending expenses are simply removed from the table once converted, no "converted" status is retained; they're meant to work like a queue.
- Test infra note: the TUnit test DbContext defaults to `QueryTrackingBehavior.NoTracking` (unlike production), which surfaced a couple of real bugs during development that are now fixed in production code too: `PendingExpensesController.Update` now explicitly uses `.AsTracking()` and correctly reloads the `Assignee` navigation after an FK change instead of relying on a now-stale `IsLoaded` flag.

## Testing

- Backend: 44/44 TUnit tests passing (`SimplyBudgetWeb.Core.Tests`), including new coverage for assignees, pending expenses (list/filter/search/ordering/update/delete/convert, including split-across-categories), and import-to-pending-expense creation.
- Frontend: `vue-tsc` build and `eslint` both clean.
- E2E: added `pending-expenses` to the Playwright anonymous-redirect route check and ran it (plus the full UI test suite, 6/6 passing) against a live Aspire-hosted SQL Server container to confirm the new migration applies correctly end-to-end.