### PR TITLE
Consolidate accounts into Settings with collapsible sections

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/CurrentUserControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/CurrentUserControllerTests.cs
@@ -1,0 +1,121 @@
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class CurrentUserControllerTests
+{
+    private static ClaimsPrincipal MakeUser(string objectId)
+    {
+        var identity = new ClaimsIdentity([new Claim("oid", objectId)], "TestAuth");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static CurrentUserController CreateController(BudgetWebContext context, ClaimsPrincipal user)
+    {
+        var controller = new CurrentUserController(context)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = user,
+                },
+            },
+        };
+
+        return controller;
+    }
+
+    [Test]
+    public async Task Get_ReturnsCurrentUser()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenseAssignees.Add(new PendingExpenseAssignee
+            {
+                Name = "Jordan",
+                ObjectId = "user-oid-1",
+                Email = "jordan@example.com",
+            });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = CreateController(context, MakeUser("user-oid-1"));
+
+        var result = await controller.Get();
+
+        var dto = result.Value ?? ((OkObjectResult)result.Result!).Value as CurrentUserDto;
+        await Assert.That(dto).IsNotNull();
+        await Assert.That(dto!.DisplayName).IsEqualTo("Jordan");
+        await Assert.That(dto.Email).IsEqualTo("jordan@example.com");
+    }
+
+    [Test]
+    public async Task UpdateDisplayName_PersistsNameAndMarksAsCustomized()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenseAssignees.Add(new PendingExpenseAssignee
+            {
+                Name = "Jordan",
+                ObjectId = "user-oid-1",
+                IsNameCustomized = false,
+            });
+            await context.SaveChangesAsync();
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = CreateController(context, MakeUser("user-oid-1"));
+            var result = await controller.UpdateDisplayName(new CurrentUserDisplayNameRequest("  Jordan S.  "));
+
+            var dto = result.Value ?? ((OkObjectResult)result.Result!).Value as CurrentUserDto;
+            await Assert.That(dto).IsNotNull();
+            await Assert.That(dto!.DisplayName).IsEqualTo("Jordan S.");
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var assignee = await context.PendingExpenseAssignees.SingleAsync(x => x.ObjectId == "user-oid-1");
+            await Assert.That(assignee.Name).IsEqualTo("Jordan S.");
+            await Assert.That(assignee.IsNameCustomized).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task UpdateDisplayName_WithBlankName_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenseAssignees.Add(new PendingExpenseAssignee
+            {
+                Name = "Jordan",
+                ObjectId = "user-oid-1",
+            });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = CreateController(context, MakeUser("user-oid-1"));
+
+        var result = await controller.UpdateDisplayName(new CurrentUserDisplayNameRequest("   "));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+    }
+}

--- a/SimplyBudgetWeb.Core.Tests/Services/CurrentUserSyncServiceTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Services/CurrentUserSyncServiceTests.cs
@@ -65,6 +65,29 @@ public class CurrentUserSyncServiceTests
     }
 
     [Test]
+    public async Task SyncAsync_DoesNotOverrideCustomizedName()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var service = new CurrentUserSyncService(context);
+
+        await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan", preferredUsername: "jordan@example.com"));
+
+        var assignee = await context.PendingExpenseAssignees.SingleAsync();
+        assignee.Name = "Custom Jordan";
+        assignee.IsNameCustomized = true;
+        await context.SaveChangesAsync();
+
+        await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan Smith", preferredUsername: "jordan.smith@example.com"));
+
+        var updatedAssignee = await context.PendingExpenseAssignees.SingleAsync();
+        await Assert.That(updatedAssignee.Name).IsEqualTo("Custom Jordan");
+        await Assert.That(updatedAssignee.Email).IsEqualTo("jordan.smith@example.com");
+    }
+
+    [Test]
     public async Task SyncAsync_IgnoresUser_WithoutObjectId()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Core.Tests/Services/CurrentUserSyncServiceTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Services/CurrentUserSyncServiceTests.cs
@@ -27,7 +27,7 @@ public class CurrentUserSyncServiceTests
 
         await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan", preferredUsername: "jordan@example.com"));
 
-        var assignee = await context.PendingExpenseAssignees.SingleAsync();
+        var assignee = await context.PendingExpenseAssignees.AsTracking().SingleAsync();
         await Assert.That(assignee.ObjectId).IsEqualTo("user-oid-1");
         await Assert.That(assignee.Name).IsEqualTo("Jordan");
         await Assert.That(assignee.Email).IsEqualTo("jordan@example.com");
@@ -60,7 +60,7 @@ public class CurrentUserSyncServiceTests
         await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan"));
         await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan Smith"));
 
-        var assignee = await context.PendingExpenseAssignees.SingleAsync();
+        var assignee = await context.PendingExpenseAssignees.AsTracking().SingleAsync();
         await Assert.That(assignee.Name).IsEqualTo("Jordan Smith");
     }
 
@@ -75,7 +75,7 @@ public class CurrentUserSyncServiceTests
 
         await service.SyncAsync(MakeUser("user-oid-1", name: "Jordan", preferredUsername: "jordan@example.com"));
 
-        var assignee = await context.PendingExpenseAssignees.SingleAsync();
+        var assignee = await context.PendingExpenseAssignees.AsTracking().SingleAsync();
         assignee.Name = "Custom Jordan";
         assignee.IsNameCustomized = true;
         await context.SaveChangesAsync();

--- a/SimplyBudgetWeb.Data/Migrations/20260822070656_AddCustomizedAssigneeName.Designer.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260822070656_AddCustomizedAssigneeName.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetWeb.Data;
 
@@ -11,9 +12,11 @@ using SimplyBudgetWeb.Data;
 namespace SimplyBudgetWeb.Data.Migrations
 {
     [DbContext(typeof(BudgetWebContext))]
-    partial class BudgetWebContextModelSnapshot : ModelSnapshot
+    [Migration("20260822070656_AddCustomizedAssigneeName")]
+    partial class AddCustomizedAssigneeName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SimplyBudgetWeb.Data/Migrations/20260822070656_AddCustomizedAssigneeName.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260822070656_AddCustomizedAssigneeName.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetWeb.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCustomizedAssigneeName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsNameCustomized",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsNameCustomized",
+                schema: "SimplyBudget",
+                table: "PendingExpenseAssignee");
+        }
+    }
+}

--- a/SimplyBudgetWeb.Data/PendingExpenseAssignee.cs
+++ b/SimplyBudgetWeb.Data/PendingExpenseAssignee.cs
@@ -15,6 +15,13 @@ public class PendingExpenseAssignee : BaseItem
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// Indicates whether <see cref="Name"/> was explicitly customized by the user in Settings.
+    /// When true, login-time profile sync keeps the custom name instead of replacing it with the
+    /// identity-provider claim value.
+    /// </summary>
+    public bool IsNameCustomized { get; set; }
+
+    /// <summary>
     /// The unique object ID (Entra ID "oid" claim) of the signed-in user this row was created
     /// for. Used to match a returning user regardless of display name changes.
     /// </summary>

--- a/SimplyBudgetWeb.Web/src/components/Layout.vue
+++ b/SimplyBudgetWeb.Web/src/components/Layout.vue
@@ -16,7 +16,6 @@ const navItems = [
   { title: 'Budget', to: '/budget', icon: 'mdi-cash-multiple' },
   { title: 'Expenses', to: '/history', icon: 'mdi-history' },
   { title: 'Pending Expenses', to: '/pending-expenses', icon: 'mdi-receipt-text-clock' },
-  { title: 'Accounts', to: '/accounts', icon: 'mdi-bank' },
   { title: 'Settings', to: '/settings', icon: 'mdi-cog' },
   { title: 'Import', to: '/import', icon: 'mdi-file-import' },
 ]
@@ -48,7 +47,7 @@ function toggleTheme() {
     </v-btn>
 
     <template v-if="authStore.isAuthenticated">
-      <span v-if="authStore.account?.name" class="mx-2">{{ authStore.account.name }}</span>
+      <span v-if="authStore.displayName" class="mx-2">{{ authStore.displayName }}</span>
       <v-btn @click="authStore.logout()">Sign out</v-btn>
     </template>
     <v-btn v-else @click="authStore.login()">Sign in</v-btn>

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -1,20 +1,43 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
-import type { RuleDto, ExpenseCategoryDto } from '@/types'
+import { useAuthStore } from '@/stores/auth'
+import type { RuleDto, ExpenseCategoryDto, AccountDto, CurrentUserDto } from '@/types'
+import { formatCents } from '@/utils/currency'
 
 const snackbar = useSnackbarStore()
+const authStore = useAuthStore()
+
+const PANEL_PROFILE = 0
+const PANEL_ACCOUNTS = 1
+const PANEL_RULES = 2
+const PANEL_CATEGORIES = 3
+
+const openPanel = ref<number | undefined>(undefined)
+
+const profileLoaded = ref(false)
+const profileLoading = ref(false)
+const profileSaving = ref(false)
+const profileDisplayName = ref(authStore.displayName ?? authStore.account?.name ?? '')
+
+const accounts = ref<AccountDto[]>([])
+const accountsLoading = ref(false)
+const accountsLoaded = ref(false)
+const accountEditId = ref<number | null>(null)
+const accountEditName = ref('')
+const accountNewName = ref('')
+const accountAddOpen = ref(false)
 
 const rules = ref<RuleDto[]>([])
 const categories = ref<ExpenseCategoryDto[]>([])
-const loading = ref(false)
-const addOpen = ref(false)
+const rulesLoading = ref(false)
+const rulesLoaded = ref(false)
+const addRuleOpen = ref(false)
 const addTargetCategoryLabel = ref('')
 const deleteRule = ref<RuleDto | null>(null)
 const editRule = ref<RuleDto | null>(null)
-
-const form = ref({ name: '', ruleRegex: '', expenseCategoryId: null as number | null })
+const ruleForm = ref({ name: '', ruleRegex: '', expenseCategoryId: null as number | null })
 
 const categoryOptions = computed(() => [{ id: null, name: 'None' }, ...categories.value])
 
@@ -31,12 +54,11 @@ const ruleGroups = computed<RuleGroup[]>(() => {
   const rulesByCategory = new Map<number | null, RuleDto[]>()
 
   for (const rule of rules.value) {
-    const key = rule.expenseCategoryId
-    const groupedRules = rulesByCategory.get(key)
+    const groupedRules = rulesByCategory.get(rule.expenseCategoryId)
     if (groupedRules) {
       groupedRules.push(rule)
     } else {
-      rulesByCategory.set(key, [rule])
+      rulesByCategory.set(rule.expenseCategoryId, [rule])
     }
   }
 
@@ -70,13 +92,194 @@ const ruleGroups = computed<RuleGroup[]>(() => {
   return groups
 })
 
-// Expense category management (rename / hide / delete)
-const manageCategories = ref<ExpenseCategoryDto[]>([])
+const categoriesLoaded = ref(false)
 const categoriesLoading = ref(false)
 const showHiddenCategories = ref(false)
+const manageCategories = ref<ExpenseCategoryDto[]>([])
 const editCategoryId = ref<number | null>(null)
 const editCategoryForm = ref({ name: '', categoryName: '' })
 const deleteCategory = ref<ExpenseCategoryDto | null>(null)
+
+async function fetchCurrentUserProfile() {
+  profileLoading.value = true
+  try {
+    const profile = await apiClient.get<CurrentUserDto>('/api/current-user')
+    profileDisplayName.value = profile.displayName ?? ''
+    authStore.setDisplayName(profile.displayName ?? null)
+    profileLoaded.value = true
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load profile', { variant: 'error' })
+  } finally {
+    profileLoading.value = false
+  }
+}
+
+async function handleSaveDisplayName() {
+  const displayName = profileDisplayName.value.trim()
+  if (!displayName) {
+    snackbar.enqueueSnackbar('Display name is required', { variant: 'error' })
+    return
+  }
+
+  profileSaving.value = true
+  try {
+    const profile = await apiClient.put<CurrentUserDto>('/api/current-user/display-name', { displayName })
+    profileDisplayName.value = profile.displayName ?? displayName
+    authStore.setDisplayName(profile.displayName ?? displayName)
+    snackbar.enqueueSnackbar('Display name updated', { variant: 'success' })
+  } catch {
+    snackbar.enqueueSnackbar('Failed to update display name', { variant: 'error' })
+  } finally {
+    profileSaving.value = false
+  }
+}
+
+async function fetchAccounts() {
+  accountsLoading.value = true
+  try {
+    accounts.value = await apiClient.get<AccountDto[]>('/api/accounts') ?? []
+    accountsLoaded.value = true
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load accounts', { variant: 'error' })
+  } finally {
+    accountsLoading.value = false
+  }
+}
+
+function startEditAccount(account: AccountDto) {
+  accountEditId.value = account.id
+  accountEditName.value = account.name ?? ''
+}
+
+async function handleSaveAccountEdit(id: number) {
+  const name = accountEditName.value.trim()
+  if (!name) {
+    snackbar.enqueueSnackbar('Account name is required', { variant: 'error' })
+    return
+  }
+
+  try {
+    await apiClient.put(`/api/accounts/${id}`, { name })
+    snackbar.enqueueSnackbar('Account updated', { variant: 'success' })
+    accountEditId.value = null
+    void fetchAccounts()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to update account', { variant: 'error' })
+  }
+}
+
+async function handleAddAccount() {
+  const name = accountNewName.value.trim()
+  if (!name) {
+    snackbar.enqueueSnackbar('Account name is required', { variant: 'error' })
+    return
+  }
+
+  try {
+    await apiClient.post('/api/accounts', { name })
+    snackbar.enqueueSnackbar('Account added', { variant: 'success' })
+    accountNewName.value = ''
+    accountAddOpen.value = false
+    void fetchAccounts()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to add account', { variant: 'error' })
+  }
+}
+
+async function handleSetDefaultAccount(id: number) {
+  try {
+    await apiClient.post(`/api/accounts/${id}/set-default`)
+    snackbar.enqueueSnackbar('Default account updated', { variant: 'success' })
+    void fetchAccounts()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to set default', { variant: 'error' })
+  }
+}
+
+async function fetchRules() {
+  rulesLoading.value = true
+  try {
+    rules.value = await apiClient.get<RuleDto[]>('/api/rules') ?? []
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load rules', { variant: 'error' })
+  } finally {
+    rulesLoading.value = false
+  }
+}
+
+async function fetchRuleCategories() {
+  try {
+    categories.value = await apiClient.get<ExpenseCategoryDto[]>('/api/expense-categories') ?? []
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load categories for rules', { variant: 'error' })
+  }
+}
+
+function resetRuleForm() {
+  ruleForm.value = { name: '', ruleRegex: '', expenseCategoryId: null }
+}
+
+function openAddRuleForCategory(expenseCategoryId: number | null, categoryLabel: string) {
+  resetRuleForm()
+  ruleForm.value.expenseCategoryId = expenseCategoryId
+  addTargetCategoryLabel.value = categoryLabel
+  addRuleOpen.value = true
+}
+
+function openEditRule(rule: RuleDto) {
+  editRule.value = rule
+  ruleForm.value = {
+    name: rule.name ?? '',
+    ruleRegex: rule.ruleRegex ?? '',
+    expenseCategoryId: rule.expenseCategoryId ?? null,
+  }
+}
+
+async function handleAddRule() {
+  try {
+    await apiClient.post('/api/rules', {
+      name: ruleForm.value.name,
+      ruleRegex: ruleForm.value.ruleRegex,
+      expenseCategoryId: ruleForm.value.expenseCategoryId,
+    })
+    snackbar.enqueueSnackbar('Rule added', { variant: 'success' })
+    addRuleOpen.value = false
+    resetRuleForm()
+    addTargetCategoryLabel.value = ''
+    void fetchRules()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to add rule', { variant: 'error' })
+  }
+}
+
+async function handleEditRule() {
+  if (!editRule.value) return
+  try {
+    await apiClient.put(`/api/rules/${editRule.value.id}`, {
+      name: ruleForm.value.name,
+      ruleRegex: ruleForm.value.ruleRegex,
+      expenseCategoryId: ruleForm.value.expenseCategoryId,
+    })
+    snackbar.enqueueSnackbar('Rule updated', { variant: 'success' })
+    editRule.value = null
+    resetRuleForm()
+    void Promise.all([fetchRules(), fetchRuleCategories()])
+  } catch {
+    snackbar.enqueueSnackbar('Failed to update rule', { variant: 'error' })
+  }
+}
+
+async function handleDeleteRule() {
+  if (!deleteRule.value) return
+  try {
+    await apiClient.delete(`/api/rules/${deleteRule.value.id}`)
+    snackbar.enqueueSnackbar('Rule deleted', { variant: 'success' })
+    deleteRule.value = null
+    void fetchRules()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to delete rule', { variant: 'error' })
+  }
+}
 
 async function fetchManageCategories() {
   categoriesLoading.value = true
@@ -84,6 +287,7 @@ async function fetchManageCategories() {
     manageCategories.value = await apiClient.get<ExpenseCategoryDto[]>(
       `/api/expense-categories?includeHidden=${showHiddenCategories.value}`,
     ) ?? []
+    categoriesLoaded.value = true
   } catch {
     snackbar.enqueueSnackbar('Failed to load expense categories', { variant: 'error' })
   } finally {
@@ -142,162 +346,300 @@ async function handleDeleteCategory() {
   }
 }
 
-watch(showHiddenCategories, () => void fetchManageCategories())
-
-async function fetchRules() {
-  loading.value = true
-  try {
-    rules.value = await apiClient.get<RuleDto[]>('/api/rules') ?? []
-  } catch {
-    snackbar.enqueueSnackbar('Failed to load rules', { variant: 'error' })
-  } finally {
-    loading.value = false
+watch(showHiddenCategories, () => {
+  if (categoriesLoaded.value) {
+    void fetchManageCategories()
   }
-}
+})
 
-async function fetchCategories() {
-  try {
-    categories.value = await apiClient.get<ExpenseCategoryDto[]>('/api/expense-categories') ?? []
-  } catch { /* ignore */ }
-}
-
-function resetForm() {
-  form.value = { name: '', ruleRegex: '', expenseCategoryId: null }
-}
-
-async function handleAdd() {
-  try {
-    await apiClient.post('/api/rules', {
-      name: form.value.name,
-      ruleRegex: form.value.ruleRegex,
-      expenseCategoryId: form.value.expenseCategoryId,
-    })
-    snackbar.enqueueSnackbar('Rule added', { variant: 'success' })
-    addOpen.value = false
-    void fetchRules()
-  } catch {
-    snackbar.enqueueSnackbar('Failed to add rule', { variant: 'error' })
-  }
-}
-
-async function handleEdit() {
-  if (!editRule.value) return
-  try {
-    await apiClient.put(`/api/rules/${editRule.value.id}`, {
-      name: form.value.name,
-      ruleRegex: form.value.ruleRegex,
-      expenseCategoryId: form.value.expenseCategoryId,
-    })
-    snackbar.enqueueSnackbar('Rule updated', { variant: 'success' })
-    editRule.value = null
-    resetForm()
-    void fetchRules()
-  } catch {
-    snackbar.enqueueSnackbar('Failed to update rule', { variant: 'error' })
-  }
-}
-
-async function handleDelete() {
-  if (!deleteRule.value) return
-  try {
-    await apiClient.delete(`/api/rules/${deleteRule.value.id}`)
-    snackbar.enqueueSnackbar('Rule deleted', { variant: 'success' })
-    deleteRule.value = null
-    void fetchRules()
-  } catch {
-    snackbar.enqueueSnackbar('Failed to delete rule', { variant: 'error' })
-  }
-}
-
-function openEdit(rule: RuleDto) {
-  editRule.value = rule
-  form.value = {
-    name: rule.name ?? '',
-    ruleRegex: rule.ruleRegex ?? '',
-    expenseCategoryId: rule.expenseCategoryId ?? null,
-  }
-}
-
-function openAddForCategory(expenseCategoryId: number | null, categoryLabel: string) {
-  resetForm()
-  form.value.expenseCategoryId = expenseCategoryId
-  addTargetCategoryLabel.value = categoryLabel
-  addOpen.value = true
-}
-
-function closeAdd() {
-  addOpen.value = false
-}
-
-watch(addOpen, (isOpen) => {
+watch(addRuleOpen, (isOpen) => {
   if (!isOpen) {
-    resetForm()
+    resetRuleForm()
     addTargetCategoryLabel.value = ''
   }
 })
 
-onMounted(() => {
-  void fetchRules()
-  void fetchCategories()
-  void fetchManageCategories()
+watch(openPanel, (panel) => {
+  if (panel === PANEL_PROFILE && !profileLoaded.value) {
+    void fetchCurrentUserProfile()
+    return
+  }
+
+  if (panel === PANEL_ACCOUNTS && !accountsLoaded.value) {
+    void fetchAccounts()
+    return
+  }
+
+  if (panel === PANEL_RULES && !rulesLoaded.value) {
+    rulesLoaded.value = true
+    void Promise.all([fetchRules(), fetchRuleCategories()])
+    return
+  }
+
+  if (panel === PANEL_CATEGORIES && !categoriesLoaded.value) {
+    void fetchManageCategories()
+  }
 })
 </script>
 
 <template>
   <div>
-    <h5 class="text-h5 mb-4">Import Rules</h5>
+    <h4 class="text-h4 mb-4">Settings</h4>
 
-    <div v-if="loading" class="d-flex justify-center pa-8">
-      <v-progress-circular indeterminate aria-label="Loading import rules" />
-    </div>
-    <div v-else>
-      <v-card
-        v-for="group in ruleGroups"
-        :key="group.key"
-        class="mb-4"
-      >
-        <v-card-title class="d-flex justify-space-between align-center">
-          <span>{{ group.label }}</span>
-          <v-btn
-            size="small"
-            color="primary"
-            @click="openAddForCategory(group.expenseCategoryId, group.label)"
-          >
-            Add Rule
-          </v-btn>
-        </v-card-title>
-        <v-divider />
-        <v-list>
-          <v-list-item v-if="group.rules.length === 0">
-            <v-list-item-title>No rules in this category.</v-list-item-title>
-          </v-list-item>
-          <v-list-item v-for="rule in group.rules" :key="rule.id">
-            <v-list-item-title>{{ rule.name }}</v-list-item-title>
-            <v-list-item-subtitle>Pattern: {{ rule.ruleRegex ?? '—' }}</v-list-item-subtitle>
-            <template #append>
-              <div class="d-flex" style="gap: 4px;">
-                <v-btn icon="mdi-pencil" variant="text" aria-label="Edit rule" @click="openEdit(rule)" />
-                <v-btn icon="mdi-delete" variant="text" color="error" aria-label="Delete rule" @click="deleteRule = rule" />
-              </div>
-            </template>
-          </v-list-item>
-        </v-list>
+    <v-expansion-panels v-model="openPanel" variant="accordion">
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <div class="w-100">
+            <div class="text-subtitle-1 font-weight-medium">Profile</div>
+            <div class="text-body-2 text-medium-emphasis">Change how your name is shown in the app.</div>
+          </div>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <div v-if="profileLoading" class="d-flex justify-center pa-8">
+            <v-progress-circular indeterminate aria-label="Loading profile" />
+          </div>
+          <div v-else class="d-flex flex-column" style="gap: 12px; max-width: 420px;">
+            <v-text-field
+              v-model="profileDisplayName"
+              label="Display Name"
+              hint="Used in the header and assignee lists"
+              persistent-hint
+            />
+            <div>
+              <v-btn color="primary" :loading="profileSaving" @click="handleSaveDisplayName">Save Display Name</v-btn>
+            </div>
+          </div>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <div class="w-100 d-flex justify-space-between align-center">
+            <div>
+              <div class="text-subtitle-1 font-weight-medium">Accounts</div>
+              <div class="text-body-2 text-medium-emphasis">Add accounts, rename them, and choose the default.</div>
+            </div>
+            <v-chip size="small" variant="tonal">{{ accounts.length }}</v-chip>
+          </div>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <div class="d-flex justify-space-between align-center mb-4">
+            <h5 class="text-h5">Accounts</h5>
+            <v-btn color="primary" @click="accountAddOpen = true">Add Account</v-btn>
+          </div>
+
+          <div v-if="accountsLoading" class="d-flex justify-center pa-8">
+            <v-progress-circular indeterminate aria-label="Loading accounts" />
+          </div>
+          <v-list v-else>
+            <v-list-item v-if="accounts.length === 0">
+              <v-list-item-title>No accounts found.</v-list-item-title>
+            </v-list-item>
+            <v-card v-for="account in accounts" :key="account.id" class="mb-2">
+              <v-list-item>
+                <v-list-item-title>
+                  <div class="d-flex align-center" style="gap: 8px;">
+                    <v-text-field
+                      v-if="accountEditId === account.id"
+                      v-model="accountEditName"
+                      density="compact"
+                      hide-details
+                      autofocus
+                      style="max-width: 240px;"
+                      @keydown.enter="handleSaveAccountEdit(account.id)"
+                    />
+                    <span v-else>{{ account.name }}</span>
+                    <v-chip v-if="account.isDefault" size="small" color="primary">Default</v-chip>
+                  </div>
+                </v-list-item-title>
+                <v-list-item-subtitle>
+                  Balance: {{ formatCents(account.currentAmount) }} · Validated: {{ new Date(account.validatedDate).toLocaleDateString() }}
+                </v-list-item-subtitle>
+                <template #append>
+                  <div v-if="accountEditId === account.id" class="d-flex" style="gap: 4px;">
+                    <v-btn icon="mdi-content-save" color="primary" variant="text" aria-label="Save" @click="handleSaveAccountEdit(account.id)" />
+                    <v-btn icon="mdi-close" variant="text" aria-label="Cancel" @click="accountEditId = null" />
+                  </div>
+                  <div v-else class="d-flex align-center" style="gap: 4px;">
+                    <v-btn v-if="!account.isDefault" size="small" variant="text" @click="handleSetDefaultAccount(account.id)">Set Default</v-btn>
+                    <v-btn icon="mdi-pencil" variant="text" aria-label="Edit account name" @click="startEditAccount(account)" />
+                  </div>
+                </template>
+              </v-list-item>
+            </v-card>
+          </v-list>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <div class="w-100 d-flex justify-space-between align-center">
+            <div>
+              <div class="text-subtitle-1 font-weight-medium">Import Rules</div>
+              <div class="text-body-2 text-medium-emphasis">Control automatic category suggestions while importing.</div>
+            </div>
+            <v-chip size="small" variant="tonal">{{ rules.length }}</v-chip>
+          </div>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <div v-if="rulesLoading" class="d-flex justify-center pa-8">
+            <v-progress-circular indeterminate aria-label="Loading import rules" />
+          </div>
+          <div v-else>
+            <v-card v-for="group in ruleGroups" :key="group.key" class="mb-4">
+              <v-card-title class="d-flex justify-space-between align-center">
+                <span>{{ group.label }}</span>
+                <v-btn
+                  size="small"
+                  color="primary"
+                  @click="openAddRuleForCategory(group.expenseCategoryId, group.label)"
+                >
+                  Add Rule
+                </v-btn>
+              </v-card-title>
+              <v-divider />
+              <v-list>
+                <v-list-item v-if="group.rules.length === 0">
+                  <v-list-item-title>No rules in this category.</v-list-item-title>
+                </v-list-item>
+                <v-list-item v-for="rule in group.rules" :key="rule.id">
+                  <v-list-item-title>{{ rule.name }}</v-list-item-title>
+                  <v-list-item-subtitle>Pattern: {{ rule.ruleRegex ?? '—' }}</v-list-item-subtitle>
+                  <template #append>
+                    <div class="d-flex" style="gap: 4px;">
+                      <v-btn icon="mdi-pencil" variant="text" aria-label="Edit rule" @click="openEditRule(rule)" />
+                      <v-btn icon="mdi-delete" variant="text" color="error" aria-label="Delete rule" @click="deleteRule = rule" />
+                    </div>
+                  </template>
+                </v-list-item>
+              </v-list>
+            </v-card>
+            <v-alert v-if="rules.length === 0" type="info" variant="tonal">No rules defined yet.</v-alert>
+          </div>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <div class="w-100 d-flex justify-space-between align-center">
+            <div>
+              <div class="text-subtitle-1 font-weight-medium">Expense Categories</div>
+              <div class="text-body-2 text-medium-emphasis">Rename, hide, restore, or delete categories.</div>
+            </div>
+            <v-chip size="small" variant="tonal">{{ manageCategories.length }}</v-chip>
+          </div>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <div class="d-flex justify-space-between align-center mb-4">
+            <h5 class="text-h5">Expense Categories</h5>
+            <v-switch
+              v-model="showHiddenCategories"
+              label="Show hidden"
+              density="compact"
+              hide-details
+              color="primary"
+            />
+          </div>
+
+          <div v-if="categoriesLoading" class="d-flex justify-center pa-8">
+            <v-progress-circular indeterminate aria-label="Loading expense categories" />
+          </div>
+          <v-list v-else>
+            <v-list-item v-if="manageCategories.length === 0">
+              <v-list-item-title>No expense categories defined.</v-list-item-title>
+            </v-list-item>
+            <v-card v-for="category in manageCategories" :key="category.id" class="mb-2">
+              <v-list-item>
+                <v-list-item-title>
+                  <div v-if="editCategoryId === category.id" class="d-flex align-center" style="gap: 8px;">
+                    <v-text-field
+                      v-model="editCategoryForm.name"
+                      label="Name"
+                      density="compact"
+                      hide-details
+                      autofocus
+                      style="max-width: 220px;"
+                      @keydown.enter="handleSaveCategoryEdit(category)"
+                    />
+                    <v-text-field
+                      v-model="editCategoryForm.categoryName"
+                      label="Group"
+                      density="compact"
+                      hide-details
+                      style="max-width: 220px;"
+                      @keydown.enter="handleSaveCategoryEdit(category)"
+                    />
+                  </div>
+                  <div v-else class="d-flex align-center" style="gap: 8px;">
+                    <span>{{ category.name }}</span>
+                    <v-chip v-if="category.isHidden" size="small">Hidden</v-chip>
+                  </div>
+                </v-list-item-title>
+                <v-list-item-subtitle v-if="editCategoryId !== category.id">
+                  {{ category.categoryName ?? 'No group' }}
+                </v-list-item-subtitle>
+                <template #append>
+                  <div v-if="editCategoryId === category.id" class="d-flex" style="gap: 4px;">
+                    <v-btn icon="mdi-content-save" color="primary" variant="text" aria-label="Save" @click="handleSaveCategoryEdit(category)" />
+                    <v-btn icon="mdi-close" variant="text" aria-label="Cancel" @click="editCategoryId = null" />
+                  </div>
+                  <div v-else class="d-flex align-center" style="gap: 4px;">
+                    <v-btn icon="mdi-pencil" variant="text" aria-label="Rename category" @click="startEditCategory(category)" />
+                    <v-btn
+                      :icon="category.isHidden ? 'mdi-eye' : 'mdi-eye-off'"
+                      variant="text"
+                      :aria-label="category.isHidden ? 'Restore category' : 'Hide category'"
+                      @click="handleToggleHideCategory(category)"
+                    />
+                    <v-tooltip :text="category.hasItems ? 'Categories with items cannot be deleted' : 'Delete category'">
+                      <template #activator="{ props }">
+                        <span v-bind="props">
+                          <v-btn
+                            icon="mdi-delete"
+                            variant="text"
+                            color="error"
+                            :disabled="category.hasItems"
+                            aria-label="Delete category"
+                            @click="deleteCategory = category"
+                          />
+                        </span>
+                      </template>
+                    </v-tooltip>
+                  </div>
+                </template>
+              </v-list-item>
+            </v-card>
+          </v-list>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+    </v-expansion-panels>
+
+    <v-dialog v-model="accountAddOpen" max-width="480">
+      <v-card>
+        <v-card-title>Add Account</v-card-title>
+        <v-card-text>
+          <v-text-field label="Account Name" v-model="accountNewName" autofocus @keydown.enter="handleAddAccount" />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="accountAddOpen = false">Cancel</v-btn>
+          <v-btn color="primary" @click="handleAddAccount">Add</v-btn>
+        </v-card-actions>
       </v-card>
-      <v-alert v-if="rules.length === 0" type="info" variant="tonal">No rules defined yet.</v-alert>
-    </div>
+    </v-dialog>
 
-    <v-dialog :model-value="addOpen" max-width="500" @update:model-value="(val: boolean) => !val && closeAdd()">
+    <v-dialog v-model="addRuleOpen" max-width="500">
       <v-card>
         <v-card-title>Add Rule</v-card-title>
         <v-card-text class="d-flex flex-column" style="gap: 16px;">
-          <v-text-field label="Name" v-model="form.name" />
-          <v-text-field label="Regex Pattern" v-model="form.ruleRegex" />
+          <v-text-field label="Name" v-model="ruleForm.name" />
+          <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
           <v-text-field label="Target Category" :model-value="addTargetCategoryLabel" readonly />
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn @click="closeAdd">Cancel</v-btn>
-          <v-btn color="primary" @click="handleAdd">Add</v-btn>
+          <v-btn @click="addRuleOpen = false">Cancel</v-btn>
+          <v-btn color="primary" @click="handleAddRule">Add</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -306,14 +648,14 @@ onMounted(() => {
       <v-card>
         <v-card-title>Edit Rule</v-card-title>
         <v-card-text class="d-flex flex-column" style="gap: 16px;">
-          <v-text-field label="Name" v-model="form.name" />
-          <v-text-field label="Regex Pattern" v-model="form.ruleRegex" />
-          <v-select label="Category" :items="categoryOptions" item-title="name" item-value="id" v-model="form.expenseCategoryId" />
+          <v-text-field label="Name" v-model="ruleForm.name" />
+          <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
+          <v-select label="Category" :items="categoryOptions" item-title="name" item-value="id" v-model="ruleForm.expenseCategoryId" />
         </v-card-text>
         <v-card-actions>
           <v-spacer />
           <v-btn @click="editRule = null">Cancel</v-btn>
-          <v-btn color="primary" @click="handleEdit">Save</v-btn>
+          <v-btn color="primary" @click="handleEditRule">Save</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -325,93 +667,10 @@ onMounted(() => {
         <v-card-actions>
           <v-spacer />
           <v-btn @click="deleteRule = null">Cancel</v-btn>
-          <v-btn color="error" @click="handleDelete">Delete</v-btn>
+          <v-btn color="error" @click="handleDeleteRule">Delete</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
-
-    <v-divider class="my-6" />
-
-    <div class="d-flex justify-space-between align-center mb-4">
-      <h5 class="text-h5">Expense Categories</h5>
-      <v-switch
-        v-model="showHiddenCategories"
-        label="Show hidden"
-        density="compact"
-        hide-details
-        color="primary"
-      />
-    </div>
-
-    <div v-if="categoriesLoading" class="d-flex justify-center pa-8">
-      <v-progress-circular indeterminate aria-label="Loading expense categories" />
-    </div>
-    <v-list v-else>
-      <v-list-item v-if="manageCategories.length === 0">
-        <v-list-item-title>No expense categories defined.</v-list-item-title>
-      </v-list-item>
-      <v-card v-for="category in manageCategories" :key="category.id" class="mb-2">
-        <v-list-item>
-          <v-list-item-title>
-            <div v-if="editCategoryId === category.id" class="d-flex align-center" style="gap: 8px;">
-              <v-text-field
-                v-model="editCategoryForm.name"
-                label="Name"
-                density="compact"
-                hide-details
-                autofocus
-                style="max-width: 220px;"
-                @keydown.enter="handleSaveCategoryEdit(category)"
-              />
-              <v-text-field
-                v-model="editCategoryForm.categoryName"
-                label="Group"
-                density="compact"
-                hide-details
-                style="max-width: 220px;"
-                @keydown.enter="handleSaveCategoryEdit(category)"
-              />
-            </div>
-            <div v-else class="d-flex align-center" style="gap: 8px;">
-              <span>{{ category.name }}</span>
-              <v-chip v-if="category.isHidden" size="small">Hidden</v-chip>
-            </div>
-          </v-list-item-title>
-          <v-list-item-subtitle v-if="editCategoryId !== category.id">
-            {{ category.categoryName ?? 'No group' }}
-          </v-list-item-subtitle>
-          <template #append>
-            <div v-if="editCategoryId === category.id" class="d-flex" style="gap: 4px;">
-              <v-btn icon="mdi-content-save" color="primary" variant="text" aria-label="Save" @click="handleSaveCategoryEdit(category)" />
-              <v-btn icon="mdi-close" variant="text" aria-label="Cancel" @click="editCategoryId = null" />
-            </div>
-            <div v-else class="d-flex align-center" style="gap: 4px;">
-              <v-btn icon="mdi-pencil" variant="text" aria-label="Rename category" @click="startEditCategory(category)" />
-              <v-btn
-                :icon="category.isHidden ? 'mdi-eye' : 'mdi-eye-off'"
-                variant="text"
-                :aria-label="category.isHidden ? 'Restore category' : 'Hide category'"
-                @click="handleToggleHideCategory(category)"
-              />
-              <v-tooltip :text="category.hasItems ? 'Categories with items cannot be deleted' : 'Delete category'">
-                <template #activator="{ props }">
-                  <span v-bind="props">
-                    <v-btn
-                      icon="mdi-delete"
-                      variant="text"
-                      color="error"
-                      :disabled="category.hasItems"
-                      aria-label="Delete category"
-                      @click="deleteCategory = category"
-                    />
-                  </span>
-                </template>
-              </v-tooltip>
-            </div>
-          </template>
-        </v-list-item>
-      </v-card>
-    </v-list>
 
     <v-dialog :model-value="!!deleteCategory" max-width="480" @update:model-value="(val: boolean) => !val && (deleteCategory = null)">
       <v-card>

--- a/SimplyBudgetWeb.Web/src/router/index.ts
+++ b/SimplyBudgetWeb.Web/src/router/index.ts
@@ -3,7 +3,6 @@ import Layout from '@/components/Layout.vue'
 import Login from '@/pages/Login.vue'
 import Budget from '@/pages/Budget.vue'
 import History from '@/pages/History.vue'
-import Accounts from '@/pages/Accounts.vue'
 import Settings from '@/pages/Settings.vue'
 import Import from '@/pages/Import.vue'
 import PendingExpenses from '@/pages/PendingExpenses.vue'
@@ -23,7 +22,7 @@ const router = createRouter({
         { path: '', redirect: '/budget' },
         { path: 'budget', name: 'budget', component: Budget },
         { path: 'history', name: 'history', component: History },
-        { path: 'accounts', name: 'accounts', component: Accounts },
+        { path: 'accounts', redirect: '/settings' },
         { path: 'settings', name: 'settings', component: Settings },
         { path: 'import', name: 'import', component: Import },
         { path: 'pending-expenses', name: 'pending-expenses', component: PendingExpenses },

--- a/SimplyBudgetWeb.Web/src/stores/auth.ts
+++ b/SimplyBudgetWeb.Web/src/stores/auth.ts
@@ -6,18 +6,42 @@ import {
   type AccountInfo,
 } from '@azure/msal-browser'
 import { msalConfig, loginRequest, apiScopes } from '@/authConfig'
-import { setTokenProvider } from '@/services/apiClient'
+import { apiClient, setTokenProvider } from '@/services/apiClient'
+import type { CurrentUserDto } from '@/types'
 
 const msalInstance = new PublicClientApplication(msalConfig)
 let initialized: Promise<void> | null = null
 
 export const useAuthStore = defineStore('auth', () => {
   const account = ref<AccountInfo | null>(null)
+  const customDisplayName = ref<string | null>(null)
   const isAuthenticated = computed(() => account.value !== null)
+  const displayName = computed(() => customDisplayName.value ?? account.value?.name ?? null)
 
   function refreshAccount() {
     const accounts = msalInstance.getAllAccounts()
     account.value = accounts[0] ?? null
+    if (!account.value) {
+      customDisplayName.value = null
+    }
+  }
+
+  async function refreshCurrentUserProfile() {
+    if (!account.value) {
+      customDisplayName.value = null
+      return
+    }
+
+    try {
+      const profile = await apiClient.get<CurrentUserDto>('/api/current-user')
+      customDisplayName.value = profile.displayName ?? account.value?.name ?? null
+    } catch {
+      customDisplayName.value = account.value?.name ?? null
+    }
+  }
+
+  function setDisplayName(name: string | null) {
+    customDisplayName.value = name
   }
 
   async function getToken(): Promise<string> {
@@ -42,6 +66,7 @@ export const useAuthStore = defineStore('auth', () => {
         await msalInstance.handleRedirectPromise()
         refreshAccount()
         setTokenProvider(getToken)
+        await refreshCurrentUserProfile()
       })()
     }
     await initialized
@@ -55,5 +80,15 @@ export const useAuthStore = defineStore('auth', () => {
     void msalInstance.logoutRedirect()
   }
 
-  return { account, isAuthenticated, initialize, login, logout, getToken }
+  return {
+    account,
+    displayName,
+    isAuthenticated,
+    initialize,
+    login,
+    logout,
+    getToken,
+    refreshCurrentUserProfile,
+    setDisplayName,
+  }
 })

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -101,6 +101,11 @@ export interface AssigneeDto {
   name: string | null
 }
 
+export interface CurrentUserDto {
+  displayName: string
+  email: string | null
+}
+
 export interface PendingExpenseDto {
   id: number
   date: string

--- a/SimplyBudgetWeb/Controllers/CurrentUserController.cs
+++ b/SimplyBudgetWeb/Controllers/CurrentUserController.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Web;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Controllers;
+
+[ApiController]
+[Route("api/current-user")]
+public class CurrentUserController(BudgetWebContext context) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<CurrentUserDto>> Get()
+    {
+        var assignee = await GetCurrentAssigneeAsync();
+        if (assignee is null)
+        {
+            return NotFound("Current user could not be resolved.");
+        }
+
+        return ToDto(assignee);
+    }
+
+    [HttpPut("display-name")]
+    public async Task<ActionResult<CurrentUserDto>> UpdateDisplayName([FromBody] CurrentUserDisplayNameRequest request)
+    {
+        var assignee = await GetCurrentAssigneeAsync();
+        if (assignee is null)
+        {
+            return NotFound("Current user could not be resolved.");
+        }
+
+        var displayName = request.DisplayName?.Trim();
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            return BadRequest("Display name is required.");
+        }
+
+        if (displayName.Length > 100)
+        {
+            return BadRequest("Display name must be 100 characters or fewer.");
+        }
+
+        assignee.Name = displayName;
+        assignee.IsNameCustomized = true;
+        await context.SaveChangesAsync();
+
+        return ToDto(assignee);
+    }
+
+    private async Task<PendingExpenseAssignee?> GetCurrentAssigneeAsync()
+    {
+        var objectId = User.GetObjectId();
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return null;
+        }
+
+        return await context.PendingExpenseAssignees
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ObjectId == objectId);
+    }
+
+    private static CurrentUserDto ToDto(PendingExpenseAssignee assignee) => new(
+        DisplayName: assignee.Name,
+        Email: assignee.Email
+    );
+}
+
+public record CurrentUserDto(string DisplayName, string? Email);
+
+public record CurrentUserDisplayNameRequest(string? DisplayName);

--- a/SimplyBudgetWeb/Services/CurrentUserSyncService.cs
+++ b/SimplyBudgetWeb/Services/CurrentUserSyncService.cs
@@ -45,13 +45,17 @@ public class CurrentUserSyncService(BudgetWebContext context)
             {
                 ObjectId = objectId,
                 Name = name,
+                IsNameCustomized = false,
                 Email = email,
                 LastLoginUtc = DateTime.UtcNow,
             });
         }
-        else if (assignee.Name != name || assignee.Email != email)
+        else if ((!assignee.IsNameCustomized && assignee.Name != name) || assignee.Email != email)
         {
-            assignee.Name = name;
+            if (!assignee.IsNameCustomized)
+            {
+                assignee.Name = name;
+            }
             assignee.Email = email;
             assignee.LastLoginUtc = DateTime.UtcNow;
         }


### PR DESCRIPTION
## Summary\n- move account-management functionality into the Settings page\n- restructure Settings into collapsible sections so long lists stay hidden until expanded\n- add profile display-name editing in Settings and persist custom display names\n- preserve customized names during login sync and add DB migration + tests\n\n## Notes\n- /accounts now redirects to /settings\n- header display name now follows the customizable profile display name