### PR TITLE
Compact month picker with quick month jump

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
@@ -13,24 +13,10 @@ public class ImportControllerTests
     private static string BuildCsv(string row) => StcuHeader + Environment.NewLine + row;
 
     [Test]
-    public async Task Parse_AppliesMatchingRuleSuggestion()
+    public async Task Parse_ParsesDebitAmountAndMarksItemCheckedWhenNotDuplicate()
     {
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
-
-        await mocker.InDbScopeAsync(async context =>
-        {
-            var category = new ExpenseCategory { Name = "Entertainment" };
-            context.ExpenseCategories.Add(category);
-            await context.SaveChangesAsync();
-            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
-            {
-                Name = "Google Play",
-                RuleRegex = "GOOGLE Play",
-                ExpenseCategoryID = category.ID
-            });
-            await context.SaveChangesAsync();
-        });
 
         using var context = mocker.Get<BudgetWebContext>();
         var controller = new ImportController(context);
@@ -42,11 +28,12 @@ public class ImportControllerTests
         await Assert.That(items!.Length).IsEqualTo(1);
         await Assert.That(items[0].Amount).IsEqualTo(21_77);
         await Assert.That(items[0].IsDebit).IsTrue();
-        await Assert.That(items[0].SuggestedCategoryName).IsEqualTo("Entertainment");
+        await Assert.That(items[0].IsChecked).IsTrue();
+        await Assert.That(items[0].IsDuplicate).IsFalse();
     }
 
     [Test]
-    public async Task Parse_WithNoMatchingRule_LeavesSuggestionNull()
+    public async Task Parse_ParsesCreditAmountAsPositive()
     {
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
@@ -61,7 +48,8 @@ public class ImportControllerTests
         await Assert.That(items!.Length).IsEqualTo(1);
         await Assert.That(items[0].IsDebit).IsFalse();
         await Assert.That(items[0].Amount).IsEqualTo(123456);
-        await Assert.That(items[0].SuggestedCategoryId).IsNull();
+        await Assert.That(items[0].IsChecked).IsTrue();
+        await Assert.That(items[0].IsDuplicate).IsFalse();
     }
 
     [Test]
@@ -75,6 +63,13 @@ public class ImportControllerTests
             var category = new ExpenseCategory { Name = "Groceries" };
             context.ExpenseCategories.Add(category);
             await context.SaveChangesAsync();
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Costco rule",
+                RuleRegex = "Costco",
+                ExpenseCategoryID = category.ID
+            });
+            await context.SaveChangesAsync();
             return category.ID;
         });
 
@@ -83,8 +78,8 @@ public class ImportControllerTests
 
         var items = new[]
         {
-            new ImportItemDto(new DateTime(2026, 1, 1), "Costco", 45_00, true, categoryId, "Groceries", IsChecked: true),
-            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, null, null, IsChecked: false),
+            new ImportItemDto(new DateTime(2026, 1, 1), "Costco", 45_00, true, true),
+            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, false),
         };
 
         var result = await controller.Save(items);
@@ -108,7 +103,7 @@ public class ImportControllerTests
 
         var items = new[]
         {
-            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, null, null, IsChecked: false),
+            new ImportItemDto(new DateTime(2026, 1, 2), "Already handled", 10_00, true, false),
         };
 
         await controller.Save(items);

--- a/SimplyBudgetWeb.Web/src/components/MonthPickerNav.vue
+++ b/SimplyBudgetWeb.Web/src/components/MonthPickerNav.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const props = defineProps<{
+  modelValue: Date
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: Date): void
+}>()
+
+interface MonthOption {
+  key: string
+  date: Date
+  label: string
+}
+
+const menuOpen = ref(false)
+
+const monthLabel = computed(() =>
+  props.modelValue.toLocaleString('default', { month: 'long', year: 'numeric' }),
+)
+
+const monthOptions = computed<MonthOption[]>(() => {
+  const today = new Date()
+  const firstMonth = new Date(today.getFullYear(), today.getMonth(), 1)
+
+  return Array.from({ length: 37 }, (_, monthOffset) => {
+    const date = new Date(firstMonth.getFullYear(), firstMonth.getMonth() - monthOffset, 1)
+    return {
+      key: `${date.getFullYear()}-${date.getMonth()}`,
+      date,
+      label: date.toLocaleString('default', { month: 'long', year: 'numeric' }),
+    }
+  })
+})
+
+function prevMonth() {
+  const date = props.modelValue
+  emit('update:modelValue', new Date(date.getFullYear(), date.getMonth() - 1, 1))
+}
+
+function nextMonth() {
+  const date = props.modelValue
+  emit('update:modelValue', new Date(date.getFullYear(), date.getMonth() + 1, 1))
+}
+
+function isSelectedMonth(optionDate: Date): boolean {
+  return (
+    props.modelValue.getFullYear() === optionDate.getFullYear()
+    && props.modelValue.getMonth() === optionDate.getMonth()
+  )
+}
+
+function selectMonth(optionDate: Date) {
+  emit('update:modelValue', new Date(optionDate.getFullYear(), optionDate.getMonth(), 1))
+  menuOpen.value = false
+}
+</script>
+
+<template>
+  <div class="month-picker-nav d-flex align-center">
+    <v-btn
+      variant="outlined"
+      size="small"
+      icon="mdi-chevron-left"
+      aria-label="Previous month"
+      @click="prevMonth"
+    />
+
+    <v-menu v-model="menuOpen" location="bottom center" offset="6">
+      <template #activator="{ props: activatorProps }">
+        <v-btn
+          v-bind="activatorProps"
+          variant="text"
+          size="small"
+          append-icon="mdi-menu-down"
+          class="month-picker-nav__label text-none"
+        >
+          {{ monthLabel }}
+        </v-btn>
+      </template>
+
+      <v-list density="compact" class="month-picker-nav__menu">
+        <v-list-item
+          v-for="option in monthOptions"
+          :key="option.key"
+          :active="isSelectedMonth(option.date)"
+          @click="selectMonth(option.date)"
+        >
+          <v-list-item-title>{{ option.label }}</v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+
+    <v-btn
+      variant="outlined"
+      size="small"
+      icon="mdi-chevron-right"
+      aria-label="Next month"
+      @click="nextMonth"
+    />
+  </div>
+</template>
+
+<style scoped>
+.month-picker-nav {
+  gap: 4px;
+}
+
+.month-picker-nav__label {
+  min-width: 0;
+  padding-inline: 4px;
+  white-space: nowrap;
+}
+
+.month-picker-nav__menu {
+  max-height: 280px;
+  overflow-y: auto;
+}
+</style>

--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -6,6 +6,7 @@ import type { BudgetResponse, BudgetCategoryDto, ExpenseCategoryDto, ExpenseCate
 import { formatCents, formatMonth, parseMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
+import MonthPickerNav from '@/components/MonthPickerNav.vue'
 
 const snackbar = useSnackbarStore()
 
@@ -17,10 +18,6 @@ const categories = ref<ExpenseCategoryDto[]>([])
 const categoryChartDialogOpen = ref(false)
 const categoryChartLoading = ref(false)
 const categoryChart = ref<ExpenseCategoryMonthlyExpensesDto | null>(null)
-
-const monthLabel = computed(() =>
-  currentMonth.value.toLocaleString('default', { month: 'long', year: 'numeric' }),
-)
 
 interface Group {
   groupName: string
@@ -84,16 +81,6 @@ async function fetchCategories() {
   } catch { /* ignore */ }
 }
 
-function prevMonth() {
-  const d = currentMonth.value
-  currentMonth.value = new Date(d.getFullYear(), d.getMonth() - 1, 1)
-}
-
-function nextMonth() {
-  const d = currentMonth.value
-  currentMonth.value = new Date(d.getFullYear(), d.getMonth() + 1, 1)
-}
-
 watch(currentMonth, fetchBudget)
 
 onMounted(() => {
@@ -141,11 +128,7 @@ async function openCategoryChart(category: BudgetCategoryDto) {
 
 <template>
   <div>
-    <div class="d-flex align-center mb-4" style="gap: 8px;">
-      <v-btn variant="outlined" size="small" prepend-icon="mdi-chevron-left" @click="prevMonth">Prev</v-btn>
-      <span class="text-h6" style="min-width: 160px; text-align: center;">{{ monthLabel }}</span>
-      <v-btn variant="outlined" size="small" append-icon="mdi-chevron-right" @click="nextMonth">Next</v-btn>
-    </div>
+    <MonthPickerNav v-model="currentMonth" class="mb-4" />
 
     <v-card v-if="budget" class="pa-4 mb-4">
       <div class="d-flex flex-wrap" style="gap: 16px;">

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -6,6 +6,7 @@ import type { HistoryItemDto, ExpenseCategoryDto, AccountDto } from '@/types'
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
+import MonthPickerNav from '@/components/MonthPickerNav.vue'
 
 const snackbar = useSnackbarStore()
 
@@ -60,16 +61,6 @@ async function fetchAccountBalances() {
   }
 }
 
-function prevMonth() {
-  const d = currentMonth.value
-  currentMonth.value = new Date(d.getFullYear(), d.getMonth() - 1, 1)
-}
-
-function nextMonth() {
-  const d = currentMonth.value
-  currentMonth.value = new Date(d.getFullYear(), d.getMonth() + 1, 1)
-}
-
 async function handleDelete() {
   if (!deleteItem.value) return
   try {
@@ -106,9 +97,7 @@ function onDialogSuccess() {
     <h5 class="text-h5 mb-4">Expenses</h5>
 
     <v-card class="pa-4 mb-4 d-flex flex-wrap align-center" style="gap: 16px;">
-      <v-btn variant="outlined" size="small" prepend-icon="mdi-chevron-left" @click="prevMonth">Prev</v-btn>
-      <span style="min-width: 140px; text-align: center;">{{ monthLabel }}</span>
-      <v-btn variant="outlined" size="small" append-icon="mdi-chevron-right" @click="nextMonth">Next</v-btn>
+      <MonthPickerNav v-model="currentMonth" />
 
       <v-text-field label="Search" v-model="search" density="compact" style="max-width: 200px;" hide-details />
 

--- a/SimplyBudgetWeb.Web/src/pages/Import.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Import.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type {
   ImportItemDto,
-  ExpenseCategoryDto,
   BudgetDataExportPackageDto,
   OldestPendingExpenseMonthDto,
 } from '@/types'
@@ -17,7 +16,6 @@ const router = useRouter()
 const csvFile = ref<File | null>(null)
 const csvFileInput = ref<HTMLInputElement | null>(null)
 const items = ref<ImportItemDto[]>([])
-const categories = ref<ExpenseCategoryDto[]>([])
 const loading = ref(false)
 const submitting = ref(false)
 const showDuplicates = ref(false)
@@ -35,12 +33,6 @@ const exportingData = ref(false)
 const importingData = ref(false)
 const importFile = ref<File | null>(null)
 const importFileInput = ref<HTMLInputElement | null>(null)
-
-async function fetchCategories() {
-  try {
-    categories.value = await apiClient.get<ExpenseCategoryDto[]>('/api/expense-categories') ?? []
-  } catch { /* ignore */ }
-}
 
 function onCsvFileSelected(event: Event) {
   const input = event.target as HTMLInputElement
@@ -60,12 +52,6 @@ async function handleParse() {
   } finally {
     loading.value = false
   }
-}
-
-function updateCategory(item: ImportItemDto, categoryId: number | null) {
-  const cat = categoryId !== null ? categories.value.find(c => c.id === categoryId) : undefined
-  item.suggestedCategoryId = categoryId
-  item.suggestedCategoryName = cat?.name ?? null
 }
 
 async function navigateToPendingExpenses() {
@@ -156,7 +142,6 @@ async function handleImportAllData() {
   }
 }
 
-onMounted(() => { void fetchCategories() })
 </script>
 
 <template>

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -6,6 +6,7 @@ import type { PendingExpenseDto, AssigneeDto, ExpenseCategoryDto } from '@/types
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 import ConvertPendingExpenseDialog from '@/components/ConvertPendingExpenseDialog.vue'
+import MonthPickerNav from '@/components/MonthPickerNav.vue'
 
 const snackbar = useSnackbarStore()
 
@@ -27,9 +28,6 @@ const noteDrafts = ref<Record<number, string>>({})
 // "All" plus the real filter options; used for both the toolbar filter and the
 // page-level assignee filter.
 const assigneeFilterOptions = computed(() => [{ id: null, name: 'All' }, ...assignees.value])
-const monthLabel = computed(() =>
-  currentMonth.value.toLocaleString('default', { month: 'long', year: 'numeric' }),
-)
 
 // Items are returned sorted oldest-first, so consecutive entries belong to the same
 // month unless this changes; used to show a divider between months in the list.
@@ -40,16 +38,6 @@ function monthGroupLabel(dateString: string) {
 function isNewMonth(index: number) {
   if (index === 0) return true
   return monthGroupLabel(items.value[index].date) !== monthGroupLabel(items.value[index - 1].date)
-}
-
-function prevMonth() {
-  const d = currentMonth.value
-  currentMonth.value = new Date(d.getFullYear(), d.getMonth() - 1, 1)
-}
-
-function nextMonth() {
-  const d = currentMonth.value
-  currentMonth.value = new Date(d.getFullYear(), d.getMonth() + 1, 1)
 }
 
 function buildFilters() {
@@ -197,9 +185,7 @@ onMounted(() => {
     <h5 class="text-h5 mb-4">Pending Expenses</h5>
 
     <v-card class="pa-4 mb-4 d-flex flex-wrap align-center" style="gap: 16px;">
-      <v-btn variant="outlined" size="small" prepend-icon="mdi-chevron-left" @click="prevMonth">Prev</v-btn>
-      <span style="min-width: 140px; text-align: center;">{{ monthLabel }}</span>
-      <v-btn variant="outlined" size="small" append-icon="mdi-chevron-right" @click="nextMonth">Next</v-btn>
+      <MonthPickerNav v-model="currentMonth" />
 
       <v-text-field label="Search" v-model="search" density="compact" style="max-width: 200px;" hide-details />
 


### PR DESCRIPTION
## Why
The month picker controls were using more horizontal space than needed on small screens, and jumping to an older month required repeated taps.

## What changed
- Added a reusable `MonthPickerNav` component.
- Replaced `Prev`/`Next` text buttons with icon-only chevron buttons.
- Made the middle month label clickable and backed it with a scrollable month list.
- Month list includes the current month and goes back 3 years.
- Tightened spacing between arrows and the month label to reduce horizontal footprint.
- Replaced the old month controls in:
  - `Budget.vue`
  - `History.vue`
  - `PendingExpenses.vue`

## Notes for reviewers
- Arrow navigation behavior is unchanged (still month-by-month).
- The dropdown is intentionally bounded to a 3-year history for fast jumping in common use.

## Verification
- `pnpm --dir .\SimplyBudgetWeb.Web exec eslint src/components/MonthPickerNav.vue src/pages/Budget.vue src/pages/History.vue src/pages/PendingExpenses.vue`
- `pnpm --dir .\SimplyBudgetWeb.Web build` still reports an existing unrelated TypeScript issue in `src/pages/Import.vue` (`TS6133: 'updateCategory' is declared but its value is never read`).