### PR TITLE
Use Keboo/sa-upload and Keboo/sa-download for cross-job artifacts

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -130,13 +130,23 @@ jobs:
             --startup-project .\SimplyBudgetWeb.AppHost\SimplyBudgetWeb.AppHost.csproj `
             --output efbundle
 
+      - name: Azure Login
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.ARM_TENANT_ID }}
+          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
       - name: Upload DB Migration
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: Keboo/sa-upload@v1
         with:
           name: DatabaseMigration
           path: 'efbundle'
-          retention-days: 1
+          storage-account: keboogithub
+          container-name: simplybudget
+          create-container: true
 
       - name: Upload frontend artifact
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
@@ -290,17 +300,19 @@ jobs:
     environment: production
 
     steps:
-      - name: Download DB Migration Bundle
-        uses: actions/download-artifact@v8
-        with:
-          name: DatabaseMigration
-
       - name: Azure Login
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID }}
           tenant-id: ${{ secrets.ARM_TENANT_ID }}
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
+      - name: Download DB Migration Bundle
+        uses: Keboo/sa-download@v1
+        with:
+          name: DatabaseMigration
+          storage-account: keboogithub
+          container-name: simplybudget
 
       - name: Apply Migration
         run: |

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -61,11 +61,13 @@ jobs:
           TF_VAR_frontend_custom_domain: 'https://budget.keboo.dev'
 
       - name: Upload Terraform Plan
-        uses: actions/upload-artifact@v7
+        uses: Keboo/sa-upload@v1
         with:
           name: tfplan
           path: Infra/tfplan
-          retention-days: 1
+          storage-account: keboogithub
+          container-name: simplybudget
+          create-container: true
 
   apply:
     runs-on: ubuntu-latest
@@ -103,9 +105,11 @@ jobs:
           ARM_USE_OIDC: true
 
       - name: Download Terraform Plan
-        uses: actions/download-artifact@v8
+        uses: Keboo/sa-download@v1
         with:
           name: tfplan
+          storage-account: keboogithub
+          container-name: simplybudget
           path: Infra
 
       - name: Terraform Apply


### PR DESCRIPTION
## Summary
Replaces `actions/upload-artifact` / `actions/download-artifact` with the custom Azure Blob Storage-backed [`Keboo/sa-upload`](https://github.com/Keboo/sa-upload) / [`Keboo/sa-download`](https://github.com/Keboo/sa-download) actions for artifacts that cross job boundaries, matching the convention already established in the GillyTracker and ConnectLoop repos (`storage-account: keboogithub`, `container-name: simplybudget`).

## Changes
- **build-and-deploy.yml**
  - `Upload DB Migration` → `Keboo/sa-upload@v1` (added an `Azure Login` step in the `build` job beforehand)
  - `Download DB Migration Bundle` (in `deploy-database`) → `Keboo/sa-download@v1`
- **deploy-infrastructure.yml**
  - `Upload Terraform Plan` (in `plan`) → `Keboo/sa-upload@v1`
  - `Download Terraform Plan` (in `apply`) → `Keboo/sa-download@v1`

## Left unchanged
Diagnostic-only artifacts that are never downloaded by another job (`test-failure-screenshots`, `test-failure-logs`, `frontend` in build-and-deploy.yml, and `Installer` in release.yml) stay on the native `actions/upload-artifact`, consistent with how other repos handle the same cases.

## Notes
This requires the identity behind `ARM_CLIENT_ID` / `ARM_CLIENT_ID_INFRA` to have the **Storage Blob Data Contributor** role on the `keboogithub` storage account (container `simplybudget` will be auto-created via `create-container: true`).