### PR TITLE
Import: checkbox selects which transactions to import

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
@@ -65,7 +65,7 @@ public class ImportControllerTests
     }
 
     [Test]
-    public async Task Save_CreatesPendingExpensesForItemsNotMarkedDone()
+    public async Task Save_CreatesPendingExpensesForCheckedItems()
     {
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
@@ -83,8 +83,8 @@ public class ImportControllerTests
 
         var items = new[]
         {
-            new ImportItemDto(new DateTime(2026, 1, 1), "Costco", 45_00, true, categoryId, "Groceries", IsDone: false),
-            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, null, null, IsDone: true),
+            new ImportItemDto(new DateTime(2026, 1, 1), "Costco", 45_00, true, categoryId, "Groceries", IsChecked: true),
+            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, null, null, IsChecked: false),
         };
 
         var result = await controller.Save(items);
@@ -98,7 +98,7 @@ public class ImportControllerTests
     }
 
     [Test]
-    public async Task Save_WithAllItemsMarkedDone_CreatesNoPendingExpenses()
+    public async Task Save_WithNoItemsChecked_CreatesNoPendingExpenses()
     {
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
@@ -108,7 +108,7 @@ public class ImportControllerTests
 
         var items = new[]
         {
-            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, null, null, IsDone: true),
+            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, null, null, IsChecked: false),
         };
 
         await controller.Save(items);
@@ -144,7 +144,7 @@ public class ImportControllerTests
         var items = ((OkObjectResult)result.Result!).Value as ImportItemDto[];
         await Assert.That(items!.Length).IsEqualTo(1);
         await Assert.That(items[0].IsDuplicate).IsTrue();
-        await Assert.That(items[0].IsDone).IsTrue();
+        await Assert.That(items[0].IsChecked).IsFalse();
     }
 
     [Test]
@@ -171,7 +171,7 @@ public class ImportControllerTests
         var items = ((OkObjectResult)result.Result!).Value as ImportItemDto[];
         await Assert.That(items!.Length).IsEqualTo(1);
         await Assert.That(items[0].IsDuplicate).IsTrue();
-        await Assert.That(items[0].IsDone).IsTrue();
+        await Assert.That(items[0].IsChecked).IsFalse();
     }
 
     [Test]
@@ -189,6 +189,6 @@ public class ImportControllerTests
         var items = ((OkObjectResult)result.Result!).Value as ImportItemDto[];
         await Assert.That(items!.Length).IsEqualTo(1);
         await Assert.That(items[0].IsDuplicate).IsFalse();
-        await Assert.That(items[0].IsDone).IsFalse();
+        await Assert.That(items[0].IsChecked).IsTrue();
     }
 }

--- a/SimplyBudgetWeb.Web/src/pages/Import.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Import.vue
@@ -23,12 +23,13 @@ const showDuplicates = ref(false)
 
 // Rows that look like they've already been imported (matched against existing pending
 // expenses/expense items by date + amount) are hidden by default so the review list stays
-// focused on new transactions. They default to "done" (excluded from Save) as well, so the
-// user must explicitly reveal and re-include the ones they actually want to import.
+// focused on new transactions. They default to unchecked (excluded from import) as well, so
+// the user must explicitly reveal and check the ones they actually want to import.
 const duplicateCount = computed(() => items.value.filter(i => i.isDuplicate).length)
 const visibleItems = computed(() =>
   showDuplicates.value ? items.value : items.value.filter(i => !i.isDuplicate)
 )
+const checkedCount = computed(() => items.value.filter(i => i.isChecked).length)
 const exportingData = ref(false)
 const importingData = ref(false)
 const importFile = ref<File | null>(null)
@@ -196,7 +197,7 @@ onMounted(() => { void fetchCategories() })
         <v-table density="compact">
           <thead>
             <tr>
-              <th>Done</th>
+              <th>Import</th>
               <th>Date</th>
               <th>Description</th>
               <th style="text-align: right;">Amount</th>
@@ -205,8 +206,8 @@ onMounted(() => { void fetchCategories() })
             </tr>
           </thead>
           <tbody>
-            <tr v-for="(item, index) in visibleItems" :key="index" :style="{ opacity: item.isDone ? 0.5 : 1 }">
-              <td><v-checkbox v-model="item.isDone" hide-details density="compact" /></td>
+            <tr v-for="(item, index) in visibleItems" :key="index" :style="{ opacity: item.isChecked ? 1 : 0.5 }">
+              <td><v-checkbox v-model="item.isChecked" hide-details density="compact" /></td>
               <td>{{ new Date(item.date).toLocaleDateString() }}</td>
               <td>
                 {{ item.description }}
@@ -232,7 +233,7 @@ onMounted(() => { void fetchCategories() })
           </tbody>
         </v-table>
       </v-card>
-      <v-btn color="primary" :loading="submitting" :disabled="submitting" @click="handleImport">Save Import</v-btn>
+      <v-btn color="primary" :loading="submitting" :disabled="submitting" @click="handleImport">Import {{ checkedCount }} Items</v-btn>
     </template>
   </div>
 </template>

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -76,7 +76,7 @@ export interface ImportItemDto {
   isDebit: boolean
   suggestedCategoryId: number | null
   suggestedCategoryName: string | null
-  isDone: boolean
+  isChecked: boolean
   isDuplicate: boolean
 }
 

--- a/SimplyBudgetWeb/Controllers/ImportController.cs
+++ b/SimplyBudgetWeb/Controllers/ImportController.cs
@@ -41,9 +41,9 @@ public class ImportController(BudgetWebContext context) : ControllerBase
                 IsDebit: rawAmount < 0,
                 SuggestedCategoryId: rule?.ExpenseCategoryID,
                 SuggestedCategoryName: rule?.ExpenseCategory?.Name,
-                // Likely duplicates default to "done" (excluded from Save) until the user
-                // explicitly opts back in from the UI.
-                IsDone: isDuplicate,
+                // Non-duplicate items are checked by default so they're imported; likely
+                // duplicates default to unchecked until the user explicitly opts back in.
+                IsChecked: !isDuplicate,
                 IsDuplicate: isDuplicate
             ));
         }
@@ -98,14 +98,14 @@ public class ImportController(BudgetWebContext context) : ControllerBase
 
     /// <summary>
     /// Saves parsed import items as pending expenses so they can be reviewed, assigned, and
-    /// categorized/split into real expense items later from the Pending Expenses page. Items the
-    /// user has checked off as already handled (<see cref="ImportItemDto.IsDone"/>) are skipped.
+    /// categorized/split into real expense items later from the Pending Expenses page. Only
+    /// items the user has checked (<see cref="ImportItemDto.IsChecked"/>) are imported.
     /// </summary>
     [HttpPost("save")]
     public async Task<IActionResult> Save([FromBody] ImportItemDto[] items)
     {
         var pendingExpenses = items
-            .Where(i => !i.IsDone)
+            .Where(i => i.IsChecked)
             .Select(i => new PendingExpense
             {
                 Date = i.Date,
@@ -132,6 +132,6 @@ public record ImportItemDto(
     bool IsDebit,
     int? SuggestedCategoryId,
     string? SuggestedCategoryName,
-    bool IsDone,
+    bool IsChecked,
     bool IsDuplicate = false
 );


### PR DESCRIPTION
## Why

On the Import Transactions page, the per-row checkbox was labeled "Done" and meant "already handled, exclude from Save" - the opposite of what most users expect from a checkbox in an import review list. This made it easy to accidentally skip transactions or import duplicates.

## What changed

The checkbox now means "include this row in the import":

- Renamed `ImportItemDto.IsDone` -> `IsChecked` (and `isDone` -> `isChecked` on the frontend), inverting the semantics.
- Non-duplicate parsed rows default to **checked** (included). Likely-duplicate rows (matched by date + amount against existing pending expenses/expense items) default to **unchecked** (excluded), so users must opt back in.
- `Save` now imports only checked items, replacing the old "import everything except IsDone" logic.
- The row checkbox column header changed from "Done" to "Import", and dimming now applies to unchecked (excluded) rows instead of "done" rows.
- The Save button is relabeled from "Save Import" to `Import {N} Items`, reflecting the live count of checked rows.
- Updated `ImportControllerTests` to match the renamed field and new default/exclusion semantics.

## Verification

- `dotnet test SimplyBudgetWeb.Core.Tests` - 48/48 passed
- `dotnet build SimplyBudgetWeb` - succeeded
- `npm run build` (vue-tsc + vite) in `SimplyBudgetWeb.Web` - succeeded, no type errors