### PR TITLE
Fix update toast refresh action

### DIFF
--- a/SimplyBudgetWeb.Web/src/App.vue
+++ b/SimplyBudgetWeb.Web/src/App.vue
@@ -11,8 +11,10 @@ onMounted(() => {
   void authStore.initialize()
 })
 
-function refreshToLatestVersion() {
-  void updateServiceWorker(true)
+async function refreshToLatestVersion() {
+  needRefresh.value = false
+  await updateServiceWorker()
+  window.location.reload()
 }
 </script>
 


### PR DESCRIPTION
## Why
Clicking **Refresh** on the "A new version is available" snackbar did not reload the app, so users could remain on stale code after an update was detected.

## What changed
- Made `refreshToLatestVersion` async in `SimplyBudgetWeb.Web/src/App.vue`.
- Clear `needRefresh` immediately so the snackbar closes on click.
- Await `updateServiceWorker()` to apply the waiting service worker.
- Force `window.location.reload()` so the page reliably refreshes to the latest version.

## Notes
This is intentionally defensive: the explicit reload ensures the Refresh action has an immediate visible effect even if service worker update signaling behaves inconsistently.