### PR TITLE
Show loading spinner during cold start initialization

### DIFF
--- a/SimplyBudgetWeb.Web/src/App.vue
+++ b/SimplyBudgetWeb.Web/src/App.vue
@@ -20,7 +20,16 @@ async function refreshToLatestVersion() {
 
 <template>
   <v-app>
-    <router-view />
+    <template v-if="authStore.isInitializing">
+      <v-main>
+        <v-container class="d-flex align-center justify-center" style="min-height: 100vh;">
+          <v-progress-circular indeterminate color="primary" size="64" />
+        </v-container>
+      </v-main>
+    </template>
+    <template v-else>
+      <router-view />
+    </template>
     <SnackbarHost />
     <v-snackbar :model-value="needRefresh" :timeout="-1" location="bottom">
       A new version is available.

--- a/SimplyBudgetWeb.Web/src/stores/auth.ts
+++ b/SimplyBudgetWeb.Web/src/stores/auth.ts
@@ -15,6 +15,7 @@ let initialized: Promise<void> | null = null
 export const useAuthStore = defineStore('auth', () => {
   const account = ref<AccountInfo | null>(null)
   const customDisplayName = ref<string | null>(null)
+  const isInitializing = ref(true)
   const isAuthenticated = computed(() => account.value !== null)
   const displayName = computed(() => customDisplayName.value ?? account.value?.name ?? null)
 
@@ -62,11 +63,15 @@ export const useAuthStore = defineStore('auth', () => {
   async function initialize() {
     if (!initialized) {
       initialized = (async () => {
-        await msalInstance.initialize()
-        await msalInstance.handleRedirectPromise()
-        refreshAccount()
-        setTokenProvider(getToken)
-        await refreshCurrentUserProfile()
+        try {
+          await msalInstance.initialize()
+          await msalInstance.handleRedirectPromise()
+          refreshAccount()
+          setTokenProvider(getToken)
+          await refreshCurrentUserProfile()
+        } finally {
+          isInitializing.value = false
+        }
       })()
     }
     await initialized
@@ -84,6 +89,7 @@ export const useAuthStore = defineStore('auth', () => {
     account,
     displayName,
     isAuthenticated,
+    isInitializing,
     initialize,
     login,
     logout,


### PR DESCRIPTION
## Summary

When loading from a cold start with a persisted login, the screen sat blank until the backend started up and the MSAL/API initialization completed.

## Changes

- Added `isInitializing` ref to the auth store (starts `true`, set to `false` in a `finally` block after initialization completes)
- In `App.vue`, show a centered `<v-progress-circular>` spinner while `isInitializing` is `true`, then render `<router-view />` once done

Users with a persisted login will now immediately see a spinner instead of a blank screen during startup.