### PR TITLE
Remove pending expense from list locally after successful delete

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -77,11 +77,12 @@ async function updateNotes(item: PendingExpenseDto) {
 
 async function handleDiscard() {
   if (!discardItem.value) return
+  const idToRemove = discardItem.value.id
   try {
-    await apiClient.delete(`/api/pending-expenses/${discardItem.value.id}`)
+    await apiClient.delete(`/api/pending-expenses/${idToRemove}`)
     snackbar.enqueueSnackbar('Pending expense discarded', { variant: 'success' })
+    items.value = items.value.filter((item) => item.id !== idToRemove)
     discardItem.value = null
-    void fetchPendingExpenses()
   } catch {
     snackbar.enqueueSnackbar('Failed to discard pending expense', { variant: 'error' })
   }


### PR DESCRIPTION
## Why

Discarding a pending expense triggered a full re-fetch of the pending expenses list, which reloads and re-renders every item just to remove the one that was deleted. That's an unnecessary round trip and causes a visible flash/reload for what should be an instant UI update.

## What changed

In `PendingExpenses.vue`, `handleDiscard` now filters the deleted item out of the local `items` array on a successful API call instead of calling `fetchPendingExpenses()` again. The error path is unchanged: if the delete fails, the confirm dialog stays open and an error toast is shown, so the user can retry.

Verified with `eslint` and `vue-tsc` (no errors).