### PR TITLE
Avoid full list reload when converting a pending expense

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -113,7 +113,11 @@ function openConvert(item: PendingExpenseDto) {
 
 function onConvertSuccess() {
   convertDialogOpen.value = false
-  void fetchPendingExpenses()
+  if (convertItem.value) {
+    const idToRemove = convertItem.value.id
+    items.value = items.value.filter((item) => item.id !== idToRemove)
+  }
+  convertItem.value = null
 }
 
 watch([search, assigneeId], fetchPendingExpenses)


### PR DESCRIPTION
Converting a pending expense to a real expense item felt like it triggered a full page reload. It didn't literally reload the page, but `onConvertSuccess()` called `fetchPendingExpenses()`, which sets `loading = true` and swaps the entire list out for a spinner (`v-if="loading"`) while re-fetching from the server, so the whole list visibly disappeared and reappeared.

Instead, remove the converted item directly from the local `items` array, mirroring the pattern already used for discard. The list now updates instantly with no refetch or loading flash.

Verified with `npm run build` (vue-tsc + vite build, no type errors) and `eslint` on the changed file (clean).