### PR TITLE
Keep assignee chip visible after unassigning pending expense

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -281,6 +281,7 @@ onMounted(async () => {
                         v-bind="props"
                         size="small"
                         variant="outlined"
+                        :model-value="true"
                         :closable="item.assigneeId !== null"
                         :prepend-icon="item.assigneeId === null ? 'mdi-account-plus-outline' : undefined"
                         @click.stop


### PR DESCRIPTION
## Why
Removing an assignee from a pending expense looked successful, but the chip itself disappeared. This made it look like the assignee control was gone instead of reset.

## What changed
The assignee chip on the Pending Expenses page is now controlled with `model-value` so Vuetify does not dismiss the chip when the close icon is clicked.

The close action still clears the assignee as before, and the chip now remains visible with the expected `Assign` label.