### PR TITLE
Add clickable category monthly expense chart with budget line

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
@@ -204,4 +204,67 @@ public class ExpenseCategoriesControllerTests
         await Assert.That(result.Single(c => c.Id == withItemsId).HasItems).IsTrue();
         await Assert.That(result.Single(c => c.Id == withoutItemsId).HasItems).IsFalse();
     }
+
+    [Test]
+    public async Task GetMonthlyExpenses_ReturnsMonthlySpendingAndBudgetedAmount()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var groceries = new ExpenseCategory { Name = "Groceries", BudgetedAmount = 30000 };
+            var savings = new ExpenseCategory { Name = "Savings" };
+            context.ExpenseCategories.AddRange(groceries, savings);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.AddRange(
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 1, 10),
+                    Description = "Store run",
+                    Details = [new ExpenseCategoryItemDetail { Amount = -8000, ExpenseCategoryId = groceries.ID }],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 1, 15),
+                    Description = "Ignored purchase",
+                    Details = [new ExpenseCategoryItemDetail { Amount = -2000, ExpenseCategoryId = groceries.ID, IgnoreBudget = true }],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 2, 12),
+                    Description = "Transfer to savings",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail { Amount = -1000, ExpenseCategoryId = groceries.ID },
+                        new ExpenseCategoryItemDetail { Amount = 1000, ExpenseCategoryId = savings.ID },
+                    ],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 3, 5),
+                    Description = "Another store run",
+                    Details = [new ExpenseCategoryItemDetail { Amount = -5000, ExpenseCategoryId = groceries.ID }],
+                });
+            await context.SaveChangesAsync();
+
+            return groceries.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.GetMonthlyExpenses(categoryId, new DateTime(2026, 3, 1), months: 3);
+
+        await Assert.That(result.Value).IsNotNull();
+        await Assert.That(result.Value!.BudgetedAmount).IsEqualTo(30000);
+        await Assert.That(result.Value.Months.Length).IsEqualTo(3);
+        await Assert.That(result.Value.Months[0].Month).IsEqualTo("2026-01");
+        await Assert.That(result.Value.Months[0].Amount).IsEqualTo(8000);
+        await Assert.That(result.Value.Months[1].Month).IsEqualTo("2026-02");
+        await Assert.That(result.Value.Months[1].Amount).IsEqualTo(0);
+        await Assert.That(result.Value.Months[2].Month).IsEqualTo("2026-03");
+        await Assert.That(result.Value.Months[2].Amount).IsEqualTo(5000);
+    }
 }

--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -2,8 +2,8 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
-import type { BudgetResponse, BudgetCategoryDto, ExpenseCategoryDto } from '@/types'
-import { formatCents, formatMonth } from '@/utils/currency'
+import type { BudgetResponse, BudgetCategoryDto, ExpenseCategoryDto, ExpenseCategoryMonthlyExpensesDto } from '@/types'
+import { formatCents, formatMonth, parseMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 
@@ -14,6 +14,9 @@ const budget = ref<BudgetResponse | null>(null)
 const loading = ref(false)
 const dialogOpen = ref(false)
 const categories = ref<ExpenseCategoryDto[]>([])
+const categoryChartDialogOpen = ref(false)
+const categoryChartLoading = ref(false)
+const categoryChart = ref<ExpenseCategoryMonthlyExpensesDto | null>(null)
 
 const monthLabel = computed(() =>
   currentMonth.value.toLocaleString('default', { month: 'long', year: 'numeric' }),
@@ -32,6 +35,28 @@ const grouped = computed<Group[]>(() => {
     map.get(key)!.push(cat)
   }
   return Array.from(map.entries()).map(([groupName, items]) => ({ groupName, items }))
+})
+
+const categoryChartMaxAmount = computed(() => {
+  const chart = categoryChart.value
+  if (!chart) return 1
+
+  const maxMonthlyExpense = chart.months.reduce((max, month) => Math.max(max, month.amount), 0)
+  return Math.max(maxMonthlyExpense, chart.budgetedAmount, 1)
+})
+
+const budgetLinePercent = computed(() => {
+  const chart = categoryChart.value
+  if (!chart) return 0
+  return Math.min(100, (chart.budgetedAmount / categoryChartMaxAmount.value) * 100)
+})
+
+const budgetLineLabel = computed(() => {
+  const chart = categoryChart.value
+  if (!chart) return ''
+  return chart.usePercentage
+    ? `${chart.budgetedPercentage}% budget`
+    : `${formatCents(chart.budgetedAmount)} budget`
 })
 
 async function fetchBudget() {
@@ -73,6 +98,38 @@ function onDialogSuccess() {
   void fetchBudget()
   dialogOpen.value = false
 }
+
+function getBarHeightPercent(amount: number): number {
+  if (amount <= 0) return 0
+  return Math.max((amount / categoryChartMaxAmount.value) * 100, 2)
+}
+
+function formatChartMonth(month: string): string {
+  return parseMonth(month).toLocaleString('default', { month: 'short' })
+}
+
+function formatChartTooltip(month: string, amount: number): string {
+  const date = parseMonth(month)
+  const label = date.toLocaleString('default', { month: 'long', year: 'numeric' })
+  return `${label}: ${formatCents(amount)}`
+}
+
+async function openCategoryChart(category: BudgetCategoryDto) {
+  categoryChartDialogOpen.value = true
+  categoryChartLoading.value = true
+  categoryChart.value = null
+
+  try {
+    const month = formatMonth(currentMonth.value)
+    categoryChart.value = await apiClient.get<ExpenseCategoryMonthlyExpensesDto>(
+      `/api/expense-categories/${category.id}/monthly-expenses?month=${month}-01&months=12`,
+    )
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load category chart', { variant: 'error' })
+  } finally {
+    categoryChartLoading.value = false
+  }
+}
 </script>
 
 <template>
@@ -98,7 +155,12 @@ function onDialogSuccess() {
           </v-expansion-panel-title>
           <v-expansion-panel-text class="pa-0">
             <v-list density="compact">
-              <v-list-item v-for="cat in group.items" :key="cat.id" class="border-b">
+              <v-list-item
+                v-for="cat in group.items"
+                :key="cat.id"
+                class="border-b category-clickable-row"
+                @click="openCategoryChart(cat)"
+              >
                 <v-list-item-title>{{ cat.name ?? '(unnamed)' }}</v-list-item-title>
                 <v-list-item-subtitle>
                   <div class="d-flex flex-wrap mt-1" style="gap: 4px;">
@@ -110,6 +172,9 @@ function onDialogSuccess() {
                     <v-chip size="small" variant="outlined">12mo avg: {{ formatCents(cat.twelveMonthAverage) }}</v-chip>
                   </div>
                 </v-list-item-subtitle>
+                <template #append>
+                  <v-icon icon="mdi-chart-bar" />
+                </template>
               </v-list-item>
             </v-list>
           </v-expansion-panel-text>
@@ -130,5 +195,110 @@ function onDialogSuccess() {
       :categories="categories"
       @success="onDialogSuccess"
     />
+
+    <v-dialog v-model="categoryChartDialogOpen" max-width="980">
+      <v-card>
+        <v-card-title>{{ categoryChart?.name ?? 'Category' }} spending (last 12 months)</v-card-title>
+        <v-card-text>
+          <div v-if="categoryChartLoading" class="d-flex justify-center pa-8">
+            <v-progress-circular indeterminate aria-label="Loading category chart" />
+          </div>
+          <div v-else-if="categoryChart">
+            <v-chip size="small" color="primary" variant="outlined" class="mb-3">
+              Budget line: {{ budgetLineLabel }}
+            </v-chip>
+            <div class="expense-chart">
+              <div class="expense-chart-budget-line" :style="{ bottom: `${budgetLinePercent}%` }">
+                <span class="expense-chart-budget-label">{{ budgetLineLabel }}</span>
+              </div>
+              <div class="expense-chart-bars">
+                <div
+                  v-for="point in categoryChart.months"
+                  :key="point.month"
+                  class="expense-chart-month"
+                  :title="formatChartTooltip(point.month, point.amount)"
+                >
+                  <div class="expense-chart-bar-wrapper">
+                    <div class="expense-chart-bar" :style="{ height: `${getBarHeightPercent(point.amount)}%` }" />
+                  </div>
+                  <span class="expense-chart-month-label">{{ formatChartMonth(point.month) }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="categoryChartDialogOpen = false">Close</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
+
+<style scoped>
+.category-clickable-row {
+  cursor: pointer;
+}
+
+.expense-chart {
+  position: relative;
+  height: 320px;
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  border-radius: 8px;
+  padding: 16px 12px 8px;
+  overflow: hidden;
+}
+
+.expense-chart-budget-line {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  border-top: 2px dashed rgb(var(--v-theme-error));
+  pointer-events: none;
+}
+
+.expense-chart-budget-label {
+  position: absolute;
+  right: 0;
+  transform: translateY(-100%);
+  color: rgb(var(--v-theme-error));
+  font-size: 0.75rem;
+  padding: 0 4px;
+  background-color: rgba(var(--v-theme-surface), 0.9);
+}
+
+.expense-chart-bars {
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 8px;
+  align-items: end;
+}
+
+.expense-chart-month {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.expense-chart-bar-wrapper {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: end;
+}
+
+.expense-chart-bar {
+  width: 100%;
+  border-radius: 4px 4px 0 0;
+  background-color: rgb(var(--v-theme-primary));
+}
+
+.expense-chart-month-label {
+  margin-top: 8px;
+  font-size: 0.75rem;
+  color: rgba(var(--v-theme-on-surface), 0.75);
+}
+</style>

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -38,6 +38,20 @@ export interface ExpenseCategoryDto {
   hasItems: boolean
 }
 
+export interface ExpenseCategoryMonthlyExpensePointDto {
+  month: string
+  amount: number
+}
+
+export interface ExpenseCategoryMonthlyExpensesDto {
+  expenseCategoryId: number
+  name: string | null
+  budgetedAmount: number
+  budgetedPercentage: number
+  usePercentage: boolean
+  months: ExpenseCategoryMonthlyExpensePointDto[]
+}
+
 export interface AccountDto {
   id: number
   name: string | null

--- a/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
+++ b/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
+using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
 
 namespace SimplyBudgetWeb.Controllers;
@@ -33,6 +34,69 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         var category = await context.ExpenseCategories.FindAsync(id);
         if (category is null) return NotFound();
         return ToDto(category, await context.HasItemsAsync(category));
+    }
+
+    [HttpGet("{id}/monthly-expenses")]
+    public async Task<ActionResult<ExpenseCategoryMonthlyExpensesDto>> GetMonthlyExpenses(
+        int id,
+        [FromQuery] DateTime? month,
+        [FromQuery] int months = 12)
+    {
+        if (months is < 1 or > 24)
+            return BadRequest("months must be between 1 and 24.");
+
+        var category = await context.ExpenseCategories.FindAsync(id);
+        if (category is null) return NotFound();
+
+        var monthDate = (month ?? DateTime.Today).StartOfMonth();
+        var rangeStart = monthDate.AddMonths(-(months - 1)).StartOfMonth();
+        var rangeEnd = monthDate.EndOfMonth();
+
+        var transferItemIds = await context.ExpenseCategoryItems
+            .Where(x => x.Date >= rangeStart && x.Date <= rangeEnd)
+            .Where(x => x.Details!.Count == 2 && x.Details.Sum(d => d.Amount) == 0)
+            .Select(x => x.ID)
+            .ToListAsync();
+
+        var monthlyExpenses = await context.ExpenseCategoryItemDetails
+            .Where(x => x.ExpenseCategoryId == id)
+            .Where(x => !x.IgnoreBudget && x.Amount < 0)
+            .Where(x => x.ExpenseCategoryItem!.Date >= rangeStart && x.ExpenseCategoryItem.Date <= rangeEnd)
+            .Where(x => !transferItemIds.Contains(x.ExpenseCategoryItemId))
+            .GroupBy(x => new
+            {
+                x.ExpenseCategoryItem!.Date.Year,
+                x.ExpenseCategoryItem.Date.Month,
+            })
+            .Select(g => new
+            {
+                g.Key.Year,
+                g.Key.Month,
+                Amount = g.Sum(x => -x.Amount),
+            })
+            .ToListAsync();
+
+        var monthlyTotals = monthlyExpenses.ToDictionary(
+            x => new DateTime(x.Year, x.Month, 1),
+            x => x.Amount);
+
+        var history = Enumerable.Range(0, months)
+            .Select(offset =>
+            {
+                var date = rangeStart.AddMonths(offset);
+                return new ExpenseCategoryMonthlyExpensePointDto(
+                    Month: date.ToString("yyyy-MM"),
+                    Amount: monthlyTotals.GetValueOrDefault(date, 0));
+            })
+            .ToArray();
+
+        return new ExpenseCategoryMonthlyExpensesDto(
+            ExpenseCategoryId: category.ID,
+            Name: category.Name,
+            BudgetedAmount: category.BudgetedAmount,
+            BudgetedPercentage: category.BudgetedPercentage,
+            UsePercentage: category.UsePercentage,
+            Months: history);
     }
 
     [HttpPost]
@@ -162,4 +226,18 @@ public record ExpenseCategoryRequest(
     int BudgetedPercentage,
     int? Cap,
     int? AccountId
+);
+
+public record ExpenseCategoryMonthlyExpensesDto(
+    int ExpenseCategoryId,
+    string? Name,
+    int BudgetedAmount,
+    int BudgetedPercentage,
+    bool UsePercentage,
+    ExpenseCategoryMonthlyExpensePointDto[] Months
+);
+
+public record ExpenseCategoryMonthlyExpensePointDto(
+    string Month,
+    int Amount
 );


### PR DESCRIPTION
## Why
The budget list shows only a single-month snapshot for each category. This change adds a quick way to inspect month-over-month spending and compare it to the category budget target.

## What changed
- Added `GET /api/expense-categories/{id}/monthly-expenses` to return monthly spending history for a category.
  - Supports selecting the ending month and number of months.
  - Excludes ignored-budget details and transfer transactions from spend totals.
  - Returns budget metadata needed for rendering a budget reference line.
- Updated the Budget page so clicking a category opens a dialog with:
  - a vertical 12-month bar chart (one bar per month), and
  - a horizontal budget line overlaid on the chart.
- Added new frontend DTO types for the category monthly expense response.
- Added controller coverage for the monthly expense aggregation behavior.

## Notes for reviewers
- The chart range is anchored to the currently selected budget month.
- Transfer exclusion is based on 2-line items that net to zero.

## Validation
- `dotnet test .\\SimplyBudgetWeb.Core.Tests\\SimplyBudgetWeb.Core.Tests.csproj --configuration Release`
- `pnpm run build` (in `SimplyBudgetWeb.Web`)