### PR TITLE
Fix mobile usability for budget and expenses

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -4,9 +4,11 @@ import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type { BudgetResponse, BudgetCategoryDto, ExpenseCategoryDto, ExpenseCategoryMonthlyExpensesDto } from '@/types'
 import { formatCents, formatMonth, parseMonth } from '@/utils/currency'
+import { useRouter } from 'vue-router'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 
 const snackbar = useSnackbarStore()
+const router = useRouter()
 
 const currentMonth = new Date()
 const budget = ref<BudgetResponse | null>(null)
@@ -120,6 +122,10 @@ async function openCategoryChart(category: BudgetCategoryDto) {
     categoryChartLoading.value = false
   }
 }
+
+function openCategoryHistory(category: BudgetCategoryDto) {
+  void router.push({ name: 'history', query: { categoryId: String(category.id) } })
+}
 </script>
 
 <template>
@@ -146,21 +152,27 @@ async function openCategoryChart(category: BudgetCategoryDto) {
                 v-for="cat in group.items"
                 :key="cat.id"
                 class="border-b category-clickable-row"
-                @click="openCategoryChart(cat)"
+                @click="openCategoryHistory(cat)"
               >
                 <v-list-item-title>{{ cat.name ?? '(unnamed)' }}</v-list-item-title>
                 <v-list-item-subtitle>
-                  <div class="d-flex flex-wrap mt-1" style="gap: 4px;">
+                  <div class="budget-chip-row d-flex flex-wrap mt-1" style="gap: 4px;">
                     <v-chip size="small">Budget: {{ cat.usePercentage ? `${cat.budgetedPercentage}%` : formatCents(cat.budgetedAmount) }}</v-chip>
                     <v-chip size="small" color="error" variant="outlined">Spent: {{ formatCents(cat.monthlyExpenses) }}</v-chip>
                     <v-chip size="small" :color="cat.currentBalance >= 0 ? 'success' : 'error'">Balance: {{ formatCents(cat.currentBalance) }}</v-chip>
-                    <v-chip size="small" variant="outlined">3mo avg: {{ formatCents(cat.threeMonthAverage) }}</v-chip>
-                    <v-chip size="small" variant="outlined">6mo avg: {{ formatCents(cat.sixMonthAverage) }}</v-chip>
-                    <v-chip size="small" variant="outlined">12mo avg: {{ formatCents(cat.twelveMonthAverage) }}</v-chip>
+                    <v-chip size="small" variant="outlined" class="avg-spend-chip">3mo avg: {{ formatCents(cat.threeMonthAverage) }}</v-chip>
+                    <v-chip size="small" variant="outlined" class="avg-spend-chip">6mo avg: {{ formatCents(cat.sixMonthAverage) }}</v-chip>
+                    <v-chip size="small" variant="outlined" class="avg-spend-chip">12mo avg: {{ formatCents(cat.twelveMonthAverage) }}</v-chip>
                   </div>
                 </v-list-item-subtitle>
                 <template #append>
-                  <v-icon icon="mdi-chart-bar" />
+                  <v-btn
+                    icon="mdi-chart-bar"
+                    variant="text"
+                    size="small"
+                    aria-label="Open category chart"
+                    @click.stop="openCategoryChart(cat)"
+                  />
                 </template>
               </v-list-item>
             </v-list>
@@ -194,6 +206,11 @@ async function openCategoryChart(category: BudgetCategoryDto) {
             <v-chip size="small" color="primary" variant="outlined" class="mb-3">
               Budget line: {{ budgetLineLabel }}
             </v-chip>
+            <div class="d-flex flex-wrap mb-3" style="gap: 6px;">
+              <v-chip size="small" variant="outlined">3mo avg: {{ formatCents(categoryChart.months.slice(-3).reduce((sum, point) => sum + point.amount, 0) / 3) }}</v-chip>
+              <v-chip size="small" variant="outlined">6mo avg: {{ formatCents(categoryChart.months.slice(-6).reduce((sum, point) => sum + point.amount, 0) / 6) }}</v-chip>
+              <v-chip size="small" variant="outlined">12mo avg: {{ formatCents(categoryChart.months.reduce((sum, point) => sum + point.amount, 0) / 12) }}</v-chip>
+            </div>
             <div class="expense-chart">
               <div class="expense-chart-plot">
                 <div class="expense-chart-budget-line" :style="{ bottom: `${budgetLinePercent}%` }">
@@ -314,5 +331,12 @@ async function openCategoryChart(category: BudgetCategoryDto) {
   text-align: center;
   font-size: 0.75rem;
   color: rgba(var(--v-theme-on-surface), 0.75);
+}
+</style>
+<style scoped>
+@media (max-width: 720px) {
+  .avg-spend-chip {
+    display: none;
+  }
 }
 </style>

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -8,8 +8,10 @@ import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 import { AMAZON_TRANSACTIONS_URL, hasAmazonInDescription } from '@/utils/merchantLinks'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
+import { useRoute } from 'vue-router'
 
 const snackbar = useSnackbarStore()
+const route = useRoute()
 
 const { currentMonth } = useMonthQueryParam({ storageKey: 'history' })
 const search = ref('')
@@ -27,6 +29,15 @@ const monthLabel = computed(() =>
 )
 
 const categoryOptions = computed(() => [{ id: null, name: 'All' }, ...categories.value])
+
+function monthGroupLabel(dateString: string) {
+  return new Date(dateString).toLocaleDateString('default', { month: 'long', year: 'numeric' })
+}
+
+function isNewMonth(index: number) {
+  if (index === 0) return true
+  return monthGroupLabel(items.value[index].date) !== monthGroupLabel(items.value[index - 1].date)
+}
 
 async function fetchCategories() {
   try {
@@ -85,6 +96,13 @@ onMounted(() => {
   void fetchCategories()
   void fetchHistory()
   void fetchAccountBalances()
+
+  const rawCategoryId = route.query.categoryId
+  const categoryIdQuery = Array.isArray(rawCategoryId) ? rawCategoryId[0] : rawCategoryId
+  const parsedCategoryId = Number(categoryIdQuery)
+  if (Number.isFinite(parsedCategoryId)) {
+    categoryId.value = parsedCategoryId
+  }
 })
 
 function onDialogSuccess() {
@@ -134,12 +152,17 @@ function onDialogSuccess() {
       <v-list-item v-if="items.length === 0">
         <v-list-item-title>No transactions found.</v-list-item-title>
       </v-list-item>
-      <v-card v-for="item in items" :key="item.id" class="mb-2">
+      <template v-for="(item, index) in items" :key="item.id">
+        <v-list-subheader v-if="isNewMonth(index)" class="expense-month-group-header">
+          {{ monthGroupLabel(item.date) }}
+        </v-list-subheader>
+        <v-card class="mb-2">
         <v-list-item>
           <v-list-item-title>
-            <div class="d-flex justify-space-between align-center">
-              <span class="d-flex align-center flex-wrap" style="gap: 6px;">
-                <span>{{ new Date(item.date).toLocaleDateString() }} — {{ item.description }}</span>
+            <div class="expense-row">
+              <span class="expense-main">
+                <span class="expense-date">{{ new Date(item.date).toLocaleDateString() }}</span>
+                <span class="expense-description">{{ item.description }}</span>
                 <v-chip v-if="item.isTransfer" size="small">Transfer</v-chip>
                 <v-btn
                   v-if="hasAmazonInDescription(item.description)"
@@ -153,7 +176,7 @@ function onDialogSuccess() {
                   aria-label="Open Amazon transactions page"
                 />
               </span>
-              <span class="font-weight-bold">{{ formatCents(totalForItem(item)) }}</span>
+              <span class="font-weight-bold expense-amount">{{ formatCents(totalForItem(item)) }}</span>
             </div>
           </v-list-item-title>
           <v-list-item-subtitle>
@@ -164,10 +187,29 @@ function onDialogSuccess() {
             </div>
           </v-list-item-subtitle>
           <template #append>
-            <v-btn icon="mdi-delete" variant="text" color="error" aria-label="Delete transaction" @click="deleteItem = item" />
+            <v-menu location="bottom end">
+              <template #activator="{ props }">
+                <v-btn
+                  v-bind="props"
+                  icon="mdi-dots-vertical"
+                  variant="text"
+                  size="small"
+                  aria-label="Transaction actions"
+                />
+              </template>
+              <v-list density="compact">
+                <v-list-item
+                  prepend-icon="mdi-delete"
+                  title="Delete transaction"
+                  base-color="error"
+                  @click="deleteItem = item"
+                />
+              </v-list>
+            </v-menu>
           </template>
         </v-list-item>
       </v-card>
+      </template>
     </v-list>
 
     <v-btn
@@ -193,3 +235,62 @@ function onDialogSuccess() {
     </v-dialog>
   </div>
 </template>
+
+<style scoped>
+.expense-month-group-header {
+  min-height: 22px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(var(--v-theme-on-surface), 0.65);
+  padding-inline: 8px;
+}
+
+.expense-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.expense-main {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.expense-date {
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+}
+
+.expense-description {
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.expense-amount {
+  flex: 0 0 auto;
+  text-align: right;
+}
+
+@media (max-width: 720px) {
+  .expense-row {
+    align-items: center;
+  }
+
+  .expense-main {
+    display: grid;
+    grid-template-columns: 1fr;
+    align-items: start;
+    gap: 4px;
+  }
+
+  .expense-description {
+    grid-column: 1;
+  }
+}
+</style>

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -263,20 +263,21 @@ onMounted(() => {
         <v-list-item-title>No pending expenses found.</v-list-item-title>
       </v-list-item>
       <template v-for="(item, index) in items" :key="item.id">
-        <v-list-subheader v-if="isNewMonth(index)" class="font-weight-bold">
+        <v-list-subheader v-if="isNewMonth(index)" class="pending-month-group-header">
           {{ monthGroupLabel(item.date) }}
         </v-list-subheader>
         <v-card class="mb-2">
           <v-list-item density="compact" style="cursor: pointer;" @click="openConvert(item)">
             <v-list-item-title>
-              <div class="d-flex justify-space-between align-center" style="gap: 12px;">
-                <span class="d-flex align-center flex-wrap" style="gap: 6px;">
-                  {{ new Date(item.date).toLocaleDateString() }} — {{ item.description }}
+              <div class="pending-row">
+                <span class="pending-main">
+                  <span class="pending-date">{{ new Date(item.date).toLocaleDateString() }}</span>
+                  <span class="pending-description">{{ item.description }}</span>
                   <v-chip v-if="item.suggestedCategoryName" size="small" variant="outlined" class="ml-1">
                     Suggested: {{ item.suggestedCategoryName }}
                   </v-chip>
                 </span>
-                <div class="d-flex align-center" style="gap: 6px;" @click.stop>
+                <div class="d-flex align-center pending-right" style="gap: 6px;" @click.stop>
                   <v-menu location="bottom end">
                     <template #activator="{ props }">
                       <v-chip
@@ -292,6 +293,7 @@ onMounted(() => {
                         {{ item.assigneeName ?? 'Assign' }}
                       </v-chip>
                     </template>
+
                     <v-list density="compact">
                       <v-list-item v-if="assignees.length === 0" title="No assignees available" disabled />
                       <v-list-item


### PR DESCRIPTION
## Summary
- made expense and pending expense rows mobile-friendly with smaller date text, wrapped descriptions, and stable right-aligned amounts
- grouped expense rows under lightweight month headers and switched expense delete action to an ellipsis menu
- hid budget average-spend chips on narrow screens while keeping budget/spent/balance prominent
- added average spend values to the category chart popup
- made budget row tap navigate to Expenses with category preselected via categoryId query parameter

## Notes
- local web build validation could not run in this environment because vue-tsc is not installed
