### PR TITLE
Style pending expense amounts by credit/debit instead of a chip

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -170,12 +170,14 @@ onMounted(() => {
             <div class="d-flex justify-space-between align-center">
               <span>
                 {{ new Date(item.date).toLocaleDateString() }} — {{ item.description }}
-                <v-chip size="small" class="ml-2">{{ item.isDebit ? 'Debit' : 'Credit' }}</v-chip>
                 <v-chip v-if="item.suggestedCategoryName" size="small" variant="outlined" class="ml-1">
                   Suggested: {{ item.suggestedCategoryName }}
                 </v-chip>
               </span>
-              <span class="font-weight-bold">{{ formatCents(item.amount) }}</span>
+              <span
+                class="font-weight-bold"
+                :style="{ color: `rgb(var(--v-theme-${item.isDebit ? 'debit' : 'credit'}))` }"
+              >{{ item.isDebit ? '' : '+' }}{{ formatCents(item.amount) }}</span>
             </div>
           </v-list-item-title>
           <template #append>

--- a/SimplyBudgetWeb.Web/src/plugins/vuetify.ts
+++ b/SimplyBudgetWeb.Web/src/plugins/vuetify.ts
@@ -28,6 +28,10 @@ export const vuetify = createVuetify({
           // Off-white so surfaces (cards, app bar, etc.) stand out against the page.
           background: '#f5f5f5',
           surface: '#ffffff',
+          // Used to tint amounts: credit (money in) vs debit (money out).
+          // Chosen for >=4.5:1 contrast against the white surface color.
+          credit: '#2E7D32',
+          debit: '#C62828',
         },
         variables: {
           // Bumped from the Vuetify default of 0.60 to meet WCAG AA contrast
@@ -42,6 +46,10 @@ export const vuetify = createVuetify({
           // app bar, and other surfaces are visually distinct from the page.
           background: '#161616',
           surface: '#242424',
+          // Lighter tints so credit/debit amounts keep >=4.5:1 contrast
+          // against the dark surface color.
+          credit: '#81C784',
+          debit: '#E57373',
         },
       },
     },


### PR DESCRIPTION
## Why

On the Pending Expenses page it wasn't visually obvious whether an item was a credit or a debit - you had to read a small "Debit"/"Credit" chip next to the description. This puts the distinction where it matters most: on the amount itself.

## What changed

- Removed the Debit/Credit `v-chip` from each pending expense row.
- The amount is now color-tinted based on `isDebit`: green for credits, red for debits.
- Credit amounts get a leading `+` (e.g. `+$42.00`) so they read as money coming in at a glance; debit amounts are unprefixed.
- Added `credit`/`debit` colors to both the light and dark Vuetify themes so the tint adapts with the rest of the UI:
  - Light: `#2E7D32` (credit) / `#C62828` (debit) - contrast ratios of ~5.1:1 and ~5.6:1 against the white surface color.
  - Dark: `#81C784` (credit) / `#E57373` (debit) - contrast ratios of ~7.7:1 and ~5.2:1 against the dark surface color.
  
  All four comfortably clear the WCAG AA 4.5:1 threshold for normal text.

## Verification

- `npm run build` (vue-tsc + vite) and `npm run lint` pass.
- Loaded the app in a browser and confirmed via computed styles that `--v-theme-credit` / `--v-theme-debit` resolve to the expected RGB values in both light and dark mode.