### PR TITLE
Add Amazon quick link to history and pending expense rows

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -5,6 +5,7 @@ import { useSnackbarStore } from '@/stores/snackbar'
 import type { HistoryItemDto, ExpenseCategoryDto, AccountDto } from '@/types'
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
+import { AMAZON_TRANSACTIONS_URL, hasAmazonInDescription } from '@/utils/merchantLinks'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
 
@@ -137,9 +138,20 @@ function onDialogSuccess() {
         <v-list-item>
           <v-list-item-title>
             <div class="d-flex justify-space-between align-center">
-              <span>
-                {{ new Date(item.date).toLocaleDateString() }} — {{ item.description }}
-                <v-chip v-if="item.isTransfer" size="small" class="ml-2">Transfer</v-chip>
+              <span class="d-flex align-center flex-wrap" style="gap: 6px;">
+                <span>{{ new Date(item.date).toLocaleDateString() }} — {{ item.description }}</span>
+                <v-chip v-if="item.isTransfer" size="small">Transfer</v-chip>
+                <v-btn
+                  v-if="hasAmazonInDescription(item.description)"
+                  icon="mdi-open-in-new"
+                  variant="text"
+                  size="x-small"
+                  color="primary"
+                  :href="AMAZON_TRANSACTIONS_URL"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Open Amazon transactions page"
+                />
               </span>
               <span class="font-weight-bold">{{ formatCents(totalForItem(item)) }}</span>
             </div>

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -5,6 +5,7 @@ import { useSnackbarStore } from '@/stores/snackbar'
 import type { PendingExpenseDto, AssigneeDto, ExpenseCategoryDto } from '@/types'
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
+import { AMAZON_TRANSACTIONS_URL, hasAmazonInDescription } from '@/utils/merchantLinks'
 import ConvertPendingExpenseDialog from '@/components/ConvertPendingExpenseDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
 
@@ -268,6 +269,18 @@ onMounted(() => {
                     aria-label="Edit pending expense note"
                     :disabled="isEditingNote(item.id)"
                     @click.stop="startEditingNote(item)"
+                  />
+                  <v-btn
+                    v-if="hasAmazonInDescription(item.description)"
+                    icon="mdi-open-in-new"
+                    variant="text"
+                    size="x-small"
+                    color="primary"
+                    :href="AMAZON_TRANSACTIONS_URL"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Open Amazon transactions page"
+                    @click.stop
                   />
                   <span
                     class="font-weight-bold"

--- a/SimplyBudgetWeb.Web/src/utils/merchantLinks.ts
+++ b/SimplyBudgetWeb.Web/src/utils/merchantLinks.ts
@@ -1,0 +1,8 @@
+const amazonWordRegex = /\bamazon\b/i
+
+export const AMAZON_TRANSACTIONS_URL = 'https://www.amazon.com/cpe/yourpayments/transactions'
+
+export function hasAmazonInDescription(description: string | null | undefined): boolean {
+  if (!description) return false
+  return amazonWordRegex.test(description)
+}


### PR DESCRIPTION
## Why
Finding a matching Amazon charge currently requires manually navigating to Amazon's payment history. This adds a direct shortcut only on relevant entries so that lookup is faster during reconciliation.

## What changed
- Added a shared helper in `src/utils/merchantLinks.ts` with:
  - `AMAZON_TRANSACTIONS_URL`
  - `hasAmazonInDescription(...)` (case-insensitive whole-word match)
- Updated `History.vue` to show an external-link icon button when a transaction description contains `Amazon`.
- Updated `PendingExpenses.vue` to show the same button for matching pending expenses.
- The button opens `https://www.amazon.com/cpe/yourpayments/transactions` in a new tab.
- On pending expenses, the button click stops propagation so existing row click behavior is unchanged.