### PR TITLE
Persist month picker state per page

### DIFF
--- a/SimplyBudgetWeb.Web/package-lock.json
+++ b/SimplyBudgetWeb.Web/package-lock.json
@@ -14,7 +14,8 @@
         "pinia": "^4.0.2",
         "vue": "^3.5.41",
         "vue-router": "^5.2.0",
-        "vuetify": "^4.1.8"
+        "vuetify": "^4.1.8",
+        "workbox-window": "^7.4.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2125,7 +2126,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2544,7 +2544,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2558,7 +2557,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2572,7 +2570,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2586,7 +2583,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2600,7 +2596,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2614,7 +2609,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2628,7 +2622,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2642,7 +2635,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2656,7 +2648,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2670,7 +2661,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2684,7 +2674,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2698,7 +2687,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2712,7 +2700,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2726,7 +2713,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2740,7 +2726,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2754,7 +2739,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2768,7 +2752,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2782,7 +2765,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2796,7 +2778,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2810,7 +2791,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2824,7 +2804,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2838,7 +2817,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2852,7 +2830,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2866,7 +2843,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2880,7 +2856,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2951,7 +2926,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -8091,7 +8065,6 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
       "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-expiration": {
@@ -8207,7 +8180,6 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.1.tgz",
       "integrity": "sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "^2.0.2",

--- a/SimplyBudgetWeb.Web/src/composables/useMonthQueryParam.ts
+++ b/SimplyBudgetWeb.Web/src/composables/useMonthQueryParam.ts
@@ -2,19 +2,49 @@ import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { formatMonth, parseMonth } from '@/utils/currency'
 
+const MONTH_STORAGE_PREFIX = 'SimplyBudgetWebMonth'
+
+interface UseMonthQueryParamOptions {
+  storageKey?: string
+}
+
+function isValidYearMonth(value: unknown): value is string {
+  return typeof value === 'string' && /^\d{4}-\d{2}$/.test(value)
+}
+
 /**
  * Returns a reactive `currentMonth` ref that is kept in sync with the `month`
  * query parameter (`?month=YYYY-MM`). The URL is updated immediately on setup
  * so the address bar always reflects the active month, enabling deep linking
- * and full-page refresh.
+ * and full-page refresh. When a `storageKey` is provided, the selected month is
+ * also persisted per page.
  */
-export function useMonthQueryParam() {
+export function useMonthQueryParam(options: UseMonthQueryParamOptions = {}) {
   const route = useRoute()
   const router = useRouter()
+  const storageKey = options.storageKey
+    ? `${MONTH_STORAGE_PREFIX}:${options.storageKey}`
+    : null
+
+  function getStoredMonth(): Date | null {
+    if (!storageKey) return null
+    const stored = localStorage.getItem(storageKey)
+    if (!isValidYearMonth(stored)) return null
+    return parseMonth(stored)
+  }
+
+  function storeMonth(month: Date) {
+    if (!storageKey) return
+    localStorage.setItem(storageKey, formatMonth(month))
+  }
 
   function resolveMonth(): Date {
     const q = route.query.month
-    if (typeof q === 'string' && /^\d{4}-\d{2}$/.test(q)) return parseMonth(q)
+    if (isValidYearMonth(q)) return parseMonth(q)
+
+    const storedMonth = getStoredMonth()
+    if (storedMonth) return storedMonth
+
     const now = new Date()
     return new Date(now.getFullYear(), now.getMonth(), 1)
   }
@@ -24,8 +54,10 @@ export function useMonthQueryParam() {
   // Write the resolved month to the URL immediately so the address bar is in
   // sync even on first load when no query param was present.
   void router.replace({ query: { ...route.query, month: formatMonth(currentMonth.value) } })
+  storeMonth(currentMonth.value)
 
   watch(currentMonth, (month) => {
+    storeMonth(month)
     void router.replace({ query: { ...route.query, month: formatMonth(month) } })
   })
 

--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -9,7 +9,7 @@ import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 
 const snackbar = useSnackbarStore()
 
-const { currentMonth } = useMonthQueryParam()
+const { currentMonth } = useMonthQueryParam({ storageKey: 'budget' })
 const budget = ref<BudgetResponse | null>(null)
 const loading = ref(false)
 const dialogOpen = ref(false)

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -9,7 +9,7 @@ import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 
 const snackbar = useSnackbarStore()
 
-const { currentMonth } = useMonthQueryParam()
+const { currentMonth } = useMonthQueryParam({ storageKey: 'history' })
 const search = ref('')
 const categoryId = ref<number | null>(null)
 const items = ref<HistoryItemDto[]>([])

--- a/SimplyBudgetWeb.Web/src/pages/Import.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Import.vue
@@ -7,8 +7,9 @@ import type {
   ImportItemDto,
   ExpenseCategoryDto,
   BudgetDataExportPackageDto,
+  OldestPendingExpenseMonthDto,
 } from '@/types'
-import { formatCents } from '@/utils/currency'
+import { formatCents, formatMonth } from '@/utils/currency'
 
 const snackbar = useSnackbarStore()
 const router = useRouter()
@@ -67,6 +68,30 @@ function updateCategory(item: ImportItemDto, categoryId: number | null) {
   item.suggestedCategoryName = cat?.name ?? null
 }
 
+async function navigateToPendingExpenses() {
+  try {
+    const oldestPendingMonth = await apiClient.get<OldestPendingExpenseMonthDto>('/api/pending-expenses/oldest-month')
+    if (oldestPendingMonth?.month) {
+      const yearMonthMatch = oldestPendingMonth.month.match(/^(\d{4}-\d{2})/)
+      const oldestMonth = yearMonthMatch
+        ? yearMonthMatch[1]
+        : (() => {
+            const oldestDate = new Date(oldestPendingMonth.month)
+            return Number.isNaN(oldestDate.getTime()) ? null : formatMonth(oldestDate)
+          })()
+
+      if (oldestMonth) {
+        await router.push({ path: '/pending-expenses', query: { month: oldestMonth } })
+        return
+      }
+    }
+  } catch {
+    // If oldest month lookup fails, still navigate to pending expenses.
+  }
+
+  await router.push('/pending-expenses')
+}
+
 async function handleImport() {
   submitting.value = true
   try {
@@ -77,7 +102,7 @@ async function handleImport() {
     if (csvFileInput.value) {
       csvFileInput.value.value = ''
     }
-    await router.push('/pending-expenses')
+    await navigateToPendingExpenses()
   } catch {
     snackbar.enqueueSnackbar('Failed to save import', { variant: 'error' })
   } finally {

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -2,14 +2,14 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
-import type { PendingExpenseDto, AssigneeDto, ExpenseCategoryDto, OldestPendingExpenseMonthDto } from '@/types'
+import type { PendingExpenseDto, AssigneeDto, ExpenseCategoryDto } from '@/types'
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 import ConvertPendingExpenseDialog from '@/components/ConvertPendingExpenseDialog.vue'
 
 const snackbar = useSnackbarStore()
 
-const { currentMonth } = useMonthQueryParam()
+const { currentMonth } = useMonthQueryParam({ storageKey: 'pending-expenses' })
 const search = ref('')
 const assigneeId = ref<number | null>(null)
 const items = ref<PendingExpenseDto[]>([])
@@ -81,28 +81,6 @@ async function fetchPendingExpenses() {
     snackbar.enqueueSnackbar('Failed to load pending expenses', { variant: 'error' })
   } finally {
     loading.value = false
-  }
-}
-
-async function setDefaultMonthToOldestPendingTransaction() {
-  try {
-    const oldestPendingMonth = await apiClient.get<OldestPendingExpenseMonthDto>('/api/pending-expenses/oldest-month')
-    if (!oldestPendingMonth?.month) return false
-
-    const oldestDate = new Date(oldestPendingMonth.month)
-    const oldestMonth = new Date(oldestDate.getFullYear(), oldestDate.getMonth(), 1)
-    const current = currentMonth.value
-    const monthChanged =
-      oldestMonth.getFullYear() !== current.getFullYear() ||
-      oldestMonth.getMonth() !== current.getMonth()
-
-    if (monthChanged) {
-      currentMonth.value = oldestMonth
-    }
-
-    return monthChanged
-  } catch {
-    return false
   }
 }
 
@@ -207,13 +185,10 @@ function onConvertSuccess() {
 
 watch([currentMonth, search, assigneeId], fetchPendingExpenses)
 
-onMounted(async () => {
+onMounted(() => {
   void fetchAssignees()
   void fetchCategories()
-  const monthChanged = await setDefaultMonthToOldestPendingTransaction()
-  if (!monthChanged) {
-    void fetchPendingExpenses()
-  }
+  void fetchPendingExpenses()
 })
 </script>
 


### PR DESCRIPTION
Month navigation was resetting to the current month when moving between pages, which made returning to Budget, Expenses, or Pending Expenses lose context. This updates month handling so each page remembers its own last month while still honoring explicit deep links.

## What changed
- Extended `useMonthQueryParam` to support optional per-page persistence keys in `localStorage`.
- Added month resolution precedence: `?month=YYYY-MM` in the URL wins, then saved page month, then current month.
- Wired page-specific keys for:
  - Budget
  - Expenses (History)
  - Pending Expenses
- Removed Pending Expenses' normal-load auto-jump to oldest pending month so saved page state is preserved.
- Updated Import post-save navigation to fetch the oldest pending month and navigate to `/pending-expenses?month=YYYY-MM` when available, with fallback to `/pending-expenses`.

## Notes for reviewers
- The per-page storage design intentionally keeps month state independent across pages instead of sharing one global month.
- Import intentionally uses URL query navigation so this flow can override saved Pending Expenses state for that entry point.