### PR TITLE
Add month selector to pending expenses page

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -57,6 +57,31 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task GetAll_WithMonthFilter_OnlyReturnsItemsFromThatMonth()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 6, 1), Description = "June 1", Amount = 100 },
+                new PendingExpense { Date = new DateTime(2026, 6, 15), Description = "June 15", Amount = 200 },
+                new PendingExpense { Date = new DateTime(2026, 7, 1), Description = "July 1", Amount = 300 });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetAll(month: new DateTime(2026, 6, 10), search: null, assigneeId: null);
+
+        await Assert.That(result.Length).IsEqualTo(2);
+        await Assert.That(result[0].Description).IsEqualTo("June 1");
+        await Assert.That(result[1].Description).IsEqualTo("June 15");
+    }
+
+    [Test]
     public async Task GetAll_FiltersBySearch()
     {
         AutoMocker mocker = new();
@@ -341,6 +366,34 @@ public class PendingExpensesControllerTests
             var remaining = await context.PendingExpenses.ToListAsync();
             await Assert.That(remaining.Count).IsEqualTo(1);
             await Assert.That(remaining[0].Description).IsEqualTo("Unassigned");
+        });
+    }
+
+    [Test]
+    public async Task DeleteAll_WithMonthFilter_OnlyRemovesMatchingPendingExpenses()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 10), Description = "January", Amount = 100 },
+                new PendingExpense { Date = new DateTime(2026, 2, 10), Description = "February", Amount = 200 });
+            await context.SaveChangesAsync();
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new PendingExpensesController(context);
+            await controller.DeleteAll(month: new DateTime(2026, 1, 1), search: null, assigneeId: null);
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var remaining = await context.PendingExpenses.ToListAsync();
+            await Assert.That(remaining.Count).IsEqualTo(1);
+            await Assert.That(remaining[0].Description).IsEqualTo("February");
         });
     }
 

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -3,11 +3,13 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type { PendingExpenseDto, AssigneeDto, ExpenseCategoryDto } from '@/types'
-import { formatCents } from '@/utils/currency'
+import { formatCents, formatMonth } from '@/utils/currency'
 import ConvertPendingExpenseDialog from '@/components/ConvertPendingExpenseDialog.vue'
 
 const snackbar = useSnackbarStore()
 
+const now = new Date()
+const currentMonth = ref(new Date(now.getFullYear(), now.getMonth(), 1))
 const search = ref('')
 const assigneeId = ref<number | null>(null)
 const items = ref<PendingExpenseDto[]>([])
@@ -24,16 +26,37 @@ const deletingAll = ref(false)
 // per-item assignee picker (which additionally needs an "Unassigned" option).
 const assigneeFilterOptions = computed(() => [{ id: null, name: 'All' }, ...assignees.value])
 const assigneeAssignOptions = computed(() => [{ id: null, name: 'Unassigned' }, ...assignees.value])
+const monthLabel = computed(() =>
+  currentMonth.value.toLocaleString('default', { month: 'long', year: 'numeric' }),
+)
 
 // Items are returned sorted oldest-first, so consecutive entries belong to the same
 // month unless this changes; used to show a divider between months in the list.
-function monthLabel(dateString: string) {
+function monthGroupLabel(dateString: string) {
   return new Date(dateString).toLocaleDateString('default', { month: 'long', year: 'numeric' })
 }
 
 function isNewMonth(index: number) {
   if (index === 0) return true
-  return monthLabel(items.value[index].date) !== monthLabel(items.value[index - 1].date)
+  return monthGroupLabel(items.value[index].date) !== monthGroupLabel(items.value[index - 1].date)
+}
+
+function prevMonth() {
+  const d = currentMonth.value
+  currentMonth.value = new Date(d.getFullYear(), d.getMonth() - 1, 1)
+}
+
+function nextMonth() {
+  const d = currentMonth.value
+  currentMonth.value = new Date(d.getFullYear(), d.getMonth() + 1, 1)
+}
+
+function buildFilters() {
+  const month = `${formatMonth(currentMonth.value)}-01`
+  const params = new URLSearchParams({ month })
+  if (search.value) params.set('search', search.value)
+  if (assigneeId.value !== null) params.set('assigneeId', String(assigneeId.value))
+  return params
 }
 
 async function fetchAssignees() {
@@ -51,10 +74,7 @@ async function fetchCategories() {
 async function fetchPendingExpenses() {
   loading.value = true
   try {
-    const params = new URLSearchParams()
-    if (search.value) params.set('search', search.value)
-    if (assigneeId.value !== null) params.set('assigneeId', String(assigneeId.value))
-    const query = params.toString()
+    const query = buildFilters().toString()
     items.value = await apiClient.get<PendingExpenseDto[]>(`/api/pending-expenses${query ? `?${query}` : ''}`) ?? []
   } catch {
     snackbar.enqueueSnackbar('Failed to load pending expenses', { variant: 'error' })
@@ -102,10 +122,7 @@ async function handleDiscard() {
 async function handleDeleteAll() {
   deletingAll.value = true
   try {
-    const params = new URLSearchParams()
-    if (search.value) params.set('search', search.value)
-    if (assigneeId.value !== null) params.set('assigneeId', String(assigneeId.value))
-    const query = params.toString()
+    const query = buildFilters().toString()
     await apiClient.delete(`/api/pending-expenses${query ? `?${query}` : ''}`)
     snackbar.enqueueSnackbar('Pending expenses discarded', { variant: 'success' })
     deleteAllOpen.value = false
@@ -131,7 +148,7 @@ function onConvertSuccess() {
   convertItem.value = null
 }
 
-watch([search, assigneeId], fetchPendingExpenses)
+watch([currentMonth, search, assigneeId], fetchPendingExpenses)
 
 onMounted(() => {
   void fetchAssignees()
@@ -145,6 +162,10 @@ onMounted(() => {
     <h5 class="text-h5 mb-4">Pending Expenses</h5>
 
     <v-card class="pa-4 mb-4 d-flex flex-wrap align-center" style="gap: 16px;">
+      <v-btn variant="outlined" size="small" prepend-icon="mdi-chevron-left" @click="prevMonth">Prev</v-btn>
+      <span style="min-width: 140px; text-align: center;">{{ monthLabel }}</span>
+      <v-btn variant="outlined" size="small" append-icon="mdi-chevron-right" @click="nextMonth">Next</v-btn>
+
       <v-text-field label="Search" v-model="search" density="compact" style="max-width: 200px;" hide-details />
 
       <v-select
@@ -181,7 +202,7 @@ onMounted(() => {
       </v-list-item>
       <template v-for="(item, index) in items" :key="item.id">
         <v-list-subheader v-if="isNewMonth(index)" class="font-weight-bold">
-          {{ monthLabel(item.date) }}
+          {{ monthGroupLabel(item.date) }}
         </v-list-subheader>
         <v-card class="mb-2">
           <v-list-item style="cursor: pointer;" @click="openConvert(item)">

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
+using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
 
 namespace SimplyBudgetWeb.Controllers;
@@ -16,13 +17,21 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 {
     [HttpGet]
     public async Task<PendingExpenseDto[]> GetAll(
-        [FromQuery] string? search,
-        [FromQuery] int? assigneeId)
+        [FromQuery] DateTime? month = null,
+        [FromQuery] string? search = null,
+        [FromQuery] int? assigneeId = null)
     {
         var query = context.PendingExpenses
             .Include(x => x.Assignee)
             .Include(x => x.SuggestedCategory)
             .AsQueryable();
+
+        if (month.HasValue)
+        {
+            var start = month.Value.StartOfMonth();
+            var end = start.EndOfMonth();
+            query = query.Where(x => x.Date >= start && x.Date <= end);
+        }
 
         if (!string.IsNullOrWhiteSpace(search))
             query = query.Where(x => x.Description != null && x.Description.Contains(search));
@@ -30,7 +39,7 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         if (assigneeId.HasValue)
             query = query.Where(x => x.AssigneeId == assigneeId.Value);
 
-        // Oldest first: pending expenses are worked off like a queue, not limited to a month.
+        // Oldest first: pending expenses are worked off like a queue.
         var items = await query
             .OrderBy(x => x.Date)
             .ThenBy(x => x.ID)
@@ -100,10 +109,18 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
     /// </summary>
     [HttpDelete]
     public async Task<IActionResult> DeleteAll(
-        [FromQuery] string? search,
-        [FromQuery] int? assigneeId)
+        [FromQuery] DateTime? month = null,
+        [FromQuery] string? search = null,
+        [FromQuery] int? assigneeId = null)
     {
         var query = context.PendingExpenses.AsQueryable();
+
+        if (month.HasValue)
+        {
+            var start = month.Value.StartOfMonth();
+            var end = start.EndOfMonth();
+            query = query.Where(x => x.Date >= start && x.Date <= end);
+        }
 
         if (!string.IsNullOrWhiteSpace(search))
             query = query.Where(x => x.Description != null && x.Description.Contains(search));


### PR DESCRIPTION
## Why
Pending expenses can accumulate across many months, which makes the page noisy and harder to work through. This change mirrors the history page workflow so users can focus on one month at a time.

## What changed
- Added history-style month navigation (Prev/Next plus current month label) to Pending Expenses.
- Pending page requests now always include the selected month and refetch when month, search, or assignee filters change.
- Updated `GET /api/pending-expenses` and `DELETE /api/pending-expenses` to accept an optional `month` filter and apply month range filtering server-side.
- Added controller tests for month-filtered list and month-filtered bulk delete behavior.