### PR TITLE
Add optimistic concurrency to pending expenses

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -122,7 +122,7 @@ jobs:
       # Playwright docker image, so this only runs the non-UI test project.
       - name: Test
         if: needs.changes.outputs.app == 'true'
-        run: dotnet test SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj --no-build --configuration Release --verbosity normal
+        run: dotnet test --project SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj --no-build --configuration Release --verbosity normal
         env:
           DOTNET_BUILD_CONFIGURATION: Release
 
@@ -271,7 +271,7 @@ jobs:
 
       - name: Run UI tests
         if: needs.changes.outputs.app == 'true'
-        run: docker exec "$UI_TESTS_CONTAINER" dotnet test "$UITESTS_PROJECT_PATH" --no-build --configuration Release --verbosity normal
+        run: docker exec "$UI_TESTS_CONTAINER" dotnet test --project "$UITESTS_PROJECT_PATH" --no-build --configuration Release --verbosity normal
 
       - name: Stop Playwright container
         if: always() && needs.changes.outputs.app == 'true'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,10 +35,10 @@ jobs:
       run: dotnet build SimplyBudget.sln --configuration Release
       
     - name: Test shared library
-      run: dotnet test SimplyBudgetSharedTests\SimplyBudgetSharedTests.csproj --configuration Release --verbosity normal
+      run: dotnet test --project SimplyBudgetSharedTests\SimplyBudgetSharedTests.csproj --configuration Release --verbosity normal
 
     - name: Test desktop app
-      run: dotnet test SimplyBudgetDesktop.Tests\SimplyBudgetDesktop.Tests.csproj --configuration Release --verbosity normal
+      run: dotnet test --project SimplyBudgetDesktop.Tests\SimplyBudgetDesktop.Tests.csproj --configuration Release --verbosity normal
 
     - name: Restore Tools
       run: dotnet tool restore
@@ -53,4 +53,3 @@ jobs:
     - name: Push Release
       if: github.event_name == 'workflow_dispatch'
       run: dotnet vpk publish -o .\Releases --waitForLive --api-key ${{ secrets.VPK_API_KEY }}
-

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetWeb.Controllers;
@@ -8,6 +9,8 @@ namespace SimplyBudgetWeb.Core.Tests.Controllers;
 
 public class PendingExpensesControllerTests
 {
+    private const string AnyVersion = "AQ==";
+
     [Test]
     public async Task GetAll_ReturnsItemsOrderedByDateAscending_OldestFirst()
     {
@@ -189,20 +192,20 @@ public class PendingExpensesControllerTests
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
 
-        var (pendingId, assigneeId) = await mocker.InDbScopeAsync(async context =>
+        var (pendingId, assigneeId, version) = await mocker.InDbScopeAsync(async context =>
         {
             var assignee = new PendingExpenseAssignee { Name = "Jordan", ObjectId = "jordan-oid" };
             var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
             context.PendingExpenseAssignees.Add(assignee);
             context.PendingExpenses.Add(pending);
             await context.SaveChangesAsync();
-            return (pending.ID, assignee.ID);
+            return (pending.ID, assignee.ID, System.Convert.ToBase64String(pending.Version));
         });
 
         using (var context = mocker.Get<BudgetWebContext>())
         {
             var controller = new PendingExpensesController(context);
-            var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(assigneeId, "Needs review"));
+            var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(assigneeId, "Needs review", version));
 
             var dto = (result.Value as PendingExpenseDto) ?? ((OkObjectResult)result.Result!).Value as PendingExpenseDto;
             await Assert.That(dto!.AssigneeId).IsEqualTo(assigneeId);
@@ -225,7 +228,7 @@ public class PendingExpensesControllerTests
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
 
-        int pendingId = await mocker.InDbScopeAsync(async context =>
+        var (pendingId, version) = await mocker.InDbScopeAsync(async context =>
         {
             var assignee = new PendingExpenseAssignee { Name = "Jordan", ObjectId = "jordan-oid" };
             context.PendingExpenseAssignees.Add(assignee);
@@ -234,13 +237,13 @@ public class PendingExpensesControllerTests
             await context.SaveChangesAsync();
             pending.AssigneeId = assignee.ID;
             await context.SaveChangesAsync();
-            return pending.ID;
+            return (pending.ID, System.Convert.ToBase64String(pending.Version));
         });
 
         using (var context = mocker.Get<BudgetWebContext>())
         {
             var controller = new PendingExpensesController(context);
-            var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(null, null));
+            var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(null, null, version));
 
             var dto = (result.Value as PendingExpenseDto) ?? ((OkObjectResult)result.Result!).Value as PendingExpenseDto;
             await Assert.That(dto!.AssigneeId).IsNull();
@@ -260,18 +263,18 @@ public class PendingExpensesControllerTests
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
 
-        int pendingId = await mocker.InDbScopeAsync(async context =>
+        var (pendingId, version) = await mocker.InDbScopeAsync(async context =>
         {
             var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
             context.PendingExpenses.Add(pending);
             await context.SaveChangesAsync();
-            return pending.ID;
+            return (pending.ID, System.Convert.ToBase64String(pending.Version));
         });
 
         using var context = mocker.Get<BudgetWebContext>();
         var controller = new PendingExpensesController(context);
 
-        var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(999, null));
+        var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(999, null, version));
 
         await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
     }
@@ -285,7 +288,7 @@ public class PendingExpensesControllerTests
         using var context = mocker.Get<BudgetWebContext>();
         var controller = new PendingExpensesController(context);
 
-        var result = await controller.Update(999, new PendingExpenseUpdateRequest(null, "notes"));
+        var result = await controller.Update(999, new PendingExpenseUpdateRequest(null, "notes", AnyVersion));
 
         await Assert.That(result.Result).IsTypeOf<NotFoundResult>();
     }
@@ -296,17 +299,19 @@ public class PendingExpensesControllerTests
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
 
-        int pendingId = await mocker.InDbScopeAsync(async context =>
+        var (pendingId, version) = await mocker.InDbScopeAsync(async context =>
         {
             var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
             context.PendingExpenses.Add(pending);
             await context.SaveChangesAsync();
-            return pending.ID;
+            return (pending.ID, System.Convert.ToBase64String(pending.Version));
         });
 
         using (var context = mocker.Get<BudgetWebContext>())
         {
             var controller = new PendingExpensesController(context);
+            controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+            controller.Request.Headers.IfMatch = version;
             var result = await controller.Delete(pendingId);
             await Assert.That(result).IsTypeOf<NoContentResult>();
         }
@@ -439,18 +444,18 @@ public class PendingExpensesControllerTests
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
 
-        int pendingId = await mocker.InDbScopeAsync(async context =>
+        var (pendingId, version) = await mocker.InDbScopeAsync(async context =>
         {
             var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
             context.PendingExpenses.Add(pending);
             await context.SaveChangesAsync();
-            return pending.ID;
+            return (pending.ID, System.Convert.ToBase64String(pending.Version));
         });
 
         using var context = mocker.Get<BudgetWebContext>();
         var controller = new PendingExpensesController(context);
 
-        var result = await controller.Convert(pendingId, new ConvertPendingExpenseRequest("Costco", DateTime.Today, []));
+        var result = await controller.Convert(pendingId, new ConvertPendingExpenseRequest("Costco", DateTime.Today, [], version));
 
         await Assert.That(result).IsTypeOf<BadRequestObjectResult>();
     }
@@ -465,7 +470,7 @@ public class PendingExpensesControllerTests
         var controller = new PendingExpensesController(context);
 
         var result = await controller.Convert(999, new ConvertPendingExpenseRequest("Costco", DateTime.Today,
-            [new ConvertPendingExpenseItemRequest(1, 100)]));
+            [new ConvertPendingExpenseItemRequest(1, 100)], AnyVersion));
 
         await Assert.That(result).IsTypeOf<NotFoundResult>();
     }
@@ -492,7 +497,7 @@ public class PendingExpensesControllerTests
 
             var controller = new PendingExpensesController(context);
             var result = await controller.Convert(pending.ID, new ConvertPendingExpenseRequest(
-                "Costco", new DateTime(2026, 1, 5), [new ConvertPendingExpenseItemRequest(category.ID, 45_00)]));
+                "Costco", new DateTime(2026, 1, 5), [new ConvertPendingExpenseItemRequest(category.ID, 45_00)], System.Convert.ToBase64String(pending.Version)));
 
             await Assert.That(result).IsTypeOf<StatusCodeResult>();
             await Assert.That(((StatusCodeResult)result).StatusCode).IsEqualTo(201);
@@ -538,6 +543,7 @@ public class PendingExpensesControllerTests
                 "Costco",
                 new DateTime(2026, 1, 5),
                 [new ConvertPendingExpenseItemRequest(category.ID, 45_00)],
+                System.Convert.ToBase64String(pending.Version),
                 IgnoreBudget: true));
         }
 
@@ -577,7 +583,8 @@ public class PendingExpensesControllerTests
                 [
                     new ConvertPendingExpenseItemRequest(groceries.ID, 70_00),
                     new ConvertPendingExpenseItemRequest(household.ID, 30_00),
-                ]));
+                ],
+                System.Convert.ToBase64String(pending.Version)));
         }
 
         await mocker.InDbScopeAsync(async context =>
@@ -617,7 +624,7 @@ public class PendingExpensesControllerTests
 
             var controller = new PendingExpensesController(context);
             await controller.Convert(pending.ID, new ConvertPendingExpenseRequest(
-                "Refund", new DateTime(2026, 1, 5), [new ConvertPendingExpenseItemRequest(category.ID, 20_00)]));
+                "Refund", new DateTime(2026, 1, 5), [new ConvertPendingExpenseItemRequest(category.ID, 20_00)], System.Convert.ToBase64String(pending.Version)));
         }
 
         await mocker.InDbScopeAsync(async context =>
@@ -659,6 +666,7 @@ public class PendingExpensesControllerTests
                     "Costco",
                     new DateTime(2026, 1, 6),
                     [new ConvertPendingExpenseItemRequest(category.ID, 50_00)],
+                    System.Convert.ToBase64String(pending.Version),
                     IgnoreBudget: true));
         }
 

--- a/SimplyBudgetWeb.Data/BudgetWebContext.cs
+++ b/SimplyBudgetWeb.Data/BudgetWebContext.cs
@@ -34,6 +34,15 @@ public class BudgetWebContext(DbContextOptions<BudgetWebContext> options)
         modelBuilder.Entity<PendingExpense>()
             .HasIndex(x => x.Date);
 
+        if (Database.ProviderName == "Microsoft.EntityFrameworkCore.Sqlite")
+        {
+            // SQLite has no native rowversion type; provide a DB-generated non-null blob
+            // so tests (which use SQLite) can still insert entities with a concurrency token.
+            modelBuilder.Entity<PendingExpense>()
+                .Property(x => x.Version)
+                .HasDefaultValueSql("randomblob(8)");
+        }
+
         modelBuilder.Entity<PendingExpense>()
             .HasOne(x => x.Assignee)
             .WithMany(x => x.PendingExpenses)

--- a/SimplyBudgetWeb.Data/Migrations/20260822211131_AddPendingExpenseOptimisticConcurrency.Designer.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260822211131_AddPendingExpenseOptimisticConcurrency.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetWeb.Data;
 
@@ -11,9 +12,11 @@ using SimplyBudgetWeb.Data;
 namespace SimplyBudgetWeb.Data.Migrations
 {
     [DbContext(typeof(BudgetWebContext))]
-    partial class BudgetWebContextModelSnapshot : ModelSnapshot
+    [Migration("20260822211131_AddPendingExpenseOptimisticConcurrency")]
+    partial class AddPendingExpenseOptimisticConcurrency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SimplyBudgetWeb.Data/Migrations/20260822211131_AddPendingExpenseOptimisticConcurrency.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260822211131_AddPendingExpenseOptimisticConcurrency.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetWeb.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPendingExpenseOptimisticConcurrency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "Version",
+                schema: "SimplyBudget",
+                table: "PendingExpense",
+                type: "rowversion",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: new byte[0]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Version",
+                schema: "SimplyBudget",
+                table: "PendingExpense");
+        }
+    }
+}

--- a/SimplyBudgetWeb.Data/PendingExpense.cs
+++ b/SimplyBudgetWeb.Data/PendingExpense.cs
@@ -13,6 +13,9 @@ namespace SimplyBudgetWeb.Data;
 [Table("PendingExpense")]
 public class PendingExpense : BaseItem
 {
+    [Timestamp]
+    public byte[] Version { get; set; } = [];
+
     private DateTime _date;
     public DateTime Date
     {

--- a/SimplyBudgetWeb.Data/PendingExpense.cs
+++ b/SimplyBudgetWeb.Data/PendingExpense.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using SimplyBudgetShared.Data;
 

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -86,6 +86,7 @@ async function submit() {
     const payload: ConvertPendingExpenseRequest = {
       description: description.value,
       date: date.value,
+      version: props.pendingExpense.version,
       ignoreBudget: ignoreBudget.value,
       items: lines.value
         .filter(l => l.expenseCategoryId !== null && l.amount !== '')

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -87,7 +87,10 @@ async function updateAssignee(item: PendingExpenseDto, newAssigneeId: number | n
     await apiClient.put(`/api/pending-expenses/${item.id}`, {
       assigneeId: newAssigneeId,
       notes: item.notes,
+      version: item.version,
     })
+    const refreshed = await apiClient.get<PendingExpenseDto>(`/api/pending-expenses/${item.id}`)
+    item.version = refreshed.version
   } catch {
     item.assigneeId = previousAssigneeId
     item.assigneeName = previousAssigneeName
@@ -125,7 +128,10 @@ async function saveNote(item: PendingExpenseDto) {
     await apiClient.put(`/api/pending-expenses/${item.id}`, {
       assigneeId: item.assigneeId,
       notes: nextNote,
+      version: item.version,
     })
+    const refreshed = await apiClient.get<PendingExpenseDto>(`/api/pending-expenses/${item.id}`)
+    item.version = refreshed.version
     discardEditingNote(item.id)
   } catch {
     item.notes = previousNote
@@ -137,7 +143,9 @@ async function handleDiscard() {
   if (!discardItem.value) return
   const idToRemove = discardItem.value.id
   try {
-    await apiClient.delete(`/api/pending-expenses/${idToRemove}`)
+    await apiClient.delete(`/api/pending-expenses/${idToRemove}`, {
+      ifMatch: discardItem.value.version,
+    })
     snackbar.enqueueSnackbar('Pending expense discarded', { variant: 'success' })
     items.value = items.value.filter((item) => item.id !== idToRemove)
     discardItem.value = null

--- a/SimplyBudgetWeb.Web/src/services/apiClient.ts
+++ b/SimplyBudgetWeb.Web/src/services/apiClient.ts
@@ -4,6 +4,10 @@ export function setTokenProvider(fn: () => Promise<string>) {
   getTokenFn = fn
 }
 
+interface DeleteOptions {
+  ifMatch?: string
+}
+
 class ApiClient {
   private baseUrl = __API_BASE_URL__ || ''
 
@@ -30,7 +34,7 @@ class ApiClient {
   }
 
   async get<T>(url: string): Promise<T> {
-    const headers = await this.getHeaders()
+    let headers = await this.getHeaders()
     const response = await fetch(this.baseUrl + url, { headers })
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
     const text = await response.text()
@@ -77,8 +81,14 @@ class ApiClient {
     return response.json()
   }
 
-  async delete<T = void>(url: string): Promise<T> {
-    const headers = await this.getHeaders()
+  async delete<T = void>(url: string, options?: DeleteOptions): Promise<T> {
+    let headers = await this.getHeaders()
+    if (options?.ifMatch) {
+      headers = {
+        ...headers,
+        'If-Match': options.ifMatch,
+      }
+    }
     const response = await fetch(this.baseUrl + url, { method: 'DELETE', headers })
     if (!response.ok) {
       const error = await response.text()

--- a/SimplyBudgetWeb.Web/src/services/apiClient.ts
+++ b/SimplyBudgetWeb.Web/src/services/apiClient.ts
@@ -34,7 +34,7 @@ class ApiClient {
   }
 
   async get<T>(url: string): Promise<T> {
-    let headers = await this.getHeaders()
+    const headers = await this.getHeaders()
     const response = await fetch(this.baseUrl + url, { headers })
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
     const text = await response.text()
@@ -82,14 +82,14 @@ class ApiClient {
   }
 
   async delete<T = void>(url: string, options?: DeleteOptions): Promise<T> {
-    let headers = await this.getHeaders()
-    if (options?.ifMatch) {
-      headers = {
-        ...headers,
-        'If-Match': options.ifMatch,
-      }
-    }
-    const response = await fetch(this.baseUrl + url, { method: 'DELETE', headers })
+    const headers = await this.getHeaders()
+    const requestHeaders = options?.ifMatch
+      ? {
+          ...headers,
+          'If-Match': options.ifMatch,
+        }
+      : headers
+    const response = await fetch(this.baseUrl + url, { method: 'DELETE', headers: requestHeaders })
     if (!response.ok) {
       const error = await response.text()
       throw new Error(error || `HTTP error! status: ${response.status}`)

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -108,6 +108,7 @@ export interface CurrentUserDto {
 
 export interface PendingExpenseDto {
   id: number
+  version: string
   date: string
   description: string | null
   amount: number
@@ -126,6 +127,7 @@ export interface OldestPendingExpenseMonthDto {
 export interface PendingExpenseUpdateRequest {
   assigneeId: number | null
   notes: string | null
+  version: string
 }
 
 export interface ConvertPendingExpenseItemRequest {
@@ -137,6 +139,7 @@ export interface ConvertPendingExpenseRequest {
   description: string
   date: string
   items: ConvertPendingExpenseItemRequest[]
+  version: string
   ignoreBudget: boolean
 }
 

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -214,7 +214,7 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 
     private static PendingExpenseDto ToDto(PendingExpense p) => new(
         Id: p.ID,
-        Version: Convert.ToBase64String(p.Version),
+        Version: System.Convert.ToBase64String(p.Version),
         Date: p.Date,
         Description: p.Description,
         Amount: p.Amount,
@@ -235,7 +235,7 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         {
             context.Entry(pending)
                 .Property(x => x.Version)
-                .OriginalValue = Convert.FromBase64String(version.Trim('"'));
+                .OriginalValue = System.Convert.FromBase64String(version.Trim('"'));
             return true;
         }
         catch (FormatException)

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -15,6 +15,8 @@ namespace SimplyBudgetWeb.Controllers;
 [Route("api/pending-expenses")]
 public class PendingExpensesController(BudgetWebContext context) : ControllerBase
 {
+    private const string ConcurrencyConflictMessage = "This pending expense was changed by another user. Refresh and try again.";
+
     [HttpGet]
     public async Task<PendingExpenseDto[]> GetAll(
         [FromQuery] DateTime? month = null,
@@ -86,6 +88,8 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
             .Include(x => x.SuggestedCategory)
             .FirstOrDefaultAsync(x => x.ID == id);
         if (pending is null) return NotFound();
+        if (!TrySetOriginalVersion(pending, request.Version))
+            return BadRequest("Version is required.");
 
         if (request.AssigneeId.HasValue &&
             !await context.PendingExpenseAssignees.AnyAsync(x => x.ID == request.AssigneeId.Value))
@@ -95,7 +99,14 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 
         pending.AssigneeId = request.AssigneeId;
         pending.Notes = request.Notes;
-        await context.SaveChangesAsync();
+        try
+        {
+            await context.SaveChangesAsync();
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return Conflict(ConcurrencyConflictMessage);
+        }
 
         // AssigneeId may have changed since the initial .Include(x => x.Assignee) load, and
         // Reference(...).LoadAsync() is normally a no-op once a navigation is marked as loaded.
@@ -109,11 +120,23 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(int id)
     {
-        var pending = await context.PendingExpenses.FindAsync(id);
+        var pending = await context.PendingExpenses
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ID == id);
         if (pending is null) return NotFound();
+        var requestVersion = Request.Headers.IfMatch.FirstOrDefault();
+        if (!TrySetOriginalVersion(pending, requestVersion))
+            return BadRequest("If-Match header with version is required.");
 
         context.PendingExpenses.Remove(pending);
-        await context.SaveChangesAsync();
+        try
+        {
+            await context.SaveChangesAsync();
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return Conflict(ConcurrencyConflictMessage);
+        }
         return NoContent();
     }
 
@@ -155,8 +178,12 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
     [HttpPost("{id}/convert")]
     public async Task<IActionResult> Convert(int id, [FromBody] ConvertPendingExpenseRequest request)
     {
-        var pending = await context.PendingExpenses.FindAsync(id);
+        var pending = await context.PendingExpenses
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.ID == id);
         if (pending is null) return NotFound();
+        if (!TrySetOriginalVersion(pending, request.Version))
+            return BadRequest("Version is required.");
 
         if (request.Items is null || request.Items.Length == 0)
             return BadRequest("At least one category item is required.");
@@ -173,13 +200,21 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         }
 
         context.PendingExpenses.Remove(pending);
-        await context.SaveChangesAsync();
+        try
+        {
+            await context.SaveChangesAsync();
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return Conflict(ConcurrencyConflictMessage);
+        }
 
         return StatusCode(201);
     }
 
     private static PendingExpenseDto ToDto(PendingExpense p) => new(
         Id: p.ID,
+        Version: Convert.ToBase64String(p.Version),
         Date: p.Date,
         Description: p.Description,
         Amount: p.Amount,
@@ -190,10 +225,29 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         SuggestedCategoryId: p.SuggestedCategoryId,
         SuggestedCategoryName: p.SuggestedCategory?.Name
     );
+
+    private bool TrySetOriginalVersion(PendingExpense pending, string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return false;
+
+        try
+        {
+            context.Entry(pending)
+                .Property(x => x.Version)
+                .OriginalValue = Convert.FromBase64String(version.Trim('"'));
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
 }
 
 public record PendingExpenseDto(
     int Id,
+    string Version,
     DateTime Date,
     string? Description,
     int Amount,
@@ -207,7 +261,7 @@ public record PendingExpenseDto(
 
 public record OldestPendingExpenseMonthDto(DateTime? Month);
 
-public record PendingExpenseUpdateRequest(int? AssigneeId, string? Notes);
+public record PendingExpenseUpdateRequest(int? AssigneeId, string? Notes, string Version);
 
 public record ConvertPendingExpenseItemRequest(int ExpenseCategoryId, int Amount);
 
@@ -215,4 +269,5 @@ public record ConvertPendingExpenseRequest(
     string Description,
     DateTime Date,
     ConvertPendingExpenseItemRequest[] Items,
+    string Version,
     bool IgnoreBudget = false);


### PR DESCRIPTION
Implement optimistic concurrency control for pending expenses using a
row version (`[Timestamp]`) column. This prevents lost updates and
accidental deletions when multiple users concurrently modify the same
pending expense.

The client sends the entity's version with update and delete requests,
and the server responds with a 409 Conflict status if a concurrency
violation is detected.
