### PR TITLE
Sort expense categories alphabetically in Convert Pending Expense dialog

### DIFF
--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -56,7 +56,7 @@ watch(
 )
 
 const sortedCategories = computed(() =>
-  [...props.categories].sort((a, b) => a.name.localeCompare(b.name)),
+  [...props.categories].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
 )
 
 const remainingCents = computed(() => {

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -55,6 +55,10 @@ watch(
   { immediate: true },
 )
 
+const sortedCategories = computed(() =>
+  [...props.categories].sort((a, b) => a.name.localeCompare(b.name)),
+)
+
 const remainingCents = computed(() => {
   if (!props.pendingExpense) return 0
   const allocated = lines.value.reduce((sum, l) => sum + dollarsToCents(l.amount || '0'), 0)
@@ -115,7 +119,7 @@ async function submit() {
           <div v-for="(item, index) in lines" :key="index" class="d-flex align-center mb-2" style="gap: 8px;">
             <v-select
               label="Category"
-              :items="props.categories"
+              :items="sortedCategories"
               item-title="name"
               item-value="id"
               v-model="item.expenseCategoryId"


### PR DESCRIPTION
## Why

In the Convert Pending Expense dialog, the category dropdown listed expense categories in whatever order the API returned them, making it hard to find a category by name.

## What changed

`ConvertPendingExpenseDialog.vue` now derives a `sortedCategories` computed property (a copy of `props.categories` sorted with `localeCompare` on `name`) and binds the category `v-select`'s `:items` to it instead of the raw prop. No API or data model changes were needed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>