### PR TITLE
Fix assignee chip and 400 error on pending expense assignment

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -283,13 +283,18 @@ onMounted(() => {
                         v-bind="props"
                         size="small"
                         variant="outlined"
-                        :model-value="true"
-                        :closable="item.assigneeId !== null"
                         :prepend-icon="item.assigneeId === null ? 'mdi-account-plus-outline' : undefined"
                         @click.stop
-                        @click:close.stop="updateAssignee(item, null)"
                       >
                         {{ item.assigneeName ?? 'Assign' }}
+                        <template v-if="item.assigneeId !== null" #append>
+                          <v-icon
+                            icon="mdi-close-circle"
+                            size="x-small"
+                            class="ms-1"
+                            @click.stop.prevent="updateAssignee(item, null)"
+                          />
+                        </template>
                       </v-chip>
                     </template>
                     <v-list density="compact">

--- a/SimplyBudgetWeb/Middleware/CurrentUserSyncMiddleware.cs
+++ b/SimplyBudgetWeb/Middleware/CurrentUserSyncMiddleware.cs
@@ -1,3 +1,4 @@
+using SimplyBudgetWeb.Data;
 using SimplyBudgetWeb.Services;
 
 namespace SimplyBudgetWeb.Middleware;
@@ -7,13 +8,24 @@ namespace SimplyBudgetWeb.Middleware;
 /// <see cref="Data.PendingExpenseAssignee"/> row for the current user, so the Pending Expenses
 /// assignee list always reflects everyone who has signed in.
 /// </summary>
-public class CurrentUserSyncMiddleware(RequestDelegate next)
+public class CurrentUserSyncMiddleware(RequestDelegate next, ILogger<CurrentUserSyncMiddleware> logger)
 {
-    public async Task InvokeAsync(HttpContext context, CurrentUserSyncService syncService)
+    public async Task InvokeAsync(HttpContext context, CurrentUserSyncService syncService, BudgetWebContext dbContext)
     {
         if (context.User.Identity?.IsAuthenticated == true)
         {
-            await syncService.SyncAsync(context.User, context.RequestAborted);
+            try
+            {
+                await syncService.SyncAsync(context.User, context.RequestAborted);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Log but don't fail the request — sync is a best-effort background operation.
+                // Clear any pending tracked changes so the failed sync does not corrupt the
+                // shared DbContext for the rest of the request pipeline.
+                logger.LogError(ex, "Failed to sync current user assignee record.");
+                dbContext.ChangeTracker.Clear();
+            }
         }
 
         await next(context);


### PR DESCRIPTION
## Summary

Fixes two bugs on the Pending Expenses page related to assigning users.

## Bug 1: 400 error when assigning a user

**Root cause:** `CurrentUserSyncMiddleware` runs on every request to upsert the current user's `PendingExpenseAssignee` row. If `SyncAsync` threw an exception, it propagated up the pipeline where `ExceptionHandlingMiddleware` converts `InvalidOperationException` → 400 BadRequest. A failed `SaveChangesAsync` could also leave the shared `DbContext` with corrupted tracked state, causing EF Core to throw when the controller later used the same context.

**Fix:** Wrap `SyncAsync` in a try-catch that logs the error, clears the change tracker, and lets the request continue. User sync is best-effort and should never fail a user's request.

## Bug 2: Clicking X removes the chip entirely instead of reverting to "Assign"

**Root cause:** Vuetify's `v-chip` with `closable` manages its own visibility via `useProxiedModel`. When the close button is clicked, the chip hides itself internally — even with `:model-value="true"` bound — rather than transitioning to the "Assign" state.

**Fix:** Replace the `closable` prop with a manual `v-icon` close button in the chip's `#append` slot (`@click.stop.prevent`). This bypasses Vuetify's visibility management. The chip always stays visible; the close icon only appears when an assignee is set.