### PR TITLE
Allow pending expense conversion to ignore budget contribution

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -478,6 +478,43 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task Convert_WithIgnoreBudget_SetsConvertedItemDetailsToIgnoreBudget()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var category = new ExpenseCategory { Name = "Groceries", CurrentBalance = 1_000_00 };
+            context.ExpenseCategories.Add(category);
+            var pending = new PendingExpense
+            {
+                Date = new DateTime(2026, 1, 5),
+                Description = "Costco",
+                Amount = 45_00,
+                IsDebit = true
+            };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+
+            var controller = new PendingExpensesController(context);
+            await controller.Convert(pending.ID, new ConvertPendingExpenseRequest(
+                "Costco",
+                new DateTime(2026, 1, 5),
+                [new ConvertPendingExpenseItemRequest(category.ID, 45_00)],
+                IgnoreBudget: true));
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var item = await context.ExpenseCategoryItems
+                .Include(x => x.Details)
+                .SingleAsync();
+            await Assert.That(item.Details!.Single().IgnoreBudget).IsTrue();
+        });
+    }
+
+    [Test]
     public async Task Convert_Debit_CanSplitAcrossMultipleCategories()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -28,6 +28,7 @@ const emptyLine = (): LineItem => ({ expenseCategoryId: null, amount: '' })
 const description = ref('')
 const date = ref('')
 const lines = ref<LineItem[]>([emptyLine()])
+const ignoreBudget = ref(false)
 const submitting = ref(false)
 
 function centsToDollars(cents: number) {
@@ -47,6 +48,7 @@ watch(
     if (!pe) return
     description.value = pe.description ?? ''
     date.value = pe.date.split('T')[0]
+    ignoreBudget.value = false
     lines.value = [{
       expenseCategoryId: pe.suggestedCategoryId ?? null,
       amount: centsToDollars(pe.amount),
@@ -84,6 +86,7 @@ async function submit() {
     const payload: ConvertPendingExpenseRequest = {
       description: description.value,
       date: date.value,
+      ignoreBudget: ignoreBudget.value,
       items: lines.value
         .filter(l => l.expenseCategoryId !== null && l.amount !== '')
         .map(l => ({
@@ -111,6 +114,12 @@ async function submit() {
         <div class="d-flex flex-column" style="gap: 16px;">
           <v-text-field label="Description" v-model="description" />
           <v-text-field label="Date" type="date" v-model="date" />
+          <v-checkbox
+            v-model="ignoreBudget"
+            label="Do not contribute toward budget"
+            density="compact"
+            hide-details
+          />
 
           <span class="text-subtitle-2">
             {{ pendingExpense.isDebit ? 'Split expense across categories' : 'Split income across categories' }}

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -113,6 +113,7 @@ export interface ConvertPendingExpenseRequest {
   description: string
   date: string
   items: ConvertPendingExpenseItemRequest[]
+  ignoreBudget: boolean
 }
 
 export interface TransactionItemRequest {

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -150,11 +150,11 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 
         if (pending.IsDebit)
         {
-            await context.AddTransaction(request.Description, request.Date, items);
+            await context.AddTransaction(request.Description, request.Date, request.IgnoreBudget, items);
         }
         else
         {
-            await context.AddIncome(request.Description, request.Date, items);
+            await context.AddIncome(request.Description, request.Date, request.IgnoreBudget, items);
         }
 
         context.PendingExpenses.Remove(pending);
@@ -194,4 +194,8 @@ public record PendingExpenseUpdateRequest(int? AssigneeId, string? Notes);
 
 public record ConvertPendingExpenseItemRequest(int ExpenseCategoryId, int Amount);
 
-public record ConvertPendingExpenseRequest(string Description, DateTime Date, ConvertPendingExpenseItemRequest[] Items);
+public record ConvertPendingExpenseRequest(
+    string Description,
+    DateTime Date,
+    ConvertPendingExpenseItemRequest[] Items,
+    bool IgnoreBudget = false);


### PR DESCRIPTION
## Why
Converting a pending expense did not provide a way to mark the created item as excluded from budget calculations. This made pending-conversion behavior inconsistent with other item creation flows that support ignore-budget entries.

## What changed
- Added `ignoreBudget` to `ConvertPendingExpenseRequest` on the backend, with a default of `false` for compatibility.
- Updated pending-expense conversion to pass `ignoreBudget` into `AddTransaction` and `AddIncome` so created details persist the flag.
- Added a checkbox in `ConvertPendingExpenseDialog` to let users choose "Do not contribute toward budget" during conversion.
- Updated web request typings to include `ignoreBudget`.
- Added a controller test covering conversion with `IgnoreBudget: true`.

## Notes
- Existing clients that omit `ignoreBudget` keep current behavior (`false`).