### PR TITLE
Add new-version prompt with manual frontend refresh

### DIFF
--- a/SimplyBudgetWeb.Web/package.json
+++ b/SimplyBudgetWeb.Web/package.json
@@ -17,7 +17,8 @@
     "pinia": "^4.0.2",
     "vue": "^3.5.41",
     "vue-router": "^5.2.0",
-    "vuetify": "^4.1.8"
+    "vuetify": "^4.1.8",
+    "workbox-window": "^7.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/SimplyBudgetWeb.Web/pnpm-lock.yaml
+++ b/SimplyBudgetWeb.Web/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       vuetify:
         specifier: ^4.1.8
         version: 4.1.8(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3))
+      workbox-window:
+        specifier: ^7.4.1
+        version: 7.4.1
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1

--- a/SimplyBudgetWeb.Web/src/App.vue
+++ b/SimplyBudgetWeb.Web/src/App.vue
@@ -1,18 +1,30 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
+import { useRegisterSW } from 'virtual:pwa-register/vue'
 import { useAuthStore } from '@/stores/auth'
 import SnackbarHost from '@/components/SnackbarHost.vue'
 
 const authStore = useAuthStore()
+const { needRefresh, updateServiceWorker } = useRegisterSW()
 
 onMounted(() => {
   void authStore.initialize()
 })
+
+function refreshToLatestVersion() {
+  void updateServiceWorker(true)
+}
 </script>
 
 <template>
   <v-app>
     <router-view />
     <SnackbarHost />
+    <v-snackbar :model-value="needRefresh" :timeout="-1" location="bottom">
+      A new version is available.
+      <template #actions>
+        <v-btn variant="text" @click="refreshToLatestVersion">Refresh</v-btn>
+      </template>
+    </v-snackbar>
   </v-app>
 </template>

--- a/SimplyBudgetWeb.Web/vite.config.ts
+++ b/SimplyBudgetWeb.Web/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     vue(),
     vuetify({ autoImport: true }),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png'],
       manifest: {
         name: 'SimplyBudgetWeb',


### PR DESCRIPTION
## Why
When a new frontend build is deployed, users need a clear in-app signal that their current tab is stale and a direct way to load the latest code.

## What changed
- Switched Vite PWA registration from `autoUpdate` to `prompt` so updates wait for user confirmation.
- Added service-worker update handling in `App.vue` via `useRegisterSW()`.
- Added a persistent snackbar popup that appears when a new version is available, with a `Refresh` button that triggers `updateServiceWorker(true)`.
- Added `workbox-window` as a runtime dependency required by `virtual:pwa-register/vue`.

## Notes
This keeps the update flow explicit for users instead of auto-reloading the app in the background.