### PR TITLE
Preserve exported category balances during data import

### DIFF
--- a/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
@@ -179,6 +179,15 @@ public static class BudgetDataPortabilityService
             context.ExpenseCategoryItemDetails.AddRange(importedDetails);
             await context.SaveChangesAsync(cancellationToken);
 
+            // Preserve exported category balances exactly. Some historical data sets
+            // cannot be reconstructed solely from item details, so rebuilding from
+            // details during import can drift from the source snapshot.
+            for (var i = 0; i < importedCategories.Count; i++)
+            {
+                importedCategories[i].CurrentBalance = categorySeed[i].CurrentBalance;
+            }
+            await context.SaveChangesAsync(cancellationToken);
+
             var importedRules = (exportPackage.Rules ?? [])
                 .OrderBy(x => x.Id)
                 .Select(x => new ExpenseCategoryRule

--- a/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
+++ b/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
@@ -85,8 +85,8 @@ public class BudgetDataPortabilityServiceTests
             ],
             Categories =
             [
-                new BudgetDataExportCategory(100, "Groceries", "Food", 10, 500_00, 0, 0, null, false),
-                new BudgetDataExportCategory(200, "Emergency Fund", "Savings", 20, 0, 10, 0, null, false)
+                new BudgetDataExportCategory(100, "Groceries", "Food", 10, 500_00, 0, 200_00, null, false),
+                new BudgetDataExportCategory(200, "Emergency Fund", "Savings", 20, 0, 10, 300_00, null, false)
             ],
             Items =
             [
@@ -129,8 +129,8 @@ public class BudgetDataPortabilityServiceTests
         var groceries = categories.Single(x => x.Name == "Groceries");
         var emergency = categories.Single(x => x.Name == "Emergency Fund");
 
-        Assert.AreEqual(1500_00, groceries.CurrentBalance);
-        Assert.AreEqual(1000_00, emergency.CurrentBalance);
+        Assert.AreEqual(200_00, groceries.CurrentBalance);
+        Assert.AreEqual(300_00, emergency.CurrentBalance);
 
         var rules = await assertContext.ExpenseCategoryRules
             .Include(x => x.ExpenseCategory)

--- a/SimplyBudgetWeb.Core.Tests/Controllers/DataPortabilityControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/DataPortabilityControllerTests.cs
@@ -125,8 +125,8 @@ public class DataPortabilityControllerTests
             ],
             Categories =
             [
-                new BudgetDataExportCategory(10, "Groceries", "Food", 1, 500_00, 0, 0, null, false),
-                new BudgetDataExportCategory(20, "Emergency Fund", "Savings", 2, 0, 10, 0, null, false)
+                new BudgetDataExportCategory(10, "Groceries", "Food", 1, 500_00, 0, 125_00, null, false),
+                new BudgetDataExportCategory(20, "Emergency Fund", "Savings", 2, 0, 10, 875_00, null, false)
             ],
             Items =
             [
@@ -183,9 +183,9 @@ public class DataPortabilityControllerTests
 
             var groceries = categories.Single(x => x.Name == "Groceries");
             var emergency = categories.Single(x => x.Name == "Emergency Fund");
-            if (groceries.CurrentBalance != 1_000_00 || emergency.CurrentBalance != 500_00)
+            if (groceries.CurrentBalance != 125_00 || emergency.CurrentBalance != 875_00)
             {
-                throw new Exception("Expected category balances to be rebuilt from imported item details.");
+                throw new Exception("Expected category balances to match imported export values.");
             }
 
             if (await context.ExpenseCategoryRules.CountAsync() != 1 ||


### PR DESCRIPTION
## Why
Importing a desktop export into the web app could produce incorrect category and account totals. The importer rebuilt `CurrentBalance` from `ItemDetails`, but historical exports can contain authoritative category balances that are not exactly reconstructable from detail rows.

## What changed
- Updated `BudgetDataPortabilityService.ImportAsync` to preserve each category's exported `CurrentBalance` after inserting item details.
- Kept the existing import mapping/relationship flow unchanged.
- Updated portability tests in shared and web test suites to assert imported balances match exported values instead of rebuilt detail sums.

## Notes
This intentionally prioritizes snapshot fidelity for cross-client import/export so totals remain consistent with the source export.