### PR TITLE
Show month-inclusive account balances on Expenses page

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/AccountsControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/AccountsControllerTests.cs
@@ -1,0 +1,75 @@
+using Moq.AutoMock;
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class AccountsControllerTests
+{
+    [Test]
+    public async Task GetAll_UsesSelectedMonthForCurrentAmount()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int accountId = await mocker.InDbScopeAsync(async context =>
+        {
+            var account = new Account
+            {
+                Name = "Checking",
+                ValidatedDate = new DateTime(2026, 1, 1),
+            };
+            context.Accounts.Add(account);
+            await context.SaveChangesAsync();
+
+            var category = new ExpenseCategory
+            {
+                Name = "Checking Category",
+                AccountID = account.ID,
+            };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.AddRange(
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 1, 10),
+                    Description = "January income",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = 1000,
+                            ExpenseCategoryId = category.ID,
+                        },
+                    ],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 3, 5),
+                    Description = "March expense",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = -300,
+                            ExpenseCategoryId = category.ID,
+                        },
+                    ],
+                });
+            await context.SaveChangesAsync();
+
+            return account.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new AccountsController(context);
+
+        var februaryAccounts = await controller.GetAll(new DateTime(2026, 2, 1));
+        var aprilAccounts = await controller.GetAll(new DateTime(2026, 4, 1));
+
+        await Assert.That(februaryAccounts.Single(x => x.Id == accountId).CurrentAmount).IsEqualTo(1000);
+        await Assert.That(aprilAccounts.Single(x => x.Id == accountId).CurrentAmount).IsEqualTo(700);
+    }
+}

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
-import type { HistoryItemDto, ExpenseCategoryDto } from '@/types'
+import type { HistoryItemDto, ExpenseCategoryDto, AccountDto } from '@/types'
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
@@ -14,7 +14,9 @@ const search = ref('')
 const categoryId = ref<number | null>(null)
 const items = ref<HistoryItemDto[]>([])
 const categories = ref<ExpenseCategoryDto[]>([])
+const accounts = ref<AccountDto[]>([])
 const loading = ref(false)
+const accountLoading = ref(false)
 const deleteItem = ref<HistoryItemDto | null>(null)
 const dialogOpen = ref(false)
 
@@ -45,6 +47,19 @@ async function fetchHistory() {
   }
 }
 
+async function fetchAccountBalances() {
+  accountLoading.value = true
+  try {
+    const month = `${formatMonth(currentMonth.value)}-01`
+    const params = new URLSearchParams({ month })
+    accounts.value = await apiClient.get<AccountDto[]>(`/api/accounts?${params}`) ?? []
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load account balances', { variant: 'error' })
+  } finally {
+    accountLoading.value = false
+  }
+}
+
 function prevMonth() {
   const d = currentMonth.value
   currentMonth.value = new Date(d.getFullYear(), d.getMonth() - 1, 1)
@@ -61,7 +76,7 @@ async function handleDelete() {
     await apiClient.delete(`/api/history/${deleteItem.value.id}`)
     snackbar.enqueueSnackbar('Transaction deleted', { variant: 'success' })
     deleteItem.value = null
-    void fetchHistory()
+    void Promise.all([fetchHistory(), fetchAccountBalances()])
   } catch {
     snackbar.enqueueSnackbar('Failed to delete transaction', { variant: 'error' })
   }
@@ -72,14 +87,16 @@ function totalForItem(item: HistoryItemDto) {
 }
 
 watch([currentMonth, search, categoryId], fetchHistory)
+watch(currentMonth, fetchAccountBalances)
 
 onMounted(() => {
   void fetchCategories()
   void fetchHistory()
+  void fetchAccountBalances()
 })
 
 function onDialogSuccess() {
-  void fetchHistory()
+  void Promise.all([fetchHistory(), fetchAccountBalances()])
   dialogOpen.value = false
 }
 </script>
@@ -105,6 +122,19 @@ function onDialogSuccess() {
         style="max-width: 200px;"
         hide-details
       />
+    </v-card>
+
+    <v-card class="pa-4 mb-4">
+      <div class="text-subtitle-2 mb-2">Account balances through {{ monthLabel }}</div>
+      <div v-if="accountLoading" class="d-flex justify-center py-2">
+        <v-progress-circular size="20" indeterminate aria-label="Loading account balances" />
+      </div>
+      <div v-else-if="accounts.length === 0" class="text-medium-emphasis">No accounts found.</div>
+      <div v-else class="d-flex flex-wrap" style="gap: 8px;">
+        <v-chip v-for="account in accounts" :key="account.id" size="small" variant="outlined">
+          {{ account.name ?? 'Unnamed account' }}: {{ formatCents(account.currentAmount) }}
+        </v-chip>
+      </div>
     </v-card>
 
     <div v-if="loading" class="d-flex justify-center pa-8">

--- a/SimplyBudgetWeb/Controllers/AccountsController.cs
+++ b/SimplyBudgetWeb/Controllers/AccountsController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
+using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
 
 namespace SimplyBudgetWeb.Controllers;
@@ -10,13 +11,16 @@ namespace SimplyBudgetWeb.Controllers;
 public class AccountsController(BudgetWebContext context) : ControllerBase
 {
     [HttpGet]
-    public async Task<AccountDto[]> GetAll()
+    public async Task<AccountDto[]> GetAll([FromQuery] DateTime? month)
     {
         var accounts = await context.Accounts.ToListAsync();
+        var monthEnd = month?.StartOfMonth().EndOfMonth();
         var dtos = new List<AccountDto>();
         foreach (var account in accounts)
         {
-            int currentAmount = await context.GetCurrentAmount(account.ID);
+            int currentAmount = monthEnd.HasValue
+                ? await GetCurrentAmountThroughMonthEnd(account.ID, monthEnd.Value)
+                : await context.GetCurrentAmount(account.ID);
             dtos.Add(ToDto(account, currentAmount));
         }
         return dtos.ToArray();
@@ -61,6 +65,22 @@ public class AccountsController(BudgetWebContext context) : ControllerBase
 
         int currentAmount = await context.GetCurrentAmount(account.ID);
         return Ok(ToDto(account, currentAmount));
+    }
+
+    private async Task<int> GetCurrentAmountThroughMonthEnd(int accountId, DateTime monthEnd)
+    {
+        var currentAmount = await context.ExpenseCategories
+            .Where(x => x.AccountID == accountId)
+            .Select(x => (int?)x.CurrentBalance)
+            .SumAsync() ?? 0;
+
+        var futureAmountAdjustments = await context.ExpenseCategoryItemDetails
+            .Where(x => x.ExpenseCategory!.AccountID == accountId)
+            .Where(x => x.ExpenseCategoryItem!.Date > monthEnd)
+            .Select(x => (int?)x.Amount)
+            .SumAsync() ?? 0;
+
+        return currentAmount - futureAmountAdjustments;
     }
 
     private static AccountDto ToDto(Account a, int currentAmount) => new(


### PR DESCRIPTION
## Why
On the Expenses page, it was hard to validate end-of-month statements because account totals were not visible in that context.

## What changed
- Added an account balances card on the Expenses page that shows each account's current amount for the selected month.
- Updated History page data loading to request `/api/accounts?month=YYYY-MM-01` and refresh balances when transactions are added or deleted.
- Extended `GET /api/accounts` with an optional `month` query parameter and month-end calculation logic that includes all transactions up to and including that month (and excludes later transactions).
- Added `AccountsControllerTests.GetAll_UsesSelectedMonthForCurrentAmount` to verify month cutoff behavior.

## Notes
- Existing Accounts page behavior is preserved: calls without `month` still return present current balances.