### PR TITLE
Add Apply Expense item to pending expense menu

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -336,6 +336,11 @@ onMounted(() => {
                 </template>
                 <v-list density="compact">
                   <v-list-item
+                    prepend-icon="mdi-check-circle-outline"
+                    title="Apply Expense"
+                    @click="openConvert(item)"
+                  />
+                  <v-list-item
                     prepend-icon="mdi-note-edit-outline"
                     title="Edit note"
                     :disabled="isEditingNote(item.id)"


### PR DESCRIPTION
## Summary\n- add an **Apply Expense** item to the pending expense overflow menu\n- wire it to the same  handler used by row click\n\n## Why\n- makes the primary action discoverable from the ellipsis menu for each pending expense