### PR TITLE
Keep left nav link color consistent in dark theme

### DIFF
--- a/SimplyBudgetWeb.Web/src/index.css
+++ b/SimplyBudgetWeb.Web/src/index.css
@@ -16,10 +16,7 @@ code {
   box-sizing: border-box;
 }
 
-.v-theme--dark a {
-  color: #90caf9;
-}
-
+.v-theme--dark a,
 .v-theme--dark a:visited {
-  color: #ce93d8;
+  color: #90caf9;
 }


### PR DESCRIPTION
## Why
Left navigation items were changing color after being clicked for the first time because visited links had a different dark-theme color. This made the nav feel inconsistent.

## What changed
- Updated `SimplyBudgetWeb.Web/src/index.css` so `.v-theme--dark a` and `.v-theme--dark a:visited` use the same color (`#90caf9`).
- Removed the separate visited-link purple override that caused the first-click color shift.

## Notes
- This is a styling-only change scoped to dark-theme link color behavior.
- No routing or navigation logic was changed.