### PR TITLE
Apply import rules to pending expenses and add rerun action

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
@@ -93,6 +93,49 @@ public class ImportControllerTests
     }
 
     [Test]
+    public async Task Save_WithEarlierUncategorizedMatch_UsesLaterCategorizedRule()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Uncategorized Costco rule",
+                RuleRegex = "Costco",
+                ExpenseCategoryID = null
+            });
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Categorized Costco rule",
+                RuleRegex = "Costco",
+                ExpenseCategoryID = category.ID
+            });
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var items = new[]
+        {
+            new ImportItemDto(new DateTime(2026, 1, 1), "Costco", 45_00, true, true),
+        };
+
+        var result = await controller.Save(items);
+
+        await Assert.That(((StatusCodeResult)result).StatusCode).IsEqualTo(201);
+        var saved = await context.PendingExpenses.SingleAsync();
+        await Assert.That(saved.SuggestedCategoryId).IsEqualTo(categoryId);
+    }
+
+    [Test]
     public async Task Save_WithNoItemsChecked_CreatesNoPendingExpenses()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -439,6 +439,56 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task ReapplyRules_UpdatesSuggestedCategoriesFromLatestRules()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int groceriesCategoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var groceriesCategory = new ExpenseCategory { Name = "Groceries", CurrentBalance = 0 };
+            var utilitiesCategory = new ExpenseCategory { Name = "Utilities", CurrentBalance = 0 };
+            context.ExpenseCategories.AddRange(groceriesCategory, utilitiesCategory);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryRules.AddRange(
+                new ExpenseCategoryRule
+                {
+                    Name = "Old uncategorized Costco rule",
+                    RuleRegex = "Costco",
+                    ExpenseCategoryID = null
+                },
+                new ExpenseCategoryRule
+                {
+                    Name = "Current Costco rule",
+                    RuleRegex = "Costco",
+                    ExpenseCategoryID = groceriesCategory.ID
+                });
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco haul", Amount = 45_00, SuggestedCategoryId = utilitiesCategory.ID },
+                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Electric bill", Amount = 90_00, SuggestedCategoryId = utilitiesCategory.ID });
+            await context.SaveChangesAsync();
+
+            return groceriesCategory.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.ReapplyRules();
+
+        var dto = (result.Value as ReapplyPendingExpenseRulesResponse) ?? ((OkObjectResult)result.Result!).Value as ReapplyPendingExpenseRulesResponse;
+        await Assert.That(dto!.UpdatedCount).IsEqualTo(2);
+
+        var updatedItems = await context.PendingExpenses
+            .OrderBy(x => x.Date)
+            .ToListAsync();
+
+        await Assert.That(updatedItems[0].SuggestedCategoryId).IsEqualTo(groceriesCategoryId);
+        await Assert.That(updatedItems[1].SuggestedCategoryId).IsNull();
+    }
+
+    [Test]
     public async Task Convert_WithNoItems_ReturnsBadRequest()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -23,6 +23,7 @@ const convertItem = ref<PendingExpenseDto | null>(null)
 const convertDialogOpen = ref(false)
 const deleteAllOpen = ref(false)
 const deletingAll = ref(false)
+const reapplyingRules = ref(false)
 const editingNoteItemId = ref<number | null>(null)
 const noteDrafts = ref<Record<number, string>>({})
 const addRuleOpen = ref(false)
@@ -169,6 +170,19 @@ async function handleDeleteAll() {
   }
 }
 
+async function handleReapplyRules() {
+  reapplyingRules.value = true
+  try {
+    await apiClient.post('/api/pending-expenses/reapply-rules')
+    snackbar.enqueueSnackbar('Pending expense rules re-run', { variant: 'success' })
+    await fetchPendingExpenses()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to re-run pending expense rules', { variant: 'error' })
+  } finally {
+    reapplyingRules.value = false
+  }
+}
+
 function openConvert(item: PendingExpenseDto) {
   convertItem.value = item
   convertDialogOpen.value = true
@@ -248,6 +262,17 @@ onMounted(() => {
       />
 
       <v-spacer />
+
+      <v-btn
+        variant="outlined"
+        size="small"
+        prepend-icon="mdi-refresh"
+        :loading="reapplyingRules"
+        :disabled="reapplyingRules"
+        @click="handleReapplyRules"
+      >
+        Re-run Rules
+      </v-btn>
 
       <v-btn
         variant="outlined"

--- a/SimplyBudgetWeb/Controllers/ImportController.cs
+++ b/SimplyBudgetWeb/Controllers/ImportController.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Import;
 using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
-using System.Text.RegularExpressions;
+using SimplyBudgetWeb.Services;
 
 namespace SimplyBudgetWeb.Controllers;
 
@@ -98,7 +98,8 @@ public class ImportController(BudgetWebContext context) : ControllerBase
     public async Task<IActionResult> Save([FromBody] ImportItemDto[] items)
     {
         var rules = await context.ExpenseCategoryRules
-            .Include(x => x.ExpenseCategory)
+            .Where(x => x.RuleRegex != null)
+            .OrderBy(x => x.ID)
             .ToListAsync();
 
         var pendingExpenses = items
@@ -109,9 +110,7 @@ public class ImportController(BudgetWebContext context) : ControllerBase
                 Description = i.Description,
                 Amount = i.Amount,
                 IsDebit = i.IsDebit,
-                SuggestedCategoryId = rules.FirstOrDefault(
-                    r => r.RuleRegex != null &&
-                        Regex.IsMatch(i.Description ?? "", r.RuleRegex, RegexOptions.IgnoreCase))?.ExpenseCategoryID,
+                SuggestedCategoryId = ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(rules, i.Description),
             })
             .ToList();
 

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
 
 namespace SimplyBudgetWeb.Controllers;
 
@@ -171,6 +172,28 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         return NoContent();
     }
 
+    [HttpPost("reapply-rules")]
+    public async Task<ActionResult<ReapplyPendingExpenseRulesResponse>> ReapplyRules()
+    {
+        var rules = await context.ExpenseCategoryRules
+            .Where(x => x.RuleRegex != null)
+            .OrderBy(x => x.ID)
+            .ToListAsync();
+
+        var pendingExpenses = await context.PendingExpenses
+            .AsTracking()
+            .ToListAsync();
+
+        foreach (var pendingExpense in pendingExpenses)
+        {
+            pendingExpense.SuggestedCategoryId =
+                ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(rules, pendingExpense.Description);
+        }
+
+        await context.SaveChangesAsync();
+        return Ok(new ReapplyPendingExpenseRulesResponse(pendingExpenses.Count));
+    }
+
     /// <summary>
     /// Converts a pending expense into a real expense item (or income item, if it represents a
     /// credit), optionally split across multiple categories, and removes it from the pending list.
@@ -271,3 +294,5 @@ public record ConvertPendingExpenseRequest(
     ConvertPendingExpenseItemRequest[] Items,
     string Version,
     bool IgnoreBudget = false);
+
+public record ReapplyPendingExpenseRulesResponse(int UpdatedCount);

--- a/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatcher.cs
+++ b/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatcher.cs
@@ -1,0 +1,24 @@
+using SimplyBudgetShared.Data;
+using System.Text.RegularExpressions;
+
+namespace SimplyBudgetWeb.Services;
+
+public static class ExpenseCategoryRuleMatcher
+{
+    public static int? GetSuggestedCategoryId(IEnumerable<ExpenseCategoryRule> rules, string? description)
+    {
+        var descriptionToMatch = description ?? "";
+        int? suggestedCategoryId = null;
+
+        foreach (var rule in rules)
+        {
+            if (rule.ExpenseCategoryID is null || string.IsNullOrWhiteSpace(rule.RuleRegex))
+                continue;
+
+            if (Regex.IsMatch(descriptionToMatch, rule.RuleRegex, RegexOptions.IgnoreCase))
+                suggestedCategoryId = rule.ExpenseCategoryID;
+        }
+
+        return suggestedCategoryId;
+    }
+}


### PR DESCRIPTION
## Summary\n- apply import-rule matching through a shared matcher so pending expenses get suggested categories from categorized matches\n- update pending import save logic to use ordered rule evaluation and last-match wins behavior\n- add  to re-run all pending expenses against current rules\n- add a **Re-run Rules** button on Pending Expenses page to trigger the new endpoint\n- add controller tests covering uncategorized-vs-categorized rule precedence and pending reapply behavior\n\n## Validation\n- dotnet test --project SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj\n- pnpm --dir SimplyBudgetWeb.Web build