### PR TITLE
Add rename, hide, and delete support for expense categories

### DIFF
--- a/SimplyBudgetDesktop/ViewModels/BudgetViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/BudgetViewModel.cs
@@ -163,6 +163,30 @@ public class BudgetViewModel : CollectionViewModelBase<ExpenseCategoryViewModelE
         }
     }
 
+    /// <summary>
+    /// Permanently removes an expense category. Only succeeds when the category has no items
+    /// posted against it (and isn't referenced by an import rule); otherwise it must be hidden
+    /// instead via <see cref="Delete"/>. Returns false without throwing when it can't be deleted
+    /// so the caller can show a friendly message.
+    /// </summary>
+    public async Task<bool> DeletePermanently(ExpenseCategoryViewModelEx category)
+    {
+        using var context = ContextFactory();
+        if (context.ExpenseCategories.Find(category.ExpenseCategoryID) is not ExpenseCategory dbCategory)
+        {
+            return false;
+        }
+
+        if (!await context.CanDeleteAsync(dbCategory))
+        {
+            return false;
+        }
+
+        context.ExpenseCategories.Remove(dbCategory);
+        await context.SaveChangesAsync();
+        return true;
+    }
+
     public async void Receive(CurrentMonthChanged message)
         => await LoadItemsAsync();
 

--- a/SimplyBudgetDesktop/ViewModels/ExpenseCategoryViewModelEx.cs
+++ b/SimplyBudgetDesktop/ViewModels/ExpenseCategoryViewModelEx.cs
@@ -43,6 +43,7 @@ public class ExpenseCategoryViewModelEx : ExpenseCategoryViewModel
         rv.ThreeMonthAverage = await GetAverage(context, expenseCategory, month.AddMonths(-3).StartOfMonth(), month.EndOfMonth());
         rv.SixMonthAverage = await GetAverage(context, expenseCategory, month.AddMonths(-6).StartOfMonth(), month.EndOfMonth());
         rv.TwelveMonthAverage = await GetAverage(context, expenseCategory, month.AddMonths(-12).StartOfMonth(), month.EndOfMonth());
+        rv.HasItems = await context.HasItemsAsync(expenseCategory);
         return rv;
 
         static async Task<int> GetAverage(BudgetContext context, ExpenseCategory expenseCategory, DateTime start, DateTime end)
@@ -110,6 +111,17 @@ public class ExpenseCategoryViewModelEx : ExpenseCategoryViewModel
     {
         get => _twelveMonthAverage;
         set => SetProperty(ref _twelveMonthAverage, value);
+    }
+
+    /// <summary>
+    /// Whether this category has ever had any items posted against it. Categories with items
+    /// cannot be permanently deleted (only hidden), to preserve transaction history.
+    /// </summary>
+    private bool _hasItems;
+    public bool HasItems
+    {
+        get => _hasItems;
+        set => SetProperty(ref _hasItems, value);
     }
 
     private bool _isEditing;

--- a/SimplyBudgetDesktop/Views/BudgetView.xaml
+++ b/SimplyBudgetDesktop/Views/BudgetView.xaml
@@ -7,6 +7,7 @@
              xmlns:vm="clr-namespace:SimplyBudget.ViewModels"
              xmlns:valueConverter="clr-namespace:SimplyBudget.ValueConverter"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes" xmlns:i="http://schemas.microsoft.com/xaml/behaviors" xmlns:behaviors="clr-namespace:SimplyBudget.Behaviors"
+             xmlns:views="clr-namespace:SimplyBudget.Views"
              d:DataContext="{d:DesignInstance Type=vm:BudgetViewModel}"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
@@ -106,6 +107,7 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
           <TextBox materialDesign:HintAssist.Hint="Name" 
                              materialDesign:HintAssist.IsFloating="True" 
@@ -177,8 +179,15 @@
                   Command="{x:Static ApplicationCommands.Delete}"
                   CommandParameter="{Binding}"/>
 
-          <Button Content="{materialDesign:PackIcon Kind=ContentSave}" 
+          <Button Content="{materialDesign:PackIcon Kind=DeleteForever}" 
                   Grid.Column="6" 
+                  ToolTip="Delete Permanently (only available when the category has no items)"
+                  Style="{StaticResource MaterialDesignFlatButton}"
+                  Command="{x:Static views:BudgetView.DeletePermanentlyCommand}"
+                  CommandParameter="{Binding}"/>
+
+          <Button Content="{materialDesign:PackIcon Kind=ContentSave}" 
+                  Grid.Column="7" 
                   Style="{StaticResource MaterialDesignFlatButton}"
                   Command="{x:Static ApplicationCommands.Save}"
                   CommandParameter="{Binding}"/>
@@ -201,6 +210,7 @@
       <CommandBinding Command="{x:Static ApplicationCommands.Delete}" Executed="Delete_Executed" CanExecute="Delete_CanExecute" />
       <CommandBinding Command="{x:Static ApplicationCommands.Replace}" Executed="Restore_Executed" CanExecute="Restore_CanExecute" />
       <CommandBinding Command="{x:Static ApplicationCommands.Copy}" Executed="Copy_Executed" />
+      <CommandBinding Command="{x:Static views:BudgetView.DeletePermanentlyCommand}" Executed="DeletePermanently_Executed" CanExecute="DeletePermanently_CanExecute" />
     </Grid.CommandBindings>
     <Grid.InputBindings>
       <KeyBinding Key="F5" Command="{Binding RefreshCommand}" />
@@ -282,6 +292,9 @@
                           CommandParameter="{Binding}" />
                 <MenuItem Header="_Restore"
                           Command="{x:Static ApplicationCommands.Replace}"
+                          CommandParameter="{Binding}" />
+                <MenuItem Header="Delete _Permanently"
+                          Command="{x:Static views:BudgetView.DeletePermanentlyCommand}"
                           CommandParameter="{Binding}" />
                 <Separator />
                 <MenuItem Header="_Edit"

--- a/SimplyBudgetDesktop/Views/BudgetView.xaml.cs
+++ b/SimplyBudgetDesktop/Views/BudgetView.xaml.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace SimplyBudget.Views;
 
@@ -11,6 +12,13 @@ namespace SimplyBudget.Views;
 /// </summary>
 public partial class BudgetView
 {
+    /// <summary>
+    /// Permanently removes an expense category (as opposed to <see cref="ApplicationCommands.Delete"/>,
+    /// which just hides it). Only enabled when the category has no items.
+    /// </summary>
+    public static readonly RoutedUICommand DeletePermanentlyCommand =
+        new("Delete Permanently", nameof(DeletePermanentlyCommand), typeof(BudgetView));
+
     private BudgetViewModel ViewModel => (BudgetViewModel)DataContext;
 
     public BudgetView()
@@ -79,6 +87,43 @@ public partial class BudgetView
         if (e.Parameter is ExpenseCategoryViewModelEx category)
         {
             e.CanExecute = category.IsHidden;
+        }
+    }
+
+    private async void DeletePermanently_Executed(object sender, System.Windows.Input.ExecutedRoutedEventArgs e)
+    {
+        if (e.Parameter is not ExpenseCategoryViewModelEx category)
+        {
+            return;
+        }
+
+        var result = MessageBox.Show(
+            $"Permanently delete '{category.Name}'? This cannot be undone.",
+            "Delete Category",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning,
+            MessageBoxResult.No);
+
+        if (result != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        if (!await ViewModel.DeletePermanently(category))
+        {
+            MessageBox.Show(
+                "This category could not be deleted because it still has items (or is used by an import rule). Hide it instead.",
+                "Delete Category",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+        }
+    }
+
+    private void DeletePermanently_CanExecute(object sender, System.Windows.Input.CanExecuteRoutedEventArgs e)
+    {
+        if (e.Parameter is ExpenseCategoryViewModelEx category)
+        {
+            e.CanExecute = !category.HasItems;
         }
     }
 

--- a/SimplyBudgetShared/Data/BudgetContextExtensions.cs
+++ b/SimplyBudgetShared/Data/BudgetContextExtensions.cs
@@ -199,6 +199,49 @@ public static class BudgetContextExtensions
         return await query.ToListAsync();
     }
 
+    /// <summary>
+    /// Whether the given expense category has ever had any transaction/income/transfer
+    /// line items posted against it.
+    /// </summary>
+    public static async Task<bool> HasItemsAsync(this BudgetContext context, ExpenseCategory expenseCategory)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (expenseCategory is null)
+        {
+            throw new ArgumentNullException(nameof(expenseCategory));
+        }
+
+        return await context.ExpenseCategoryItemDetails.AnyAsync(x => x.ExpenseCategoryId == expenseCategory.ID);
+    }
+
+    /// <summary>
+    /// Whether the given expense category is safe to permanently delete: it must not have any
+    /// items posted against it, and must not still be referenced by an import rule.
+    /// </summary>
+    public static async Task<bool> CanDeleteAsync(this BudgetContext context, ExpenseCategory expenseCategory)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (expenseCategory is null)
+        {
+            throw new ArgumentNullException(nameof(expenseCategory));
+        }
+
+        if (await context.HasItemsAsync(expenseCategory))
+        {
+            return false;
+        }
+
+        return !await context.ExpenseCategoryRules.AnyAsync(x => x.ExpenseCategoryID == expenseCategory.ID);
+    }
+
     public static async Task<int> GetRemainingBudgetAmount(this BudgetContext context, ExpenseCategory expenseCategory, DateTime month)
     {
         if (context is null)

--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
@@ -1,0 +1,207 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class ExpenseCategoriesControllerTests
+{
+    [Test]
+    public async Task Update_RenamesCategory()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Old Name", CategoryName = "Old Group" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Update(categoryId, new ExpenseCategoryRequest(
+            Name: "New Name", CategoryName: "New Group", BudgetedAmount: 0, BudgetedPercentage: 0, Cap: null, AccountId: null));
+
+        await Assert.That(result.Value!.Name).IsEqualTo("New Name");
+        await Assert.That(result.Value!.CategoryName).IsEqualTo("New Group");
+    }
+
+    [Test]
+    public async Task Hide_SetsIsHidden()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Hide(categoryId);
+
+        await Assert.That(result.Value!.IsHidden).IsTrue();
+    }
+
+    [Test]
+    public async Task Restore_ClearsIsHidden()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries", IsHidden = true };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Restore(categoryId);
+
+        await Assert.That(result.Value!.IsHidden).IsFalse();
+    }
+
+    [Test]
+    public async Task Delete_RemovesCategory_WhenItHasNoItems()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Unused" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new ExpenseCategoriesController(context);
+            var result = await controller.Delete(categoryId);
+            await Assert.That(result).IsTypeOf<NoContentResult>();
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var count = await context.ExpenseCategories.CountAsync(c => c.ID == categoryId);
+            await Assert.That(count).IsEqualTo(0);
+        });
+    }
+
+    [Test]
+    public async Task Delete_ReturnsConflict_WhenCategoryHasItems()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.Add(new ExpenseCategoryItem
+            {
+                Date = DateTime.Today,
+                Description = "Store run",
+                Details =
+                [
+                    new ExpenseCategoryItemDetail { Amount = -500, ExpenseCategoryId = category.ID }
+                ],
+            });
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Delete(categoryId);
+
+        await Assert.That(result).IsTypeOf<ConflictObjectResult>();
+
+        var stored = await context.ExpenseCategories.FindAsync(categoryId);
+        await Assert.That(stored).IsNotNull();
+    }
+
+    [Test]
+    public async Task Delete_ReturnsConflict_WhenCategoryIsReferencedByARule()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Grocery rule",
+                RuleRegex = "grocery",
+                ExpenseCategoryID = category.ID,
+            });
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Delete(categoryId);
+
+        await Assert.That(result).IsTypeOf<ConflictObjectResult>();
+    }
+
+    [Test]
+    public async Task GetAll_MarksHasItems_ForCategoriesWithPostedItems()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        var (withItemsId, withoutItemsId) = await mocker.InDbScopeAsync(async context =>
+        {
+            var withItems = new ExpenseCategory { Name = "Has Items" };
+            var withoutItems = new ExpenseCategory { Name = "No Items" };
+            context.ExpenseCategories.AddRange(withItems, withoutItems);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.Add(new ExpenseCategoryItem
+            {
+                Date = DateTime.Today,
+                Description = "Store run",
+                Details =
+                [
+                    new ExpenseCategoryItemDetail { Amount = -500, ExpenseCategoryId = withItems.ID }
+                ],
+            });
+            await context.SaveChangesAsync();
+            return (withItems.ID, withoutItems.ID);
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.GetAll(includeHidden: false, search: null);
+
+        await Assert.That(result.Single(c => c.Id == withItemsId).HasItems).IsTrue();
+        await Assert.That(result.Single(c => c.Id == withoutItemsId).HasItems).IsFalse();
+    }
+}

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type { RuleDto, ExpenseCategoryDto } from '@/types'
@@ -16,6 +16,80 @@ const editRule = ref<RuleDto | null>(null)
 const form = ref({ name: '', ruleRegex: '', expenseCategoryId: null as number | null })
 
 const categoryOptions = computed(() => [{ id: null, name: 'None' }, ...categories.value])
+
+// Expense category management (rename / hide / delete)
+const manageCategories = ref<ExpenseCategoryDto[]>([])
+const categoriesLoading = ref(false)
+const showHiddenCategories = ref(false)
+const editCategoryId = ref<number | null>(null)
+const editCategoryForm = ref({ name: '', categoryName: '' })
+const deleteCategory = ref<ExpenseCategoryDto | null>(null)
+
+async function fetchManageCategories() {
+  categoriesLoading.value = true
+  try {
+    manageCategories.value = await apiClient.get<ExpenseCategoryDto[]>(
+      `/api/expense-categories?includeHidden=${showHiddenCategories.value}`,
+    ) ?? []
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load expense categories', { variant: 'error' })
+  } finally {
+    categoriesLoading.value = false
+  }
+}
+
+function startEditCategory(category: ExpenseCategoryDto) {
+  editCategoryId.value = category.id
+  editCategoryForm.value = { name: category.name ?? '', categoryName: category.categoryName ?? '' }
+}
+
+async function handleSaveCategoryEdit(category: ExpenseCategoryDto) {
+  try {
+    await apiClient.put(`/api/expense-categories/${category.id}`, {
+      name: editCategoryForm.value.name,
+      categoryName: editCategoryForm.value.categoryName,
+      budgetedAmount: category.budgetedAmount,
+      budgetedPercentage: category.budgetedPercentage,
+      cap: category.cap,
+      accountId: category.accountId,
+    })
+    snackbar.enqueueSnackbar('Category updated', { variant: 'success' })
+    editCategoryId.value = null
+    void fetchManageCategories()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to update category', { variant: 'error' })
+  }
+}
+
+async function handleToggleHideCategory(category: ExpenseCategoryDto) {
+  try {
+    if (category.isHidden) {
+      await apiClient.post(`/api/expense-categories/${category.id}/restore`)
+      snackbar.enqueueSnackbar('Category restored', { variant: 'success' })
+    } else {
+      await apiClient.post(`/api/expense-categories/${category.id}/hide`)
+      snackbar.enqueueSnackbar('Category hidden', { variant: 'success' })
+    }
+    void fetchManageCategories()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to update category', { variant: 'error' })
+  }
+}
+
+async function handleDeleteCategory() {
+  if (!deleteCategory.value) return
+  try {
+    await apiClient.delete(`/api/expense-categories/${deleteCategory.value.id}`)
+    snackbar.enqueueSnackbar('Category deleted', { variant: 'success' })
+    deleteCategory.value = null
+    void fetchManageCategories()
+  } catch (err) {
+    snackbar.enqueueSnackbar(err instanceof Error ? err.message : 'Failed to delete category', { variant: 'error' })
+    deleteCategory.value = null
+  }
+}
+
+watch(showHiddenCategories, () => void fetchManageCategories())
 
 async function fetchRules() {
   loading.value = true
@@ -100,6 +174,7 @@ function openAdd() {
 onMounted(() => {
   void fetchRules()
   void fetchCategories()
+  void fetchManageCategories()
 })
 </script>
 
@@ -171,6 +246,101 @@ onMounted(() => {
           <v-spacer />
           <v-btn @click="deleteRule = null">Cancel</v-btn>
           <v-btn color="error" @click="handleDelete">Delete</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-divider class="my-6" />
+
+    <div class="d-flex justify-space-between align-center mb-4">
+      <h5 class="text-h5">Expense Categories</h5>
+      <v-switch
+        v-model="showHiddenCategories"
+        label="Show hidden"
+        density="compact"
+        hide-details
+        color="primary"
+      />
+    </div>
+
+    <div v-if="categoriesLoading" class="d-flex justify-center pa-8">
+      <v-progress-circular indeterminate aria-label="Loading expense categories" />
+    </div>
+    <v-list v-else>
+      <v-list-item v-if="manageCategories.length === 0">
+        <v-list-item-title>No expense categories defined.</v-list-item-title>
+      </v-list-item>
+      <v-card v-for="category in manageCategories" :key="category.id" class="mb-2">
+        <v-list-item>
+          <v-list-item-title>
+            <div v-if="editCategoryId === category.id" class="d-flex align-center" style="gap: 8px;">
+              <v-text-field
+                v-model="editCategoryForm.name"
+                label="Name"
+                density="compact"
+                hide-details
+                autofocus
+                style="max-width: 220px;"
+                @keydown.enter="handleSaveCategoryEdit(category)"
+              />
+              <v-text-field
+                v-model="editCategoryForm.categoryName"
+                label="Group"
+                density="compact"
+                hide-details
+                style="max-width: 220px;"
+                @keydown.enter="handleSaveCategoryEdit(category)"
+              />
+            </div>
+            <div v-else class="d-flex align-center" style="gap: 8px;">
+              <span>{{ category.name }}</span>
+              <v-chip v-if="category.isHidden" size="small">Hidden</v-chip>
+            </div>
+          </v-list-item-title>
+          <v-list-item-subtitle v-if="editCategoryId !== category.id">
+            {{ category.categoryName ?? 'No group' }}
+          </v-list-item-subtitle>
+          <template #append>
+            <div v-if="editCategoryId === category.id" class="d-flex" style="gap: 4px;">
+              <v-btn icon="mdi-content-save" color="primary" variant="text" aria-label="Save" @click="handleSaveCategoryEdit(category)" />
+              <v-btn icon="mdi-close" variant="text" aria-label="Cancel" @click="editCategoryId = null" />
+            </div>
+            <div v-else class="d-flex align-center" style="gap: 4px;">
+              <v-btn icon="mdi-pencil" variant="text" aria-label="Rename category" @click="startEditCategory(category)" />
+              <v-btn
+                :icon="category.isHidden ? 'mdi-eye' : 'mdi-eye-off'"
+                variant="text"
+                :aria-label="category.isHidden ? 'Restore category' : 'Hide category'"
+                @click="handleToggleHideCategory(category)"
+              />
+              <v-tooltip :text="category.hasItems ? 'Categories with items cannot be deleted' : 'Delete category'">
+                <template #activator="{ props }">
+                  <span v-bind="props">
+                    <v-btn
+                      icon="mdi-delete"
+                      variant="text"
+                      color="error"
+                      :disabled="category.hasItems"
+                      aria-label="Delete category"
+                      @click="deleteCategory = category"
+                    />
+                  </span>
+                </template>
+              </v-tooltip>
+            </div>
+          </template>
+        </v-list-item>
+      </v-card>
+    </v-list>
+
+    <v-dialog :model-value="!!deleteCategory" max-width="480" @update:model-value="(val: boolean) => !val && (deleteCategory = null)">
+      <v-card>
+        <v-card-title>Confirm Delete</v-card-title>
+        <v-card-text>Permanently delete category "{{ deleteCategory?.name }}"? This cannot be undone.</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="deleteCategory = null">Cancel</v-btn>
+          <v-btn color="error" @click="handleDeleteCategory">Delete</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/SimplyBudgetWeb.Web/src/services/apiClient.ts
+++ b/SimplyBudgetWeb.Web/src/services/apiClient.ts
@@ -80,9 +80,13 @@ class ApiClient {
   async delete<T = void>(url: string): Promise<T> {
     const headers = await this.getHeaders()
     const response = await fetch(this.baseUrl + url, { method: 'DELETE', headers })
-    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(error || `HTTP error! status: ${response.status}`)
+    }
     if (response.status === 204) return undefined as T
-    return response.json()
+    const text = await response.text()
+    return text ? JSON.parse(text) : undefined as T
   }
 }
 

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -35,6 +35,7 @@ export interface ExpenseCategoryDto {
   cap: number | null
   isHidden: boolean
   usePercentage: boolean
+  hasItems: boolean
 }
 
 export interface AccountDto {

--- a/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
+++ b/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
@@ -23,7 +23,8 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
             query = query.Where(c => c.Name != null && c.Name.Contains(search));
 
         var categories = await query.ToListAsync();
-        return categories.Select(ToDto).ToArray();
+        var idsWithItems = await GetIdsWithItemsAsync(categories.Select(c => c.ID));
+        return categories.Select(c => ToDto(c, idsWithItems.Contains(c.ID))).ToArray();
     }
 
     [HttpGet("{id}")]
@@ -31,7 +32,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
     {
         var category = await context.ExpenseCategories.FindAsync(id);
         if (category is null) return NotFound();
-        return ToDto(category);
+        return ToDto(category, await context.HasItemsAsync(category));
     }
 
     [HttpPost]
@@ -48,7 +49,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         };
         context.ExpenseCategories.Add(category);
         await context.SaveChangesAsync();
-        return CreatedAtAction(nameof(GetById), new { id = category.ID }, ToDto(category));
+        return CreatedAtAction(nameof(GetById), new { id = category.ID }, ToDto(category, hasItems: false));
     }
 
     [HttpPut("{id}")]
@@ -65,18 +66,22 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         category.AccountID = request.AccountId;
 
         await context.SaveChangesAsync();
-        return ToDto(category);
+        return ToDto(category, await context.HasItemsAsync(category));
     }
 
-    [HttpDelete("{id}")]
-    public async Task<IActionResult> Delete(int id)
+    /// <summary>
+    /// Hides a category from normal views (e.g. the budget list) without deleting it or losing
+    /// its transaction history. Use <see cref="Restore"/> to unhide it again.
+    /// </summary>
+    [HttpPost("{id}/hide")]
+    public async Task<ActionResult<ExpenseCategoryDto>> Hide(int id)
     {
         var category = await context.ExpenseCategories.FindAsync(id);
         if (category is null) return NotFound();
 
         category.IsHidden = true;
         await context.SaveChangesAsync();
-        return NoContent();
+        return ToDto(category, await context.HasItemsAsync(category));
     }
 
     [HttpPost("{id}/restore")]
@@ -87,10 +92,41 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
 
         category.IsHidden = false;
         await context.SaveChangesAsync();
-        return Ok(ToDto(category));
+        return ToDto(category, await context.HasItemsAsync(category));
     }
 
-    private static ExpenseCategoryDto ToDto(ExpenseCategory c) => new(
+    /// <summary>
+    /// Permanently deletes a category. Only allowed when the category has no items posted
+    /// against it and isn't referenced by an import rule; otherwise use <see cref="Hide"/>.
+    /// </summary>
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var category = await context.ExpenseCategories.FindAsync(id);
+        if (category is null) return NotFound();
+
+        if (!await context.CanDeleteAsync(category))
+            return Conflict("This category has items (or is used by an import rule) and cannot be deleted. Hide it instead.");
+
+        context.ExpenseCategories.Remove(category);
+        await context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    private async Task<HashSet<int>> GetIdsWithItemsAsync(IEnumerable<int> categoryIds)
+    {
+        var ids = categoryIds.ToList();
+        if (ids.Count == 0) return [];
+
+        var idsWithItems = await context.ExpenseCategoryItemDetails
+            .Where(d => ids.Contains(d.ExpenseCategoryId))
+            .Select(d => d.ExpenseCategoryId)
+            .Distinct()
+            .ToListAsync();
+        return [.. idsWithItems];
+    }
+
+    private static ExpenseCategoryDto ToDto(ExpenseCategory c, bool hasItems) => new(
         Id: c.ID,
         Name: c.Name,
         CategoryName: c.CategoryName,
@@ -100,7 +136,8 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         CurrentBalance: c.CurrentBalance,
         Cap: c.Cap,
         IsHidden: c.IsHidden,
-        UsePercentage: c.UsePercentage
+        UsePercentage: c.UsePercentage,
+        HasItems: hasItems
     );
 }
 
@@ -114,7 +151,8 @@ public record ExpenseCategoryDto(
     int CurrentBalance,
     int? Cap,
     bool IsHidden,
-    bool UsePercentage
+    bool UsePercentage,
+    bool HasItems
 );
 
 public record ExpenseCategoryRequest(


### PR DESCRIPTION
## Why

Users had no way to clean up their expense category list: renaming and hiding categories worked in the Desktop app already, but there was no true delete anywhere in the codebase, and the web app had no category management UI at all. This adds full rename/hide/delete support, with delete only allowed when a category has no items posted against it.

## Approach

- **Shared**: added `HasItemsAsync`/`CanDeleteAsync` extensions on `BudgetContext` (`SimplyBudgetShared/Data/BudgetContextExtensions.cs`) so both apps share one definition of "deletable" - no posted `ExpenseCategoryItemDetail` rows and no `ExpenseCategoryRule` references (the rule FK has no cascade behavior configured, so it would otherwise hit a DB constraint).
- **Desktop**: rename and hide/unhide already existed (the existing "Delete"/"Restore" commands were actually just toggling `IsHidden`). Added a genuinely new "Delete Permanently" command (context menu + inline button), enabled only when the category has no items, with a confirmation dialog. Left the existing hide/unhide commands untouched to avoid regressions.
- **Web API** (`ExpenseCategoriesController`): added `POST /api/expense-categories/{id}/hide`, kept `/restore`, and reworked `DELETE` into a true permanent delete that returns `409 Conflict` with an explanatory message when the category has items or is referenced by a rule. `HasItems` is now included in the DTO (computed in bulk for `GetAll` to avoid N+1 queries).
- **Web UI**: added an "Expense Categories" management section to `Settings.vue` following the existing inline-edit pattern used by `Accounts.vue` - list with a "Show hidden" toggle, inline rename, hide/restore toggle, and a delete button that's disabled with a tooltip when the category has items. Also improved `apiClient.delete()` to surface server error text (e.g. the 409 conflict message) instead of a generic HTTP error.

## Notes for reviewers

- No existing frontend code called the old `DELETE`/`hide`/`restore` endpoints, so changing `DELETE`'s semantics from soft-hide to true delete is not a breaking change for any current caller.
- Added 7 new controller tests covering rename, hide, restore, delete success, delete conflicts (items and rule references), and the `GetAll` `HasItems` flag.

## Testing

- `dotnet test SimplyBudgetWeb.Core.Tests` - 55 passed
- `dotnet test SimplyBudgetDesktop.Tests` - 44 passed
- `dotnet test SimplyBudgetSharedTests` - 60 passed
- `dotnet build` for Desktop and Web API - 0 warnings/errors
- `npm run build` (vue-tsc + vite) in `SimplyBudgetWeb.Web` - succeeds with no type errors