### PR TITLE
Keep backend Container App warm 60 min before scale-to-zero

### DIFF
--- a/Infra/modules/container_app/main.tf
+++ b/Infra/modules/container_app/main.tf
@@ -23,8 +23,9 @@ resource "azurerm_container_app" "app" {
   }
 
   template {
-    min_replicas = var.min_replicas
-    max_replicas = var.max_replicas
+    min_replicas               = var.min_replicas
+    max_replicas               = var.max_replicas
+    cooldown_period_in_seconds = var.cooldown_period_seconds
 
     container {
       name   = var.name

--- a/Infra/modules/container_app/variables.tf
+++ b/Infra/modules/container_app/variables.tf
@@ -46,6 +46,12 @@ variable "max_replicas" {
   default     = 1
 }
 
+variable "cooldown_period_seconds" {
+  description = "Seconds to wait after the last active trigger before scaling replicas back down (e.g. to 0). Azure Container Apps defaults to 300 (5 minutes) if unset; max allowed is 3600."
+  type        = number
+  default     = 300
+}
+
 variable "env_vars" {
   description = "Map of environment variables for the container."
   type        = map(string)

--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -335,6 +335,11 @@ module "backend_container_app" {
   identity_id                     = azurerm_user_assigned_identity.app_identity.id
   container_registry_login_server = data.azurerm_container_registry.existing.login_server
 
+  # Keep the backend warm for 60 minutes of inactivity before KEDA scales it
+  # down to 0 replicas (min_replicas defaults to 0), avoiding cold starts for
+  # infrequent traffic.
+  cooldown_period_seconds = 3600
+
   # AllowedOrigins must cover every hostname the frontend can be served from
   # (the SWA's auto-generated default hostname and the production custom
   # domain), mirroring the azuread_application_redirect_uris.webapp_spa list


### PR DESCRIPTION
## Why

The backend Container App scales down to 0 replicas by default after only 5 minutes of inactivity (Azure's default KEDA cooldown period), causing cold starts for infrequent traffic. We want it to stay warm for 60 minutes before scaling down.

## Approach

The production backend is provisioned by Terraform (`Infra/prod/main.tf` -> `Infra/modules/container_app`), not Aspire's `PublishAsAzureContainerApp` bicep customization in `AppHost.cs` - that path is unused for the real deployment, so the fix belongs in Terraform.

- Added a `cooldown_period_seconds` variable to the `container_app` module, wired to `azurerm_container_app`'s `template.cooldown_period_in_seconds`. Defaults to `300` (Azure's built-in default) so other/future consumers of the module are unaffected unless they opt in.
- Set `cooldown_period_seconds = 3600` (60 minutes) for the backend app in `Infra/prod/main.tf`.

`min_replicas` (0) and `max_replicas` (1) are unchanged, so the app still scales to zero - it just waits an hour of inactivity before doing so.

## Verification

- `terraform init -backend=false` + `terraform validate` -> succeeded.
- `terraform fmt -check -recursive` -> no issues in the changed files.

This takes effect on the next `terraform apply` against the prod environment.