### PR TITLE
Update import rule creation UI

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -26,12 +26,12 @@ const deletingAll = ref(false)
 const editingNoteItemId = ref<number | null>(null)
 const noteDrafts = ref<Record<number, string>>({})
 const addRuleOpen = ref(false)
-const addRuleTargetCategoryLabel = ref('')
 const ruleForm = ref({ name: '', ruleRegex: '', expenseCategoryId: null as number | null })
 
 // "All" plus the real filter options; used for both the toolbar filter and the
 // page-level assignee filter.
 const assigneeFilterOptions = computed(() => [{ id: null, name: 'All' }, ...assignees.value])
+const ruleCategoryOptions = computed(() => [{ id: null, name: 'None' }, ...categories.value])
 
 // Items are returned sorted oldest-first, so consecutive entries belong to the same
 // month unless this changes; used to show a divider between months in the list.
@@ -176,14 +176,12 @@ function openConvert(item: PendingExpenseDto) {
 
 function resetRuleForm() {
   ruleForm.value = { name: '', ruleRegex: '', expenseCategoryId: null }
-  addRuleTargetCategoryLabel.value = ''
 }
 
 function openAddRule(item: PendingExpenseDto) {
   resetRuleForm()
   ruleForm.value.ruleRegex = item.description ?? ''
   ruleForm.value.expenseCategoryId = item.suggestedCategoryId ?? null
-  addRuleTargetCategoryLabel.value = item.suggestedCategoryName ?? 'No category'
   addRuleOpen.value = true
 }
 
@@ -399,7 +397,7 @@ onMounted(() => {
         <v-card-text class="d-flex flex-column" style="gap: 16px;">
           <v-text-field label="Name" v-model="ruleForm.name" />
           <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
-          <v-text-field label="Target Category" :model-value="addRuleTargetCategoryLabel" readonly />
+          <v-select label="Target Category" :items="ruleCategoryOptions" item-title="name" item-value="id" v-model="ruleForm.expenseCategoryId" />
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -34,7 +34,6 @@ const categories = ref<ExpenseCategoryDto[]>([])
 const rulesLoading = ref(false)
 const rulesLoaded = ref(false)
 const addRuleOpen = ref(false)
-const addTargetCategoryLabel = ref('')
 const deleteRule = ref<RuleDto | null>(null)
 const editRule = ref<RuleDto | null>(null)
 const ruleForm = ref({ name: '', ruleRegex: '', expenseCategoryId: null as number | null })
@@ -219,10 +218,8 @@ function resetRuleForm() {
   ruleForm.value = { name: '', ruleRegex: '', expenseCategoryId: null }
 }
 
-function openAddRuleForCategory(expenseCategoryId: number | null, categoryLabel: string) {
+function openAddRule() {
   resetRuleForm()
-  ruleForm.value.expenseCategoryId = expenseCategoryId
-  addTargetCategoryLabel.value = categoryLabel
   addRuleOpen.value = true
 }
 
@@ -245,7 +242,6 @@ async function handleAddRule() {
     snackbar.enqueueSnackbar('Rule added', { variant: 'success' })
     addRuleOpen.value = false
     resetRuleForm()
-    addTargetCategoryLabel.value = ''
     void fetchRules()
   } catch {
     snackbar.enqueueSnackbar('Failed to add rule', { variant: 'error' })
@@ -355,7 +351,6 @@ watch(showHiddenCategories, () => {
 watch(addRuleOpen, (isOpen) => {
   if (!isOpen) {
     resetRuleForm()
-    addTargetCategoryLabel.value = ''
   }
 })
 
@@ -480,17 +475,11 @@ watch(openPanel, (panel) => {
             <v-progress-circular indeterminate aria-label="Loading import rules" />
           </div>
           <div v-else>
+            <div class="d-flex justify-end mb-4">
+              <v-btn color="primary" @click="openAddRule">Add Rule</v-btn>
+            </div>
             <v-card v-for="group in ruleGroups" :key="group.key" class="mb-4">
-              <v-card-title class="d-flex justify-space-between align-center">
-                <span>{{ group.label }}</span>
-                <v-btn
-                  size="small"
-                  color="primary"
-                  @click="openAddRuleForCategory(group.expenseCategoryId, group.label)"
-                >
-                  Add Rule
-                </v-btn>
-              </v-card-title>
+              <v-card-title>{{ group.label }}</v-card-title>
               <v-divider />
               <v-list>
                 <v-list-item v-if="group.rules.length === 0">
@@ -625,7 +614,7 @@ watch(openPanel, (panel) => {
         <v-card-text class="d-flex flex-column" style="gap: 16px;">
           <v-text-field label="Name" v-model="ruleForm.name" />
           <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
-          <v-text-field label="Target Category" :model-value="addTargetCategoryLabel" readonly />
+          <v-select label="Target Category" :items="categoryOptions" item-title="name" item-value="id" v-model="ruleForm.expenseCategoryId" />
         </v-card-text>
         <v-card-actions>
           <v-spacer />


### PR DESCRIPTION
## Summary\n- replace per-category add buttons in Settings > Import Rules with one top-level **Add Rule** button\n- make **Target Category** selectable via dropdown in the Settings add-rule dialog\n- make **Target Category** selectable via dropdown in the Pending Expenses add-rule dialog (still prefilled from suggested category)\n\n## Validation\n- pnpm lint\n- pnpm build