### PR TITLE
Add ability to delete all pending expenses

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -257,6 +257,94 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task DeleteAll_WithNoFilters_RemovesAllPendingExpenses()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 },
+                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Gas station", Amount = 200 });
+            await context.SaveChangesAsync();
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new PendingExpensesController(context);
+            var result = await controller.DeleteAll(search: null, assigneeId: null);
+            await Assert.That(result).IsTypeOf<NoContentResult>();
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            await Assert.That(await context.PendingExpenses.CountAsync()).IsEqualTo(0);
+        });
+    }
+
+    [Test]
+    public async Task DeleteAll_WithSearchFilter_OnlyRemovesMatchingPendingExpenses()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco groceries", Amount = 100 },
+                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Gas station", Amount = 200 });
+            await context.SaveChangesAsync();
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new PendingExpensesController(context);
+            await controller.DeleteAll(search: "Costco", assigneeId: null);
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var remaining = await context.PendingExpenses.ToListAsync();
+            await Assert.That(remaining.Count).IsEqualTo(1);
+            await Assert.That(remaining[0].Description).IsEqualTo("Gas station");
+        });
+    }
+
+    [Test]
+    public async Task DeleteAll_WithAssigneeFilter_OnlyRemovesMatchingPendingExpenses()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int assigneeId = await mocker.InDbScopeAsync(async context =>
+        {
+            var assignee = new PendingExpenseAssignee { Name = "Jordan" };
+            context.PendingExpenseAssignees.Add(assignee);
+            await context.SaveChangesAsync();
+
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Assigned", Amount = 100, AssigneeId = assignee.ID },
+                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Unassigned", Amount = 200 });
+            await context.SaveChangesAsync();
+            return assignee.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new PendingExpensesController(context);
+            await controller.DeleteAll(search: null, assigneeId: assigneeId);
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var remaining = await context.PendingExpenses.ToListAsync();
+            await Assert.That(remaining.Count).IsEqualTo(1);
+            await Assert.That(remaining[0].Description).IsEqualTo("Unassigned");
+        });
+    }
+
+    [Test]
     public async Task Convert_WithNoItems_ReturnsBadRequest()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -19,6 +19,8 @@ const convertItem = ref<PendingExpenseDto | null>(null)
 const convertDialogOpen = ref(false)
 const newAssigneeName = ref('')
 const addAssigneeOpen = ref(false)
+const deleteAllOpen = ref(false)
+const deletingAll = ref(false)
 
 // "All" plus the real filter options; used for both the toolbar filter and the
 // per-item assignee picker (which additionally needs an "Unassigned" option).
@@ -87,6 +89,24 @@ async function handleDiscard() {
   }
 }
 
+async function handleDeleteAll() {
+  deletingAll.value = true
+  try {
+    const params = new URLSearchParams()
+    if (search.value) params.set('search', search.value)
+    if (assigneeId.value !== null) params.set('assigneeId', String(assigneeId.value))
+    const query = params.toString()
+    await apiClient.delete(`/api/pending-expenses${query ? `?${query}` : ''}`)
+    snackbar.enqueueSnackbar('Pending expenses discarded', { variant: 'success' })
+    deleteAllOpen.value = false
+    void fetchPendingExpenses()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to discard pending expenses', { variant: 'error' })
+  } finally {
+    deletingAll.value = false
+  }
+}
+
 async function handleAddAssignee() {
   if (!newAssigneeName.value.trim()) return
   try {
@@ -139,6 +159,19 @@ onMounted(() => {
 
       <v-btn variant="outlined" size="small" prepend-icon="mdi-account-plus" @click="addAssigneeOpen = true">
         Add Assignee
+      </v-btn>
+
+      <v-spacer />
+
+      <v-btn
+        variant="outlined"
+        size="small"
+        color="error"
+        prepend-icon="mdi-delete-sweep"
+        :disabled="items.length === 0"
+        @click="deleteAllOpen = true"
+      >
+        Delete All
       </v-btn>
     </v-card>
 
@@ -226,6 +259,21 @@ onMounted(() => {
           <v-spacer />
           <v-btn @click="discardItem = null">Cancel</v-btn>
           <v-btn color="error" @click="handleDiscard">Discard</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+    <v-dialog v-model="deleteAllOpen" max-width="480">
+      <v-card>
+        <v-card-title>Confirm Delete All</v-card-title>
+        <v-card-text>
+          Discard all {{ items.length }} pending expense{{ items.length === 1 ? '' : 's' }}
+          <template v-if="search || assigneeId !== null">matching the current filters</template>?
+          This cannot be undone.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="deleteAllOpen = false" :disabled="deletingAll">Cancel</v-btn>
+          <v-btn color="error" @click="handleDeleteAll" :loading="deletingAll">Delete All</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -94,6 +94,29 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
     }
 
     /// <summary>
+    /// Deletes every pending expense matching the given filters (the same filters used by
+    /// <see cref="GetAll"/>), so "delete all" only discards what is currently visible to the user.
+    /// Omitting both filters deletes every pending expense.
+    /// </summary>
+    [HttpDelete]
+    public async Task<IActionResult> DeleteAll(
+        [FromQuery] string? search,
+        [FromQuery] int? assigneeId)
+    {
+        var query = context.PendingExpenses.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(search))
+            query = query.Where(x => x.Description != null && x.Description.Contains(search));
+
+        if (assigneeId.HasValue)
+            query = query.Where(x => x.AssigneeId == assigneeId.Value);
+
+        context.PendingExpenses.RemoveRange(query);
+        await context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    /// <summary>
     /// Converts a pending expense into a real expense item (or income item, if it represents a
     /// credit), optionally split across multiple categories, and removes it from the pending list.
     /// </summary>


### PR DESCRIPTION
## Why
Users working through a backlog of pending expenses had no fast way to clear them out in bulk; they could only discard items one at a time.

## What changed
- Added a `DELETE /api/pending-expenses` endpoint (`DeleteAll`) that removes pending expenses matching the same `search`/`assigneeId` query filters used by the existing `GET` list endpoint. This means the bulk delete respects whatever the user currently has filtered on screen, and omitting both filters deletes everything.
- Added a "Delete All" button to the toolbar on the Pending Expenses page (disabled when the list is empty), which opens a confirmation dialog stating how many items will be discarded and whether a filter is applied, before calling the new endpoint and refreshing the list.
- Added controller tests covering delete-all with no filters, with a search filter, and with an assignee filter.

## Notes for reviewers
- The endpoint reuses the exact same filter logic as `GetAll`, so "Delete All" always matches what's currently visible in the list rather than silently wiping unfiltered data.
- No new confirmation is needed at the API layer (no soft delete) - deletion is immediate, matching the existing single-item delete behavior.