### PR TITLE
Rename History tab label to Expenses

### DIFF
--- a/SimplyBudgetWeb.UITests/AuthTests.cs
+++ b/SimplyBudgetWeb.UITests/AuthTests.cs
@@ -17,7 +17,7 @@ public class AuthTests : UITestBase
     {
         await Page.GotoAsync(FrontendBaseUri.ToString());
         await Assert.That(await Page.GetByRole(AriaRole.Button, new() { Name = "Budget" }).CountAsync()).IsEqualTo(0);
-        await Assert.That(await Page.GetByRole(AriaRole.Button, new() { Name = "History" }).CountAsync()).IsEqualTo(0);
+        await Assert.That(await Page.GetByRole(AriaRole.Button, new() { Name = "Expenses" }).CountAsync()).IsEqualTo(0);
         await Assert.That(await Page.GetByRole(AriaRole.Button, new() { Name = "Sign out" }).CountAsync()).IsEqualTo(0);
     }
 
@@ -29,4 +29,3 @@ public class AuthTests : UITestBase
         await AssertNoAccessibilityViolations();
     }
 }
-

--- a/SimplyBudgetWeb.Web/src/components/Layout.vue
+++ b/SimplyBudgetWeb.Web/src/components/Layout.vue
@@ -14,7 +14,7 @@ const isDark = computed(() => theme.global.name.value === 'dark')
 
 const navItems = [
   { title: 'Budget', to: '/budget', icon: 'mdi-cash-multiple' },
-  { title: 'History', to: '/history', icon: 'mdi-history' },
+  { title: 'Expenses', to: '/history', icon: 'mdi-history' },
   { title: 'Pending Expenses', to: '/pending-expenses', icon: 'mdi-receipt-text-clock' },
   { title: 'Accounts', to: '/accounts', icon: 'mdi-bank' },
   { title: 'Settings', to: '/settings', icon: 'mdi-cog' },

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -86,7 +86,7 @@ function onDialogSuccess() {
 
 <template>
   <div>
-    <h5 class="text-h5 mb-4">History</h5>
+    <h5 class="text-h5 mb-4">Expenses</h5>
 
     <v-card class="pa-4 mb-4 d-flex flex-wrap align-center" style="gap: 16px;">
       <v-btn variant="outlined" size="small" prepend-icon="mdi-chevron-left" @click="prevMonth">Prev</v-btn>


### PR DESCRIPTION
## Why
The navigation label was requested to use "Expenses" instead of "History" so the tab name matches user terminology more clearly.

## What changed
- Updated the web navigation item title from `History` to `Expenses`.
- Updated the History page heading from `History` to `Expenses`.
- Updated the UI auth navigation test assertion to expect the `Expenses` label.

## Notes
- The route path (`/history`) and underlying component names remain unchanged to keep behavior and links stable.