### PR TITLE
Allow converted pending expenses to ignore budget totals

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -505,4 +505,44 @@ public class PendingExpensesControllerTests
             await Assert.That(category.CurrentBalance).IsEqualTo(20_00);
         });
     }
+
+    [Test]
+    public async Task Convert_WithIgnoreBudget_StoresConvertedItemAsIgnoredByBudget()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var category = new ExpenseCategory { Name = "Groceries", CurrentBalance = 200_00 };
+            context.ExpenseCategories.Add(category);
+            var pending = new PendingExpense
+            {
+                Date = new DateTime(2026, 1, 6),
+                Description = "Costco",
+                Amount = 50_00,
+                IsDebit = true
+            };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+
+            var controller = new PendingExpensesController(context);
+            await controller.Convert(
+                pending.ID,
+                new ConvertPendingExpenseRequest(
+                    "Costco",
+                    new DateTime(2026, 1, 6),
+                    [new ConvertPendingExpenseItemRequest(category.ID, 50_00)],
+                    IgnoreBudget: true));
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var item = await context.ExpenseCategoryItems
+                .Include(x => x.Details)
+                .SingleAsync();
+            await Assert.That(item.IgnoreBudget).IsTrue();
+            await Assert.That(item.Details!.All(x => x.IgnoreBudget)).IsTrue();
+        });
+    }
 }

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -28,6 +28,7 @@ const emptyLine = (): LineItem => ({ expenseCategoryId: null, amount: '' })
 const description = ref('')
 const date = ref('')
 const lines = ref<LineItem[]>([emptyLine()])
+const ignoreBudget = ref(false)
 const submitting = ref(false)
 
 function centsToDollars(cents: number) {
@@ -47,6 +48,7 @@ watch(
     if (!pe) return
     description.value = pe.description ?? ''
     date.value = pe.date.split('T')[0]
+    ignoreBudget.value = false
     lines.value = [{
       expenseCategoryId: pe.suggestedCategoryId ?? null,
       amount: centsToDollars(pe.amount),
@@ -84,6 +86,7 @@ async function submit() {
     const payload: ConvertPendingExpenseRequest = {
       description: description.value,
       date: date.value,
+      ignoreBudget: ignoreBudget.value,
       items: lines.value
         .filter(l => l.expenseCategoryId !== null && l.amount !== '')
         .map(l => ({
@@ -111,6 +114,12 @@ async function submit() {
         <div class="d-flex flex-column" style="gap: 16px;">
           <v-text-field label="Description" v-model="description" />
           <v-text-field label="Date" type="date" v-model="date" />
+          <v-checkbox
+            v-model="ignoreBudget"
+            label="Do not contribute toward budget"
+            density="compact"
+            hide-details
+          />
 
           <span class="text-subtitle-2">
             {{ pendingExpense.isDebit ? 'Split expense across categories' : 'Split income across categories' }}

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -113,6 +113,7 @@ export interface ConvertPendingExpenseRequest {
   description: string
   date: string
   items: ConvertPendingExpenseItemRequest[]
+  ignoreBudget: boolean
 }
 
 export interface TransactionItemRequest {

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -133,11 +133,11 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 
         if (pending.IsDebit)
         {
-            await context.AddTransaction(request.Description, request.Date, items);
+            await context.AddTransaction(request.Description, request.Date, request.IgnoreBudget, items);
         }
         else
         {
-            await context.AddIncome(request.Description, request.Date, items);
+            await context.AddIncome(request.Description, request.Date, request.IgnoreBudget, items);
         }
 
         context.PendingExpenses.Remove(pending);
@@ -177,4 +177,8 @@ public record PendingExpenseUpdateRequest(int? AssigneeId, string? Notes);
 
 public record ConvertPendingExpenseItemRequest(int ExpenseCategoryId, int Amount);
 
-public record ConvertPendingExpenseRequest(string Description, DateTime Date, ConvertPendingExpenseItemRequest[] Items);
+public record ConvertPendingExpenseRequest(
+    string Description,
+    DateTime Date,
+    ConvertPendingExpenseItemRequest[] Items,
+    bool IgnoreBudget = false);


### PR DESCRIPTION
## Why
When converting a pending expense into a real expense item, there was no way to mark that new item as excluded from budget calculations. Users needed parity with other entry flows that already support "ignore budget" behavior.

## What changed
- Added an `ignoreBudget` option to the pending expense conversion request contract.
- Updated the convert dialog UI to include a "Do not contribute toward budget" checkbox and send that value with the conversion payload.
- Wired the API conversion path to pass `IgnoreBudget` into `AddTransaction` / `AddIncome` so converted items are created with the correct budget behavior.
- Added controller test coverage to verify converted items are persisted as ignored-by-budget when requested.

## Notes
- `IgnoreBudget` defaults to `false` on the API request to keep existing clients backward compatible when the field is omitted.