### PR TITLE
Require a passing Terraform plan before merging infra PRs

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'Infra/**'
       - '.github/workflows/deploy-infrastructure.yml'
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -17,19 +19,50 @@ env:
   AZURE_LOCATION: 'westus2'
 
 jobs:
+  # Determine whether this run touches Infra-as-code (or this workflow) at
+  # all. The `main` branch ruleset requires the `plan` check on every PR, but
+  # GitHub only clears a required check once some job reports it - a check
+  # that no job ever runs stays "Expected" forever. So `plan` always runs;
+  # for PRs that don't touch Infra it just skips the real Terraform work and
+  # reports success trivially.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Detect Infra changes
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            infra:
+              - 'Infra/**'
+              - '.github/workflows/deploy-infrastructure.yml'
+
+  # Terraform plan. Runs (and is required) on every PR so infra changes get
+  # reviewed/validated before merge, but only does real work when Infra
+  # actually changed. Never applies anything - see the push/workflow_dispatch
+  # only `apply` job below for that.
   plan:
     runs-on: ubuntu-latest
     environment: production
+    needs: changes
     steps:
       - uses: actions/checkout@v7
 
       - name: Setup Terraform
+        if: needs.changes.outputs.infra == 'true'
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
       - name: Azure Login
+        if: needs.changes.outputs.infra == 'true'
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID_INFRA }}
@@ -37,6 +70,7 @@ jobs:
           subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID_INFRA }}
 
       - name: Terraform Init
+        if: needs.changes.outputs.infra == 'true'
         working-directory: Infra
         run: terraform init -lock-timeout=5m
         env:
@@ -46,6 +80,7 @@ jobs:
           ARM_USE_OIDC: true
 
       - name: Terraform Plan
+        if: needs.changes.outputs.infra == 'true'
         working-directory: Infra
         run: terraform plan -out=tfplan
         env:
@@ -60,7 +95,10 @@ jobs:
           TF_VAR_backend_custom_domain: 'https://api.budget.keboo.dev'
           TF_VAR_frontend_custom_domain: 'https://budget.keboo.dev'
 
+      # Only push events (a merge to main) go on to `apply`, so only upload
+      # the plan artifact then - a PR's plan is for review purposes only.
       - name: Upload Terraform Plan
+        if: needs.changes.outputs.infra == 'true' && github.event_name != 'pull_request'
         uses: Keboo/sa-upload@v1
         with:
           name: tfplan
@@ -69,10 +107,14 @@ jobs:
           container-name: simplybudget
           create-container: true
 
+  # Applies the plan. Only runs for pushes to main (or manual dispatch) -
+  # never for pull_request events, so opening/updating a PR can never modify
+  # real infrastructure, only validate it via `terraform plan` above.
   apply:
     runs-on: ubuntu-latest
     environment: production
     needs: plan
+    if: github.event_name != 'pull_request'
     outputs:
       acr_login_server: ${{ steps.terraform-outputs.outputs.acr_login_server }}
       backend_container_app_name: ${{ steps.terraform-outputs.outputs.backend_container_app_name }}


### PR DESCRIPTION
Mirrors the build-and-deploy.yml fix: `deploy-infrastructure.yml` never
ran on pull requests at all, so there was no way to require a Terraform
plan before merge. Now:

- Added a `pull_request` trigger (targeting main, no path filter).
- Added a `changes` job (dorny/paths-filter) that both `plan` (and
  transitively `apply`) rely on to detect whether Infra/** or this
  workflow file changed.
- `plan`'s real steps are gated on `needs.changes.outputs.infra ==
  'true'`, so it always runs and reports quickly for PRs that don't
  touch infra, and does a real `terraform plan` for ones that do.
- `apply` now has `if: github.event_name != 'pull_request'`, so a PR
  can only ever run `plan` (read-only validation) - never apply
  infrastructure changes. Push-to-main and workflow_dispatch behavior
  is unchanged.

Once merged, `plan` should be added to the `main` branch ruleset's
required status checks (alongside `build`/`ui-tests`) so infra PRs
can't merge without a clean plan:

  gh api -X PUT repos/Keboo/SimplyBudget/rulesets/20882044 \
    -f name=main -f target=branch -f enforcement=active \
    --input - <<updated ruleset JSON with "plan" added to
    required_status_checks>>

This should happen after merge (and after existing open PRs rebase),
since PRs branched before this change won't have the new `pull_request`
trigger and would otherwise get stuck the same way #131 did.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
