### PR TITLE
Populate pending expense assignees from logged-in users

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/AssigneesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/AssigneesControllerTests.cs
@@ -16,8 +16,8 @@ public class AssigneesControllerTests
         await mocker.InDbScopeAsync(async context =>
         {
             context.PendingExpenseAssignees.AddRange(
-                new PendingExpenseAssignee { Name = "Zoe" },
-                new PendingExpenseAssignee { Name = "Alice" });
+                new PendingExpenseAssignee { Name = "Zoe", ObjectId = "zoe-oid" },
+                new PendingExpenseAssignee { Name = "Alice", ObjectId = "alice-oid" });
             await context.SaveChangesAsync();
         });
 
@@ -32,78 +32,6 @@ public class AssigneesControllerTests
     }
 
     [Test]
-    public async Task Create_AddsNewAssignee()
-    {
-        AutoMocker mocker = new();
-        mocker.WithDbContext<BudgetWebContext>();
-
-        using var context = mocker.Get<BudgetWebContext>();
-        var controller = new AssigneesController(context);
-
-        var result = await controller.Create(new AssigneeRequest("Jordan"));
-
-        var created = ((CreatedAtActionResult)result.Result!).Value as AssigneeDto;
-        await Assert.That(created).IsNotNull();
-        await Assert.That(created!.Name).IsEqualTo("Jordan");
-        await Assert.That(created.Id).IsGreaterThan(0);
-
-        await Assert.That(await context.PendingExpenseAssignees.CountAsync()).IsEqualTo(1);
-    }
-
-    [Test]
-    public async Task Create_TrimsName()
-    {
-        AutoMocker mocker = new();
-        mocker.WithDbContext<BudgetWebContext>();
-
-        using var context = mocker.Get<BudgetWebContext>();
-        var controller = new AssigneesController(context);
-
-        var result = await controller.Create(new AssigneeRequest("  Jordan  "));
-
-        var created = ((CreatedAtActionResult)result.Result!).Value as AssigneeDto;
-        await Assert.That(created!.Name).IsEqualTo("Jordan");
-    }
-
-    [Test]
-    [Arguments(null)]
-    [Arguments("")]
-    [Arguments("   ")]
-    public async Task Create_WithBlankName_ReturnsBadRequest(string? name)
-    {
-        AutoMocker mocker = new();
-        mocker.WithDbContext<BudgetWebContext>();
-
-        using var context = mocker.Get<BudgetWebContext>();
-        var controller = new AssigneesController(context);
-
-        var result = await controller.Create(new AssigneeRequest(name));
-
-        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
-    }
-
-    [Test]
-    public async Task Create_WithDuplicateName_ReturnsConflict()
-    {
-        AutoMocker mocker = new();
-        mocker.WithDbContext<BudgetWebContext>();
-
-        await mocker.InDbScopeAsync(async context =>
-        {
-            context.PendingExpenseAssignees.Add(new PendingExpenseAssignee { Name = "Jordan" });
-            await context.SaveChangesAsync();
-        });
-
-        using var context = mocker.Get<BudgetWebContext>();
-        var controller = new AssigneesController(context);
-
-        var result = await controller.Create(new AssigneeRequest("Jordan"));
-
-        await Assert.That(result.Result).IsTypeOf<ConflictObjectResult>();
-        await Assert.That(await context.PendingExpenseAssignees.CountAsync()).IsEqualTo(1);
-    }
-
-    [Test]
     public async Task Delete_RemovesAssignee()
     {
         AutoMocker mocker = new();
@@ -111,7 +39,7 @@ public class AssigneesControllerTests
 
         int assigneeId = await mocker.InDbScopeAsync(async context =>
         {
-            var assignee = new PendingExpenseAssignee { Name = "Jordan" };
+            var assignee = new PendingExpenseAssignee { Name = "Jordan", ObjectId = "jordan-oid" };
             context.PendingExpenseAssignees.Add(assignee);
             await context.SaveChangesAsync();
             return assignee.ID;

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -87,7 +87,7 @@ public class PendingExpensesControllerTests
 
         int assigneeId = await mocker.InDbScopeAsync(async context =>
         {
-            var assignee = new PendingExpenseAssignee { Name = "Jordan" };
+            var assignee = new PendingExpenseAssignee { Name = "Jordan", ObjectId = "jordan-oid" };
             context.PendingExpenseAssignees.Add(assignee);
             await context.SaveChangesAsync();
 
@@ -130,7 +130,7 @@ public class PendingExpensesControllerTests
 
         var (pendingId, assigneeId) = await mocker.InDbScopeAsync(async context =>
         {
-            var assignee = new PendingExpenseAssignee { Name = "Jordan" };
+            var assignee = new PendingExpenseAssignee { Name = "Jordan", ObjectId = "jordan-oid" };
             var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
             context.PendingExpenseAssignees.Add(assignee);
             context.PendingExpenses.Add(pending);
@@ -166,7 +166,7 @@ public class PendingExpensesControllerTests
 
         int pendingId = await mocker.InDbScopeAsync(async context =>
         {
-            var assignee = new PendingExpenseAssignee { Name = "Jordan" };
+            var assignee = new PendingExpenseAssignee { Name = "Jordan", ObjectId = "jordan-oid" };
             context.PendingExpenseAssignees.Add(assignee);
             var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
             context.PendingExpenses.Add(pending);

--- a/SimplyBudgetWeb.Core.Tests/Services/CurrentUserSyncServiceTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Services/CurrentUserSyncServiceTests.cs
@@ -1,0 +1,81 @@
+using System.Security.Claims;
+
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
+
+namespace SimplyBudgetWeb.Core.Tests.Services;
+
+public class CurrentUserSyncServiceTests
+{
+    private static ClaimsPrincipal MakeUser(string objectId, string? name = null, string? preferredUsername = null)
+    {
+        var claims = new List<Claim> { new("oid", objectId) };
+        if (name is not null) claims.Add(new Claim("name", name));
+        if (preferredUsername is not null) claims.Add(new Claim("preferred_username", preferredUsername));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+
+    [Test]
+    public async Task SyncAsync_CreatesAssignee_ForNewUser()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var service = new CurrentUserSyncService(context);
+
+        await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan", preferredUsername: "jordan@example.com"));
+
+        var assignee = await context.PendingExpenseAssignees.SingleAsync();
+        await Assert.That(assignee.ObjectId).IsEqualTo("user-oid-1");
+        await Assert.That(assignee.Name).IsEqualTo("Jordan");
+        await Assert.That(assignee.Email).IsEqualTo("jordan@example.com");
+    }
+
+    [Test]
+    public async Task SyncAsync_DoesNotDuplicate_ForReturningUser()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var service = new CurrentUserSyncService(context);
+
+        await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan"));
+        await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan"));
+
+        await Assert.That(await context.PendingExpenseAssignees.CountAsync()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task SyncAsync_UpdatesName_WhenDisplayNameChanges()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var service = new CurrentUserSyncService(context);
+
+        await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan"));
+        await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan Smith"));
+
+        var assignee = await context.PendingExpenseAssignees.SingleAsync();
+        await Assert.That(assignee.Name).IsEqualTo("Jordan Smith");
+    }
+
+    [Test]
+    public async Task SyncAsync_IgnoresUser_WithoutObjectId()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var service = new CurrentUserSyncService(context);
+
+        var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
+        await service.SyncAsync(anonymous);
+
+        await Assert.That(await context.PendingExpenseAssignees.CountAsync()).IsEqualTo(0);
+    }
+}

--- a/SimplyBudgetWeb.Data/BudgetWebContext.cs
+++ b/SimplyBudgetWeb.Data/BudgetWebContext.cs
@@ -47,7 +47,7 @@ public class BudgetWebContext(DbContextOptions<BudgetWebContext> options)
             .OnDelete(DeleteBehavior.SetNull);
 
         modelBuilder.Entity<PendingExpenseAssignee>()
-            .HasIndex(x => x.Name)
+            .HasIndex(x => x.ObjectId)
             .IsUnique();
     }
 }

--- a/SimplyBudgetWeb.Data/Migrations/20260819061106_AddAssigneeUserSync.Designer.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260819061106_AddAssigneeUserSync.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetWeb.Data;
 
@@ -11,9 +12,11 @@ using SimplyBudgetWeb.Data;
 namespace SimplyBudgetWeb.Data.Migrations
 {
     [DbContext(typeof(BudgetWebContext))]
-    partial class BudgetWebContextModelSnapshot : ModelSnapshot
+    [Migration("20260819061106_AddAssigneeUserSync")]
+    partial class AddAssigneeUserSync
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SimplyBudgetWeb.Data/Migrations/20260819061106_AddAssigneeUserSync.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260819061106_AddAssigneeUserSync.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetWeb.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAssigneeUserSync : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PendingExpenseAssignee_Name",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Email",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastLoginUtc",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "ObjectId",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee",
+                type: "nvarchar(450)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingExpenseAssignee_ObjectId",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee",
+                column: "ObjectId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PendingExpenseAssignee_ObjectId",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee");
+
+            migrationBuilder.DropColumn(
+                name: "Email",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee");
+
+            migrationBuilder.DropColumn(
+                name: "LastLoginUtc",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee");
+
+            migrationBuilder.DropColumn(
+                name: "ObjectId",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingExpenseAssignee_Name",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee",
+                column: "Name",
+                unique: true);
+        }
+    }
+}

--- a/SimplyBudgetWeb.Data/PendingExpenseAssignee.cs
+++ b/SimplyBudgetWeb.Data/PendingExpenseAssignee.cs
@@ -5,12 +5,24 @@ namespace SimplyBudgetWeb.Data;
 
 /// <summary>
 /// A person a <see cref="PendingExpense"/> can optionally be assigned to.
-/// This is a web-only concept (not shared with the desktop client).
+/// This is a web-only concept (not shared with the desktop client). Rows are created and kept
+/// up to date automatically whenever a user signs in (see <c>CurrentUserSyncMiddleware</c>) —
+/// there is no manual "add assignee" flow, so this doubles as the list of known application users.
 /// </summary>
 [Table("PendingExpenseAssignee")]
 public class PendingExpenseAssignee : BaseItem
 {
     public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The unique object ID (Entra ID "oid" claim) of the signed-in user this row was created
+    /// for. Used to match a returning user regardless of display name changes.
+    /// </summary>
+    public string ObjectId { get; set; } = string.Empty;
+
+    public string? Email { get; set; }
+
+    public DateTime LastLoginUtc { get; set; } = DateTime.UtcNow;
 
     public List<PendingExpense>? PendingExpenses { get; set; }
 }

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -17,8 +17,6 @@ const loading = ref(false)
 const discardItem = ref<PendingExpenseDto | null>(null)
 const convertItem = ref<PendingExpenseDto | null>(null)
 const convertDialogOpen = ref(false)
-const newAssigneeName = ref('')
-const addAssigneeOpen = ref(false)
 const deleteAllOpen = ref(false)
 const deletingAll = ref(false)
 
@@ -108,18 +106,6 @@ async function handleDeleteAll() {
   }
 }
 
-async function handleAddAssignee() {
-  if (!newAssigneeName.value.trim()) return
-  try {
-    await apiClient.post('/api/assignees', { name: newAssigneeName.value })
-    snackbar.enqueueSnackbar('Assignee added', { variant: 'success' })
-    newAssigneeName.value = ''
-    addAssigneeOpen.value = false
-    void fetchAssignees()
-  } catch {
-    snackbar.enqueueSnackbar('Failed to add assignee', { variant: 'error' })
-  }
-}
 function openConvert(item: PendingExpenseDto) {
   convertItem.value = item
   convertDialogOpen.value = true
@@ -156,10 +142,6 @@ onMounted(() => {
         style="max-width: 200px;"
         hide-details
       />
-
-      <v-btn variant="outlined" size="small" prepend-icon="mdi-account-plus" @click="addAssigneeOpen = true">
-        Add Assignee
-      </v-btn>
 
       <v-spacer />
 

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -120,7 +120,6 @@ async function handleAddAssignee() {
     snackbar.enqueueSnackbar('Failed to add assignee', { variant: 'error' })
   }
 }
-
 function openConvert(item: PendingExpenseDto) {
   convertItem.value = item
   convertDialogOpen.value = true
@@ -237,20 +236,6 @@ onMounted(() => {
       :categories="categories"
       @success="onConvertSuccess"
     />
-
-    <v-dialog v-model="addAssigneeOpen" max-width="480">
-      <v-card>
-        <v-card-title>Add Assignee</v-card-title>
-        <v-card-text>
-          <v-text-field label="Name" v-model="newAssigneeName" @keyup.enter="handleAddAssignee" />
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn @click="addAssigneeOpen = false">Cancel</v-btn>
-          <v-btn color="primary" @click="handleAddAssignee">Add</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
 
     <v-dialog :model-value="!!discardItem" max-width="480" @update:model-value="(val: boolean) => !val && (discardItem = null)">
       <v-card>

--- a/SimplyBudgetWeb/Controllers/AssigneesController.cs
+++ b/SimplyBudgetWeb/Controllers/AssigneesController.cs
@@ -5,8 +5,11 @@ using SimplyBudgetWeb.Data;
 namespace SimplyBudgetWeb.Controllers;
 
 /// <summary>
-/// Manages the people that a <see cref="PendingExpense"/> can optionally be assigned to.
-/// This is a web-only concept and does not exist in the desktop client.
+/// Exposes the people that a <see cref="PendingExpense"/> can optionally be assigned to.
+/// This is a web-only concept and does not exist in the desktop client. There is no manual
+/// "add assignee" flow - rows are created and kept up to date automatically whenever a user
+/// signs in (see <see cref="Services.CurrentUserSyncService"/>), so this list is simply
+/// everyone who has logged in.
 /// </summary>
 [ApiController]
 [Route("api/assignees")]
@@ -19,28 +22,6 @@ public class AssigneesController(BudgetWebContext context) : ControllerBase
             .OrderBy(x => x.Name)
             .ToListAsync();
         return assignees.Select(ToDto).ToArray();
-    }
-
-    [HttpPost]
-    public async Task<ActionResult<AssigneeDto>> Create([FromBody] AssigneeRequest request)
-    {
-        var name = request.Name?.Trim();
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            return BadRequest("Name is required.");
-        }
-
-        var existing = await context.PendingExpenseAssignees
-            .FirstOrDefaultAsync(x => x.Name == name);
-        if (existing is not null)
-        {
-            return Conflict(ToDto(existing));
-        }
-
-        var assignee = new PendingExpenseAssignee { Name = name };
-        context.PendingExpenseAssignees.Add(assignee);
-        await context.SaveChangesAsync();
-        return CreatedAtAction(nameof(GetAll), new { }, ToDto(assignee));
     }
 
     [HttpDelete("{id}")]
@@ -61,5 +42,3 @@ public class AssigneesController(BudgetWebContext context) : ControllerBase
 }
 
 public record AssigneeDto(int Id, string Name);
-
-public record AssigneeRequest(string? Name);

--- a/SimplyBudgetWeb/Middleware/CurrentUserSyncMiddleware.cs
+++ b/SimplyBudgetWeb/Middleware/CurrentUserSyncMiddleware.cs
@@ -1,0 +1,21 @@
+using SimplyBudgetWeb.Services;
+
+namespace SimplyBudgetWeb.Middleware;
+
+/// <summary>
+/// Runs after authentication/authorization for every request and upserts a
+/// <see cref="Data.PendingExpenseAssignee"/> row for the current user, so the Pending Expenses
+/// assignee list always reflects everyone who has signed in.
+/// </summary>
+public class CurrentUserSyncMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context, CurrentUserSyncService syncService)
+    {
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            await syncService.SyncAsync(context.User, context.RequestAborted);
+        }
+
+        await next(context);
+    }
+}

--- a/SimplyBudgetWeb/Program.cs
+++ b/SimplyBudgetWeb/Program.cs
@@ -1,5 +1,6 @@
 using SimplyBudgetWeb.Core;
 using SimplyBudgetWeb.Middleware;
+using SimplyBudgetWeb.Services;
 
 using Microsoft.Identity.Web;
 
@@ -57,6 +58,8 @@ builder.Services.AddAuthorization(options =>
     options.FallbackPolicy = options.GetPolicy("SimplyBudgetUsers")!;
 });
 
+builder.Services.AddScoped<CurrentUserSyncService>();
+
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
@@ -88,6 +91,10 @@ if (!app.Environment.IsDevelopment())
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+// Record/refresh the signed-in user as a pending-expense assignee so the "assign to" list on
+// the Pending Expenses page is always the set of people who have logged in.
+app.UseMiddleware<CurrentUserSyncMiddleware>();
 
 app.MapControllers();
 

--- a/SimplyBudgetWeb/Services/CurrentUserSyncService.cs
+++ b/SimplyBudgetWeb/Services/CurrentUserSyncService.cs
@@ -1,0 +1,65 @@
+using System.Security.Claims;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Services;
+
+/// <summary>
+/// Ensures a <see cref="PendingExpenseAssignee"/> row exists (and stays up to date) for every
+/// signed-in user. There is no manual "add assignee" flow: the Pending Expenses assignee list
+/// is simply the set of people who have logged in, keyed by their Entra ID object ID.
+/// </summary>
+public class CurrentUserSyncService(BudgetWebContext context)
+{
+    public async Task SyncAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default)
+    {
+        var objectId = user.GetObjectId();
+        if (string.IsNullOrEmpty(objectId))
+        {
+            // Not an authenticated Entra ID user (or the oid claim is missing) - nothing to sync.
+            return;
+        }
+
+        // Prefer the actual "name" claim for display purposes - GetDisplayName() falls back to
+        // preferred_username (the UPN/email) first, which reads poorly in the assignee dropdown.
+        var name = user.FindFirstValue("name")
+            ?? user.FindFirstValue(ClaimTypes.Name)
+            ?? user.GetDisplayName()
+            ?? objectId;
+        var email = user.FindFirstValue(ClaimTypes.Upn)
+            ?? user.FindFirstValue("preferred_username")
+            ?? user.FindFirstValue(ClaimTypes.Email);
+
+        // AsTracking() guarantees this entity is change-tracked (and its mutations below actually
+        // saved) even if the context's default query tracking behavior has been set to NoTracking.
+        var assignee = await context.PendingExpenseAssignees
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ObjectId == objectId, cancellationToken);
+
+        if (assignee is null)
+        {
+            context.PendingExpenseAssignees.Add(new PendingExpenseAssignee
+            {
+                ObjectId = objectId,
+                Name = name,
+                Email = email,
+                LastLoginUtc = DateTime.UtcNow,
+            });
+        }
+        else if (assignee.Name != name || assignee.Email != email)
+        {
+            assignee.Name = name;
+            assignee.Email = email;
+            assignee.LastLoginUtc = DateTime.UtcNow;
+        }
+        else
+        {
+            assignee.LastLoginUtc = DateTime.UtcNow;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Why

The Pending Expenses assignee dropdown was always empty. Assignees could only be created through
a manual "Add Assignee" button, and nobody had ever used it, so there was no one to assign
expenses to (not even the signed-in user).

## Approach

Assignees are now derived automatically from who has actually logged in, instead of being
manually entered:

- `PendingExpenseAssignee` gains `ObjectId` (the Entra ID `oid` claim), `Email`, and
  `LastLoginUtc`, and is now keyed uniquely by `ObjectId` instead of `Name`.
- A new `CurrentUserSyncService` upserts the assignee row for the current user (matched by
  Entra object ID, refreshing name/email/last-login on each request). It runs via
  `CurrentUserSyncMiddleware`, placed after authentication/authorization so it only fires for
  users who are actually signed in and pass the `SimplyBudgetUsers` group policy.
- `AssigneesController`'s manual `Create` endpoint is removed since there's no more manual
  add flow; `GetAll`/`Delete` remain.
- Added EF Core migration `AddAssigneeUserSync` for the schema change.

## Frontend

Removed the "Add Assignee" button and its dialog from the Pending Expenses page - the assignee
dropdown is populated solely from `/api/assignees`, which now reflects everyone who has logged in.

## Testing

- `dotnet build SimplyBudget.sln` succeeds.
- `dotnet test SimplyBudgetWeb.Core.Tests` - all 42 tests pass, including new
  `CurrentUserSyncServiceTests` covering create/update/no-duplicate/anonymous-ignore behavior.
- Frontend `pnpm run build` (vue-tsc + vite) and `pnpm run lint` both pass cleanly.

## Notes for reviewers

- Every authenticated request now does a DB read (and occasionally a write) to sync the current
  user. For this app's scale that's fine, but worth calling out.
- Existing `PendingExpenseAssignee` rows created before this change won't have an `ObjectId` and
  won't match any user going forward; there's no data migration for that since the feature
  hasn't shipped/been used yet.