### PR TITLE
Show month-scoped total account balance on Budget page

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/BudgetControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/BudgetControllerTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore;
+using Moq.AutoMock;
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class BudgetControllerTests
+{
+    [Test]
+    public async Task Get_UsesSelectedMonthForTotalAccountAmount()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var account = new Account
+            {
+                Name = "Checking",
+                ValidatedDate = new DateTime(2026, 1, 1),
+            };
+            context.Accounts.Add(account);
+            await context.SaveChangesAsync();
+
+            var category = new ExpenseCategory
+            {
+                Name = "Checking Category",
+                AccountID = account.ID,
+            };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.AddRange(
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 1, 10),
+                    Description = "January income",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = 1000,
+                            ExpenseCategoryId = category.ID,
+                        },
+                    ],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 3, 5),
+                    Description = "March expense",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = -300,
+                            ExpenseCategoryId = category.ID,
+                        },
+                    ],
+                });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
+        var controller = new BudgetController(context);
+
+        var februaryBudget = await controller.Get(new DateTime(2026, 2, 1));
+        var aprilBudget = await controller.Get(new DateTime(2026, 4, 1));
+
+        await Assert.That(februaryBudget.TotalAccountAmount).IsEqualTo(1000);
+        await Assert.That(aprilBudget.TotalAccountAmount).IsEqualTo(700);
+    }
+}

--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -84,7 +84,10 @@ function onDialogSuccess() {
     </div>
 
     <v-card v-if="budget" class="pa-4 mb-4">
-      <span class="text-h5">Total Budget: <strong>{{ formatCents(budget.totalBudget) }}</strong></span>
+      <div class="d-flex flex-wrap" style="gap: 16px;">
+        <span class="text-h5">Total Budget: <strong>{{ formatCents(budget.totalBudget) }}</strong></span>
+        <span class="text-h5">Total In Accounts: <strong>{{ formatCents(budget.totalAccountAmount) }}</strong></span>
+      </div>
     </v-card>
 
     <div v-if="loading" class="d-flex justify-center pa-8">

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -20,6 +20,7 @@ export interface BudgetCategoryDto {
 
 export interface BudgetResponse {
   totalBudget: number
+  totalAccountAmount: number
   month: string
   categories: BudgetCategoryDto[]
 }

--- a/SimplyBudgetWeb/Controllers/BudgetController.cs
+++ b/SimplyBudgetWeb/Controllers/BudgetController.cs
@@ -16,6 +16,18 @@ public class BudgetController(BudgetWebContext context) : ControllerBase
         var monthDate = (month ?? DateTime.Today).StartOfMonth();
         var start = monthDate.StartOfMonth();
         var end = monthDate.EndOfMonth();
+        var totalAccountAmount = await context.ExpenseCategories
+            .Where(x => x.AccountID != null)
+            .Select(x => (int?)x.CurrentBalance)
+            .SumAsync() ?? 0;
+
+        var futureAccountAmountAdjustments = await context.ExpenseCategoryItemDetails
+            .Where(x => x.ExpenseCategory!.AccountID != null)
+            .Where(x => x.ExpenseCategoryItem!.Date > end)
+            .Select(x => (int?)x.Amount)
+            .SumAsync() ?? 0;
+
+        totalAccountAmount -= futureAccountAmountAdjustments;
 
         var categories = await context.ExpenseCategories
             .Where(c => !c.IsHidden)
@@ -64,6 +76,7 @@ public class BudgetController(BudgetWebContext context) : ControllerBase
 
         return new BudgetResponse(
             TotalBudget: totalBudget,
+            TotalAccountAmount: totalAccountAmount,
             Month: monthDate.ToString("yyyy-MM"),
             Categories: categoryDtos
         );
@@ -83,7 +96,7 @@ public class BudgetController(BudgetWebContext context) : ControllerBase
     }
 }
 
-public record BudgetResponse(int TotalBudget, string Month, List<BudgetCategoryDto> Categories);
+public record BudgetResponse(int TotalBudget, int TotalAccountAmount, string Month, List<BudgetCategoryDto> Categories);
 
 public record BudgetCategoryDto(
     int Id,


### PR DESCRIPTION
The Budget page needed to show the same all-accounts money view as Accounts, but tied to the selected month so future-dated items do not affect past months.

## What changed
- Added `TotalAccountAmount` to `GET /api/budget`.
- Computed it as:
  - current summed balance across account-backed categories, minus
  - all account-backed item detail amounts dated after the selected month end.
- Updated the web `BudgetResponse` type to include `totalAccountAmount`.
- Displayed `Total In Accounts` on the Budget page header card.
- Added controller coverage for month behavior to confirm future items are excluded until their month is reached.

## Notes for reviewers
This keeps account-total behavior aligned with existing account balances while making the Budget page month-aware.