### PR TITLE
ci: only install chromium for Playwright UI tests

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -89,7 +89,9 @@ jobs:
           timeout_minutes: 20
           max_attempts: 3
           shell: pwsh
-          command: pwsh SimplyBudgetWeb.UITests/bin/Release/net10.0/playwright.ps1 install --with-deps
+          # Only chromium is ever launched (see UITestBase.CreateBrowserAsync), so
+          # installing firefox/webkit here is wasted download + apt-get time.
+          command: pwsh SimplyBudgetWeb.UITests/bin/Release/net10.0/playwright.ps1 install --with-deps chromium
 
       - name: Test
         run: dotnet test ${{ env.WEB_SOLUTION_PATH }} --no-build --configuration Release --verbosity normal


### PR DESCRIPTION
UITestBase only ever launches playwright.Chromium, so installing firefox/webkit via --with-deps was wasted download + apt-get time (a contributor to the slow/flaky installs described in microsoft/playwright#23388).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
