### PR TITLE
Flag likely duplicate CSV import rows and hide them by default

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
@@ -115,4 +115,80 @@ public class ImportControllerTests
 
         await Assert.That(await context.PendingExpenses.CountAsync()).IsEqualTo(0);
     }
+
+    [Test]
+    public async Task Parse_WithMatchingExistingPendingExpense_FlagsAsDuplicate()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        var date = new DateTime(2020, 11, 23);
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.Add(new PendingExpense
+            {
+                Date = date,
+                Description = "Purchase GOOGLE Play",
+                Amount = 21_77,
+                IsDebit = true,
+            });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var csv = BuildCsv(@"""1"",""11/23/2020"",""11/23/2020"",""Debit"",""-21.77000"","""",""1"",""Purchase GOOGLE Play"",""Entertainment"",""Debit Card"",""1"","""",""Purchase GOOGLE Play""");
+        var result = await controller.Parse(new ImportRequest(csv));
+
+        var items = ((OkObjectResult)result.Result!).Value as ImportItemDto[];
+        await Assert.That(items!.Length).IsEqualTo(1);
+        await Assert.That(items[0].IsDuplicate).IsTrue();
+        await Assert.That(items[0].IsDone).IsTrue();
+    }
+
+    [Test]
+    public async Task Parse_WithMatchingExistingExpenseCategoryItem_FlagsAsDuplicate()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        var date = new DateTime(2020, 11, 23);
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Entertainment" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            await context.AddTransaction("Purchase GOOGLE Play", date, (21_77, category.ID));
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var csv = BuildCsv(@"""1"",""11/23/2020"",""11/23/2020"",""Debit"",""-21.77000"","""",""1"",""Purchase GOOGLE Play"",""Entertainment"",""Debit Card"",""1"","""",""Purchase GOOGLE Play""");
+        var result = await controller.Parse(new ImportRequest(csv));
+
+        var items = ((OkObjectResult)result.Result!).Value as ImportItemDto[];
+        await Assert.That(items!.Length).IsEqualTo(1);
+        await Assert.That(items[0].IsDuplicate).IsTrue();
+        await Assert.That(items[0].IsDone).IsTrue();
+    }
+
+    [Test]
+    public async Task Parse_WithNoMatchingExistingData_DoesNotFlagAsDuplicate()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var csv = BuildCsv(@"""1"",""11/23/2020"",""11/23/2020"",""Debit"",""-21.77000"","""",""1"",""Purchase GOOGLE Play"",""Entertainment"",""Debit Card"",""1"","""",""Purchase GOOGLE Play""");
+        var result = await controller.Parse(new ImportRequest(csv));
+
+        var items = ((OkObjectResult)result.Result!).Value as ImportItemDto[];
+        await Assert.That(items!.Length).IsEqualTo(1);
+        await Assert.That(items[0].IsDuplicate).IsFalse();
+        await Assert.That(items[0].IsDone).IsFalse();
+    }
 }

--- a/SimplyBudgetWeb.Web/src/pages/Import.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Import.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
@@ -19,6 +19,16 @@ const items = ref<ImportItemDto[]>([])
 const categories = ref<ExpenseCategoryDto[]>([])
 const loading = ref(false)
 const submitting = ref(false)
+const showDuplicates = ref(false)
+
+// Rows that look like they've already been imported (matched against existing pending
+// expenses/expense items by date + amount) are hidden by default so the review list stays
+// focused on new transactions. They default to "done" (excluded from Save) as well, so the
+// user must explicitly reveal and re-include the ones they actually want to import.
+const duplicateCount = computed(() => items.value.filter(i => i.isDuplicate).length)
+const visibleItems = computed(() =>
+  showDuplicates.value ? items.value : items.value.filter(i => !i.isDuplicate)
+)
 const exportingData = ref(false)
 const importingData = ref(false)
 const importFile = ref<File | null>(null)
@@ -50,9 +60,7 @@ async function handleParse() {
   }
 }
 
-function updateCategory(index: number, categoryId: number | null) {
-  const item = items.value[index]
-  if (!item) return
+function updateCategory(item: ImportItemDto, categoryId: number | null) {
   const cat = categoryId !== null ? categories.value.find(c => c.id === categoryId) : undefined
   item.suggestedCategoryId = categoryId
   item.suggestedCategoryName = cat?.name ?? null
@@ -175,6 +183,15 @@ onMounted(() => { void fetchCategories() })
     </v-card>
 
     <template v-if="items.length > 0">
+      <div class="d-flex align-center mb-2" style="gap: 12px;">
+        <v-switch
+          v-model="showDuplicates"
+          color="primary"
+          density="compact"
+          hide-details
+          :label="duplicateCount > 0 ? `Show possible duplicates (${duplicateCount})` : 'Show possible duplicates'"
+        />
+      </div>
       <v-card class="mb-4" style="overflow: auto;">
         <v-table density="compact">
           <thead>
@@ -188,10 +205,15 @@ onMounted(() => { void fetchCategories() })
             </tr>
           </thead>
           <tbody>
-            <tr v-for="(item, index) in items" :key="index" :style="{ opacity: item.isDone ? 0.5 : 1 }">
+            <tr v-for="(item, index) in visibleItems" :key="index" :style="{ opacity: item.isDone ? 0.5 : 1 }">
               <td><v-checkbox v-model="item.isDone" hide-details density="compact" /></td>
               <td>{{ new Date(item.date).toLocaleDateString() }}</td>
-              <td>{{ item.description }}</td>
+              <td>
+                {{ item.description }}
+                <v-chip v-if="item.isDuplicate" size="small" color="warning" variant="outlined" class="ml-1">
+                  Possible duplicate
+                </v-chip>
+              </td>
               <td style="text-align: right;">{{ formatCents(item.amount) }}</td>
               <td>{{ item.isDebit ? 'Debit' : 'Credit' }}</td>
               <td>
@@ -203,7 +225,7 @@ onMounted(() => { void fetchCategories() })
                   density="compact"
                   hide-details
                   style="min-width: 150px;"
-                  @update:model-value="(val: number | null) => updateCategory(index, val)"
+                  @update:model-value="(val: number | null) => updateCategory(item, val)"
                 />
               </td>
             </tr>

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -77,6 +77,7 @@ export interface ImportItemDto {
   suggestedCategoryId: number | null
   suggestedCategoryName: string | null
   isDone: boolean
+  isDuplicate: boolean
 }
 
 export interface AssigneeDto {

--- a/SimplyBudgetWeb/Controllers/ImportController.cs
+++ b/SimplyBudgetWeb/Controllers/ImportController.cs
@@ -22,12 +22,17 @@ public class ImportController(BudgetWebContext context) : ControllerBase
             .Include(x => x.ExpenseCategory)
             .ToListAsync();
 
+        var existingSignedAmountsByDate = await GetExistingSignedAmountsByDateAsync(parsedItems.Select(x => x.Date));
+
         var result = new List<ImportItemDto>();
         foreach (var item in parsedItems)
         {
             var rawAmount = item.Details?.FirstOrDefault()?.Amount ?? 0;
             var rule = rules.FirstOrDefault(r => r.RuleRegex != null &&
                 Regex.IsMatch(item.Description ?? "", r.RuleRegex, RegexOptions.IgnoreCase));
+
+            bool isDuplicate = existingSignedAmountsByDate.TryGetValue(item.Date, out var amounts) &&
+                amounts.Contains(rawAmount);
 
             result.Add(new ImportItemDto(
                 Date: item.Date,
@@ -36,11 +41,59 @@ public class ImportController(BudgetWebContext context) : ControllerBase
                 IsDebit: rawAmount < 0,
                 SuggestedCategoryId: rule?.ExpenseCategoryID,
                 SuggestedCategoryName: rule?.ExpenseCategory?.Name,
-                IsDone: false
+                // Likely duplicates default to "done" (excluded from Save) until the user
+                // explicitly opts back in from the UI.
+                IsDone: isDuplicate,
+                IsDuplicate: isDuplicate
             ));
         }
 
         return Ok(result.ToArray());
+    }
+
+    /// <summary>
+    /// Builds a lookup of signed amounts (positive for credits, negative for debits) already
+    /// recorded on each date, from both pending expenses and already-categorized expense items.
+    /// Used to flag freshly-parsed CSV rows that look like they were already imported.
+    /// </summary>
+    private async Task<Dictionary<DateTime, HashSet<int>>> GetExistingSignedAmountsByDateAsync(IEnumerable<DateTime> dates)
+    {
+        var distinctDates = dates.Distinct().ToList();
+        var result = new Dictionary<DateTime, HashSet<int>>();
+        if (distinctDates.Count == 0) return result;
+
+        var minDate = distinctDates.Min();
+        var maxDate = distinctDates.Max();
+
+        void Add(DateTime date, int signedAmount)
+        {
+            if (!result.TryGetValue(date, out var amounts))
+            {
+                amounts = new HashSet<int>();
+                result[date] = amounts;
+            }
+            amounts.Add(signedAmount);
+        }
+
+        var existingPending = await context.PendingExpenses
+            .Where(x => x.Date >= minDate && x.Date <= maxDate)
+            .Select(x => new { x.Date, x.Amount, x.IsDebit })
+            .ToListAsync();
+        foreach (var pe in existingPending)
+        {
+            Add(pe.Date, pe.IsDebit ? -pe.Amount : pe.Amount);
+        }
+
+        var existingExpenseItems = await context.ExpenseCategoryItems
+            .Include(x => x.Details)
+            .Where(x => x.Date >= minDate && x.Date <= maxDate)
+            .ToListAsync();
+        foreach (var eci in existingExpenseItems)
+        {
+            Add(eci.Date, eci.Details?.Sum(d => d.Amount) ?? 0);
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -79,5 +132,6 @@ public record ImportItemDto(
     bool IsDebit,
     int? SuggestedCategoryId,
     string? SuggestedCategoryName,
-    bool IsDone
+    bool IsDone,
+    bool IsDuplicate = false
 );


### PR DESCRIPTION
## Summary
When importing a CSV of transactions to convert into pending expenses, rows that look like they were already imported are now flagged as likely duplicates.

- `ImportController.Parse` cross-references each parsed row (by date + signed amount) against existing `PendingExpense` records and already-categorized `ExpenseCategoryItem`s.
- Matches are flagged via a new `IsDuplicate` field on `ImportItemDto`, and default `IsDone` to `true` so they're excluded from `Save` unless the user explicitly re-includes them.
- The Import page now hides duplicate rows by default. A "Show possible duplicates (N)" switch reveals them, tagged with a "Possible duplicate" chip, so the user can selectively uncheck "Done" on the ones they actually want to import.

## Testing
- `dotnet test SimplyBudgetWeb.Core.Tests` — 47/47 passed (44 existing + 3 new duplicate-detection tests)
- `pnpm run build` (vue-tsc + vite build) — succeeded, no type errors
- `pnpm run lint` — clean

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>