### PR TITLE
Default pending expenses month to oldest pending transaction

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -82,6 +82,42 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task GetOldestMonth_ReturnsOldestPendingExpenseMonthStart()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 6, 15), Description = "Recent", Amount = 100 },
+                new PendingExpense { Date = new DateTime(2024, 1, 31), Description = "Oldest", Amount = 200 });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetOldestMonth();
+
+        await Assert.That(result.Month).IsEqualTo(new DateTime(2024, 1, 1));
+    }
+
+    [Test]
+    public async Task GetOldestMonth_WithNoPendingExpenses_ReturnsNull()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetOldestMonth();
+
+        await Assert.That(result.Month).IsNull();
+    }
+
+    [Test]
     public async Task GetAll_FiltersBySearch()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
-import type { PendingExpenseDto, AssigneeDto, ExpenseCategoryDto } from '@/types'
+import type { PendingExpenseDto, AssigneeDto, ExpenseCategoryDto, OldestPendingExpenseMonthDto } from '@/types'
 import { formatCents, formatMonth } from '@/utils/currency'
 import ConvertPendingExpenseDialog from '@/components/ConvertPendingExpenseDialog.vue'
 
@@ -81,6 +81,28 @@ async function fetchPendingExpenses() {
     snackbar.enqueueSnackbar('Failed to load pending expenses', { variant: 'error' })
   } finally {
     loading.value = false
+  }
+}
+
+async function setDefaultMonthToOldestPendingTransaction() {
+  try {
+    const oldestPendingMonth = await apiClient.get<OldestPendingExpenseMonthDto>('/api/pending-expenses/oldest-month')
+    if (!oldestPendingMonth?.month) return false
+
+    const oldestDate = new Date(oldestPendingMonth.month)
+    const oldestMonth = new Date(oldestDate.getFullYear(), oldestDate.getMonth(), 1)
+    const current = currentMonth.value
+    const monthChanged =
+      oldestMonth.getFullYear() !== current.getFullYear() ||
+      oldestMonth.getMonth() !== current.getMonth()
+
+    if (monthChanged) {
+      currentMonth.value = oldestMonth
+    }
+
+    return monthChanged
+  } catch {
+    return false
   }
 }
 
@@ -185,10 +207,13 @@ function onConvertSuccess() {
 
 watch([currentMonth, search, assigneeId], fetchPendingExpenses)
 
-onMounted(() => {
+onMounted(async () => {
   void fetchAssignees()
   void fetchCategories()
-  void fetchPendingExpenses()
+  const monthChanged = await setDefaultMonthToOldestPendingTransaction()
+  if (!monthChanged) {
+    void fetchPendingExpenses()
+  }
 })
 </script>
 

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -99,6 +99,10 @@ export interface PendingExpenseDto {
   suggestedCategoryName: string | null
 }
 
+export interface OldestPendingExpenseMonthDto {
+  month: string | null
+}
+
 export interface PendingExpenseUpdateRequest {
   assigneeId: number | null
   notes: string | null

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -48,6 +48,21 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         return items.Select(ToDto).ToArray();
     }
 
+    [HttpGet("oldest-month")]
+    public async Task<OldestPendingExpenseMonthDto> GetOldestMonth()
+    {
+        var oldestDate = await context.PendingExpenses
+            .OrderBy(x => x.Date)
+            .Select(x => (DateTime?)x.Date)
+            .FirstOrDefaultAsync();
+
+        DateTime? oldestMonth = oldestDate.HasValue
+            ? oldestDate.Value.StartOfMonth()
+            : null;
+
+        return new OldestPendingExpenseMonthDto(oldestMonth);
+    }
+
     [HttpGet("{id}")]
     public async Task<ActionResult<PendingExpenseDto>> GetById(int id)
     {
@@ -189,6 +204,8 @@ public record PendingExpenseDto(
     int? SuggestedCategoryId,
     string? SuggestedCategoryName
 );
+
+public record OldestPendingExpenseMonthDto(DateTime? Month);
 
 public record PendingExpenseUpdateRequest(int? AssigneeId, string? Notes);
 


### PR DESCRIPTION
## Why
The Pending Expenses page always started on the current month, which made older pending transactions easy to miss. This change makes the page open on the oldest month that still has pending work, while keeping the current month as the fallback when nothing is pending.

## What changed
- Added `GET /api/pending-expenses/oldest-month` to return the oldest pending transaction month (normalized to month start) or `null` when there are no pending expenses.
- Updated `PendingExpenses.vue` to request that month during initialization and set `currentMonth` before the first data load.
- Added `OldestPendingExpenseMonthDto` in web types for the new API response.
- Added controller tests for both cases:
  - oldest month is returned as month start
  - `null` is returned when no pending expenses exist

## Notes
- The existing month-navigation and filtering behavior are unchanged after initialization.