### PR TITLE
Sort expense categories alphabetically within budget groups

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -27,6 +27,10 @@ interface Group {
   items: BudgetCategoryDto[]
 }
 
+function compareCategoryName(a: BudgetCategoryDto, b: BudgetCategoryDto): number {
+  return (a.name ?? '').localeCompare(b.name ?? '', undefined, { sensitivity: 'base' })
+}
+
 const grouped = computed<Group[]>(() => {
   const map = new Map<string, BudgetCategoryDto[]>()
   for (const cat of budget.value?.categories ?? []) {
@@ -34,7 +38,10 @@ const grouped = computed<Group[]>(() => {
     if (!map.has(key)) map.set(key, [])
     map.get(key)!.push(cat)
   }
-  return Array.from(map.entries()).map(([groupName, items]) => ({ groupName, items }))
+  return Array.from(map.entries()).map(([groupName, items]) => ({
+    groupName,
+    items: [...items].sort(compareCategoryName),
+  }))
 })
 
 const categoryChartMaxAmount = computed(() => {


### PR DESCRIPTION
Budget groups currently preserve insertion order, which makes categories appear in a non-alphabetical order inside each group and harder to scan. This change makes category lists predictable by sorting them by name within each group.

## What changed
- Added a `compareCategoryName` helper in `Budget.vue` that uses case-insensitive `localeCompare` on category names.
- Updated the grouped-category projection to sort each group's `items` with that comparer before rendering.
- Kept existing grouping behavior unchanged (`categoryName` or `Uncategorized`).

## Notes
- This is a UI-only ordering change scoped to the budget page.
- Group membership and backend data are unchanged.