### PR TITLE
Fix income allocation to support category list with budget remaining

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
@@ -206,6 +206,38 @@ public class ExpenseCategoriesControllerTests
     }
 
     [Test]
+    public async Task GetRemainingBudget_ReturnsRemainingAmountPerCategory()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        var (groceriesId, savingsId) = await mocker.InDbScopeAsync(async context =>
+        {
+            var groceries = new ExpenseCategory { Name = "Groceries", BudgetedAmount = 30000 };
+            var savings = new ExpenseCategory { Name = "Savings", BudgetedPercentage = 10 };
+            context.ExpenseCategories.AddRange(groceries, savings);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.Add(new ExpenseCategoryItem
+            {
+                Date = new DateTime(2026, 1, 10),
+                Description = "Paycheck allocation",
+                Details = [new ExpenseCategoryItemDetail { Amount = 10000, ExpenseCategoryId = groceries.ID }],
+            });
+            await context.SaveChangesAsync();
+            return (groceries.ID, savings.ID);
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.GetRemainingBudget(new DateTime(2026, 1, 15));
+
+        await Assert.That(result[groceriesId]).IsEqualTo(20000);
+        await Assert.That(result[savingsId]).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task GetMonthlyExpenses_ReturnsMonthlySpendingAndBudgetedAmount()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
@@ -3,7 +3,8 @@ import { computed, ref, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type { ExpenseCategoryDto, TransactionRequest, TransferRequest } from '@/types'
-import { formatCents } from '@/utils/currency'
+import { formatCents, dollarsToCents, centsToDollars } from '@/utils/currency'
+import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
 
 const props = defineProps<{
   modelValue: boolean
@@ -28,6 +29,8 @@ const tab = ref<'transaction' | 'income' | 'transfer'>('transaction')
 const description = ref('')
 const date = ref(new Date().toISOString().split('T')[0])
 const lines = ref<LineItem[]>([emptyLine()])
+const incomeTotal = ref('')
+const incomeAllocations = ref<Record<number, string>>({})
 const transferAmount = ref('')
 const fromCategoryId = ref<number | null>(null)
 const toCategoryId = ref<number | null>(null)
@@ -46,6 +49,8 @@ function resetForm() {
   description.value = ''
   date.value = new Date().toISOString().split('T')[0]
   lines.value = [emptyLine()]
+  incomeTotal.value = ''
+  incomeAllocations.value = {}
   transferAmount.value = ''
   fromCategoryId.value = null
   toCategoryId.value = null
@@ -56,14 +61,6 @@ function close() {
   closeCalculator()
   resetForm()
   emit('update:modelValue', false)
-}
-
-function dollarsToCents(s: string) {
-  return Math.round((parseFloat(s) || 0) * 100)
-}
-
-function centsToDollars(cents: number) {
-  return (cents / 100).toFixed(2)
 }
 
 function isValidCategoryId(value: LineItem['expenseCategoryId']): value is number {
@@ -86,6 +83,23 @@ const canSubmitLines = computed(() =>
   !hasPartialLines.value && lines.value.some(isCompleteLine),
 )
 
+const incomeTotalCents = computed(() => dollarsToCents(incomeTotal.value))
+
+const incomeAllocatedCents = computed(() =>
+  Object.values(incomeAllocations.value).reduce((sum, amount) => sum + dollarsToCents(amount || '0'), 0),
+)
+
+const incomeRemainingCents = computed(() => incomeTotalCents.value - incomeAllocatedCents.value)
+
+const canSubmitIncome = computed(() =>
+  incomeTotalCents.value > 0 && incomeRemainingCents.value === 0,
+)
+
+const dateAsMonth = computed(() => {
+  const parsed = new Date(date.value)
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed
+})
+
 const calculatorTotalCents = computed(() => {
   const subtotal = calculatorItems.value.reduce((sum, amount) => sum + amount, 0)
   return calculatorAddTax.value ? Math.round(subtotal * 1.091) : subtotal
@@ -95,7 +109,7 @@ watch(
   lines,
   currentLines => {
     if (
-      (tab.value === 'transaction' || tab.value === 'income')
+      tab.value === 'transaction'
       && currentLines.length > 0
       && currentLines.every(line => isCompleteLine(line))
     ) {
@@ -140,9 +154,8 @@ function applyCalculator() {
 async function submit() {
   submitting.value = true
   try {
-    if (tab.value === 'transaction' || tab.value === 'income') {
+    if (tab.value === 'transaction') {
       if (!canSubmitLines.value) return
-      const endpoint = tab.value === 'transaction' ? '/api/transactions/transaction' : '/api/transactions/income'
       const payload: TransactionRequest = {
         description: description.value,
         date: date.value,
@@ -153,8 +166,22 @@ async function submit() {
             amount: dollarsToCents(l.amount),
           })),
       }
-      await apiClient.post(endpoint, payload)
-      snackbar.enqueueSnackbar(tab.value === 'transaction' ? 'Transaction added' : 'Income added', { variant: 'success' })
+      await apiClient.post('/api/transactions/transaction', payload)
+      snackbar.enqueueSnackbar('Transaction added', { variant: 'success' })
+    } else if (tab.value === 'income') {
+      if (!canSubmitIncome.value) return
+      const payload: TransactionRequest = {
+        description: description.value,
+        date: date.value,
+        items: Object.entries(incomeAllocations.value)
+          .map(([categoryId, amount]) => ({
+            expenseCategoryId: Number(categoryId),
+            amount: dollarsToCents(amount),
+          }))
+          .filter(item => item.amount > 0),
+      }
+      await apiClient.post('/api/transactions/income', payload)
+      snackbar.enqueueSnackbar('Income added', { variant: 'success' })
     } else {
       const payload: TransferRequest = {
         description: description.value,
@@ -191,7 +218,7 @@ async function submit() {
           <v-text-field label="Description" v-model="description" hide-details />
           <v-text-field label="Date" type="date" v-model="date" hide-details />
 
-          <template v-if="tab === 'transaction' || tab === 'income'">
+          <template v-if="tab === 'transaction'">
             <span class="text-subtitle-2">Items</span>
             <div v-for="(item, index) in lines" :key="index" class="allocation-line d-flex align-center ga-1">
               <v-combobox
@@ -242,6 +269,24 @@ async function submit() {
             </span>
           </template>
 
+          <template v-else-if="tab === 'income'">
+            <v-text-field
+              label="Total Income Amount ($)"
+              type="number"
+              step="0.01"
+              min="0"
+              v-model="incomeTotal"
+              hide-details
+            />
+            <span class="text-subtitle-2">Allocate to Categories</span>
+            <IncomeAllocationList
+              :total-cents="incomeTotalCents"
+              :categories="props.categories"
+              :month="dateAsMonth"
+              v-model="incomeAllocations"
+            />
+          </template>
+
           <template v-else>
             <v-text-field label="Amount ($)" type="number" step="0.01" min="0" v-model="transferAmount" />
             <v-select label="From Category" :items="props.categories" item-title="name" item-value="id" v-model="fromCategoryId" />
@@ -255,7 +300,7 @@ async function submit() {
         <v-btn
           color="primary"
           :loading="submitting"
-          :disabled="(tab === 'transaction' || tab === 'income') && !canSubmitLines"
+          :disabled="(tab === 'transaction' && !canSubmitLines) || (tab === 'income' && !canSubmitIncome)"
           @click="submit"
         >
           Save
@@ -263,6 +308,7 @@ async function submit() {
       </v-card-actions>
     </v-card>
   </v-dialog>
+
 
   <v-dialog v-model="calculatorOpen" max-width="400">
     <v-card>

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -3,7 +3,8 @@ import { ref, computed, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type { ExpenseCategoryDto, PendingExpenseDto, ConvertPendingExpenseRequest } from '@/types'
-import { formatCents } from '@/utils/currency'
+import { formatCents, dollarsToCents, centsToDollars } from '@/utils/currency'
+import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
 
 const props = defineProps<{
   modelValue: boolean
@@ -28,6 +29,7 @@ const emptyLine = (): LineItem => ({ expenseCategoryId: null, amount: '' })
 const description = ref('')
 const date = ref('')
 const lines = ref<LineItem[]>([emptyLine()])
+const incomeAllocations = ref<Record<number, string>>({})
 const ignoreBudget = ref(false)
 const submitting = ref(false)
 const calculatorOpen = ref(false)
@@ -35,14 +37,6 @@ const calculatorLineIndex = ref<number | null>(null)
 const calculatorInput = ref('')
 const calculatorItems = ref<number[]>([])
 const calculatorAddTax = ref(false)
-
-function centsToDollars(cents: number) {
-  return (cents / 100).toFixed(2)
-}
-
-function dollarsToCents(s: string) {
-  return Math.round((parseFloat(s) || 0) * 100)
-}
 
 function isValidCategoryId(value: LineItem['expenseCategoryId']): value is number {
   return typeof value === 'number' && props.categories.some(category => category.id === value)
@@ -58,7 +52,8 @@ function isCompleteLine(line: LineItem): line is LineItem & { expenseCategoryId:
 
 // Pre-fill the form whenever a new pending expense is opened for conversion:
 // a single line item defaulting to the suggested category (if any) and the
-// full amount, ready for the user to edit or split across categories.
+// full amount, ready for the user to edit or split across categories. Income
+// (credit) items instead use the allocation list, seeded empty.
 watch(
   () => props.pendingExpense,
   pe => {
@@ -70,6 +65,7 @@ watch(
       expenseCategoryId: pe.suggestedCategoryId ?? null,
       amount: centsToDollars(pe.amount),
     }]
+    incomeAllocations.value = {}
   },
   { immediate: true },
 )
@@ -78,8 +74,20 @@ const sortedCategories = computed(() =>
   [...props.categories].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
 )
 
+const dateAsMonth = computed(() => {
+  const parsed = new Date(date.value)
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed
+})
+
+const incomeRemainingCents = computed(() => {
+  if (!props.pendingExpense) return 0
+  const allocated = Object.values(incomeAllocations.value).reduce((sum, amount) => sum + dollarsToCents(amount || '0'), 0)
+  return props.pendingExpense.amount - allocated
+})
+
 const remainingCents = computed(() => {
   if (!props.pendingExpense) return 0
+  if (!props.pendingExpense.isDebit) return incomeRemainingCents.value
   const allocated = lines.value.reduce((sum, l) => sum + dollarsToCents(l.amount || '0'), 0)
   return props.pendingExpense.amount - allocated
 })
@@ -88,11 +96,13 @@ const hasPartialLines = computed(() =>
   lines.value.some(line => !isEmptyLine(line) && !isCompleteLine(line)),
 )
 
-const canSubmit = computed(() =>
-  remainingCents.value === 0
-  && !hasPartialLines.value
-  && lines.value.some(isCompleteLine),
-)
+const canSubmit = computed(() => {
+  if (!props.pendingExpense) return false
+  if (!props.pendingExpense.isDebit) return incomeRemainingCents.value === 0
+  return remainingCents.value === 0
+    && !hasPartialLines.value
+    && lines.value.some(isCompleteLine)
+})
 
 const calculatorTotalCents = computed(() => {
   const subtotal = calculatorItems.value.reduce((sum, amount) => sum + amount, 0)
@@ -158,17 +168,26 @@ async function submit() {
   if (!props.pendingExpense || !canSubmit.value) return
   submitting.value = true
   try {
+    const items = props.pendingExpense.isDebit
+      ? lines.value
+        .filter(isCompleteLine)
+        .map(l => ({
+          expenseCategoryId: l.expenseCategoryId,
+          amount: dollarsToCents(l.amount),
+        }))
+      : Object.entries(incomeAllocations.value)
+        .map(([categoryId, amount]) => ({
+          expenseCategoryId: Number(categoryId),
+          amount: dollarsToCents(amount),
+        }))
+        .filter(item => item.amount > 0)
+
     const payload: ConvertPendingExpenseRequest = {
       description: description.value,
       date: date.value,
       version: props.pendingExpense.version,
       ignoreBudget: ignoreBudget.value,
-      items: lines.value
-        .filter(isCompleteLine)
-        .map(l => ({
-          expenseCategoryId: l.expenseCategoryId,
-          amount: dollarsToCents(l.amount),
-        })),
+      items,
     }
     await apiClient.post(`/api/pending-expenses/${props.pendingExpense.id}/convert`, payload)
     snackbar.enqueueSnackbar('Pending expense converted', { variant: 'success' })
@@ -202,63 +221,73 @@ async function submit() {
             />
           </div>
 
-          <span class="text-subtitle-2">
-            {{ pendingExpense.isDebit ? 'Split expense across categories' : 'Split income across categories' }}
-          </span>
-          <div v-for="(item, index) in lines" :key="index" class="allocation-line d-flex align-center ga-1">
-            <v-combobox
-              label="Category"
-              :items="sortedCategories"
-              item-title="name"
-              item-value="id"
-              v-model="item.expenseCategoryId"
-              :return-object="false"
-              auto-select-first="exact"
-              clearable
-              hide-details
-              :error="item.expenseCategoryId !== null && !isValidCategoryId(item.expenseCategoryId)"
-              density="compact"
-              class="category-field"
-            />
-            <div class="amount-field d-flex align-center ga-1">
-              <v-text-field
-                label="Amount ($)"
-                type="number"
-                step="0.01"
-                min="0"
-                v-model="item.amount"
+          <template v-if="pendingExpense.isDebit">
+            <span class="text-subtitle-2">Split expense across categories</span>
+            <div v-for="(item, index) in lines" :key="index" class="allocation-line d-flex align-center ga-1">
+              <v-combobox
+                label="Category"
+                :items="sortedCategories"
+                item-title="name"
+                item-value="id"
+                v-model="item.expenseCategoryId"
+                :return-object="false"
+                auto-select-first="exact"
+                clearable
                 hide-details
+                :error="item.expenseCategoryId !== null && !isValidCategoryId(item.expenseCategoryId)"
                 density="compact"
+                class="category-field"
               />
+              <div class="amount-field d-flex align-center ga-1">
+                <v-text-field
+                  label="Amount ($)"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  v-model="item.amount"
+                  hide-details
+                  density="compact"
+                />
+                <v-btn
+                  icon="mdi-calculator"
+                  size="small"
+                  variant="text"
+                  aria-label="Open amount calculator"
+                  @click="openCalculator(index)"
+                />
+              </div>
               <v-btn
-                icon="mdi-calculator"
+                v-if="lines.length > 1"
+                icon="mdi-delete"
                 size="small"
                 variant="text"
-                aria-label="Open amount calculator"
-                @click="openCalculator(index)"
+                color="error"
+                aria-label="Remove line"
+                class="align-self-center"
+                @click="removeLine(index)"
               />
             </div>
-            <v-btn
-              v-if="lines.length > 1"
-              icon="mdi-delete"
-              size="small"
-              variant="text"
-              color="error"
-              aria-label="Remove line"
-              class="align-self-center"
-              @click="removeLine(index)"
-            />
-          </div>
 
-          <span
-            class="text-body-2"
-            :class="remainingCents === 0 ? 'text-success' : 'text-warning'"
-          >
-            Remaining to allocate: {{ formatCents(remainingCents) }}
-          </span>
-          <span v-if="hasPartialLines" class="text-body-2 text-error">
-            Each line item must have a category and an amount greater than zero.
-          </span>
+            <span
+              class="text-body-2"
+              :class="remainingCents === 0 ? 'text-success' : 'text-warning'"
+            >
+              Remaining to allocate: {{ formatCents(remainingCents) }}
+            </span>
+            <span v-if="hasPartialLines" class="text-body-2 text-error">
+              Each line item must have a category and an amount greater than zero.
+            </span>
+          </template>
+
+          <template v-else>
+            <span class="text-subtitle-2">Allocate income to categories</span>
+            <IncomeAllocationList
+              :total-cents="pendingExpense.amount"
+              :categories="sortedCategories"
+              :month="dateAsMonth"
+              v-model="incomeAllocations"
+            />
+          </template>
         </div>
       </v-card-text>
       <v-card-actions>

--- a/SimplyBudgetWeb.Web/src/components/IncomeAllocationList.vue
+++ b/SimplyBudgetWeb.Web/src/components/IncomeAllocationList.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { apiClient } from '@/services/apiClient'
+import type { ExpenseCategoryDto } from '@/types'
+import { formatCents, dollarsToCents, centsToDollars } from '@/utils/currency'
+
+const props = defineProps<{
+  /** Total income amount (in cents) being allocated. */
+  totalCents: number
+  categories: ExpenseCategoryDto[]
+  /** Month whose budget remaining amounts should be shown/used (any date within the month). */
+  month: Date
+  /** Dollar-string amount per expense category id. */
+  modelValue: Record<number, string>
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: Record<number, string>]
+}>()
+
+const remainingBudgetByCategory = ref<Record<number, number>>({})
+
+async function loadRemainingBudget() {
+  const year = props.month.getFullYear()
+  const month = String(props.month.getMonth() + 1).padStart(2, '0')
+  try {
+    remainingBudgetByCategory.value = await apiClient.get<Record<number, number>>(
+      `/api/expense-categories/remaining-budget?month=${year}-${month}-01`,
+    ) ?? {}
+  } catch {
+    remainingBudgetByCategory.value = {}
+  }
+}
+
+watch(() => props.month, loadRemainingBudget, { immediate: true })
+
+function amountFor(categoryId: number): string {
+  return props.modelValue[categoryId] ?? ''
+}
+
+function setAmount(categoryId: number, amount: string) {
+  emit('update:modelValue', { ...props.modelValue, [categoryId]: amount })
+}
+
+function amountCentsFor(categoryId: number): number {
+  return dollarsToCents(amountFor(categoryId))
+}
+
+function remainingBudgetFor(category: ExpenseCategoryDto): number {
+  return remainingBudgetByCategory.value[category.id] ?? 0
+}
+
+function percentageAmountFor(category: ExpenseCategoryDto): number {
+  return Math.round((category.budgetedPercentage / 100) * props.totalCents)
+}
+
+// Categories first by percentage-based (percentage before fixed), then by whether there's a
+// pending/remaining budget amount for the month, then alphabetically.
+const sortedCategories = computed(() =>
+  [...props.categories].sort((a, b) => {
+    if (a.usePercentage !== b.usePercentage) return a.usePercentage ? -1 : 1
+
+    const aHasRemaining = !a.usePercentage && remainingBudgetFor(a) > 0
+    const bHasRemaining = !b.usePercentage && remainingBudgetFor(b) > 0
+    if (aHasRemaining !== bHasRemaining) return aHasRemaining ? -1 : 1
+
+    return (a.name ?? '').localeCompare(b.name ?? '')
+  }),
+)
+
+const allocatedCents = computed(() =>
+  props.categories.reduce((sum, c) => sum + amountCentsFor(c.id), 0),
+)
+
+const remainingCents = computed(() => props.totalCents - allocatedCents.value)
+
+defineExpose({ remainingCents })
+
+function applyRemainingBudget(category: ExpenseCategoryDto) {
+  setAmount(category.id, centsToDollars(remainingBudgetFor(category)))
+}
+
+function applyPercentage(category: ExpenseCategoryDto) {
+  setAmount(category.id, centsToDollars(percentageAmountFor(category)))
+}
+</script>
+
+<template>
+  <div class="d-flex flex-column ga-1">
+    <div
+      v-for="category in sortedCategories"
+      :key="category.id"
+      class="income-allocation-row d-flex align-center ga-2"
+    >
+      <div class="category-info">
+        <div>{{ category.name }}</div>
+        <div class="text-caption text-medium-emphasis">
+          <template v-if="category.usePercentage">
+            Budget:
+            <a href="#" class="allocation-link" @click.prevent="applyPercentage(category)">
+              {{ category.budgetedPercentage }}%
+            </a>
+          </template>
+          <template v-else>
+            Budget: {{ formatCents(category.budgetedAmount) }} &middot; Remaining:
+            <a href="#" class="allocation-link" @click.prevent="applyRemainingBudget(category)">
+              {{ formatCents(remainingBudgetFor(category)) }}
+            </a>
+          </template>
+        </div>
+      </div>
+      <v-text-field
+        label="Amount ($)"
+        type="number"
+        step="0.01"
+        min="0"
+        :model-value="amountFor(category.id)"
+        @update:model-value="(val: string) => setAmount(category.id, val)"
+        hide-details
+        density="compact"
+        class="amount-field"
+      />
+    </div>
+
+    <div
+      class="text-body-2 mt-2"
+      :class="remainingCents === 0 ? 'text-success' : 'text-warning'"
+    >
+      Remaining to allocate: {{ formatCents(remainingCents) }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.income-allocation-row {
+  min-height: 40px;
+}
+
+.category-info {
+  flex: 2 1 0;
+}
+
+.amount-field {
+  flex: 1 1 160px;
+}
+
+.allocation-link {
+  text-decoration: underline;
+}
+</style>

--- a/SimplyBudgetWeb.Web/src/utils/currency.ts
+++ b/SimplyBudgetWeb.Web/src/utils/currency.ts
@@ -10,3 +10,11 @@ export function parseMonth(yearMonth: string): Date {
   const [year, month] = yearMonth.split('-').map(Number)
   return new Date(year, month - 1, 1)
 }
+
+export function dollarsToCents(s: string): number {
+  return Math.round((parseFloat(s) || 0) * 100)
+}
+
+export function centsToDollars(cents: number): string {
+  return (cents / 100).toFixed(2)
+}

--- a/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
+++ b/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
@@ -36,6 +36,29 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         return ToDto(category, await context.HasItemsAsync(category));
     }
 
+    /// <summary>
+    /// Returns, for every visible (non-hidden, non-percentage) category, how much of its
+    /// budgeted amount for the given month has not yet been allocated. Used by the income
+    /// allocation UI to show/pre-fill the remaining budget for each category. Percentage-based
+    /// categories always report 0 here since their allocation is computed from the income total.
+    /// </summary>
+    [HttpGet("remaining-budget")]
+    public async Task<Dictionary<int, int>> GetRemainingBudget([FromQuery] DateTime? month)
+    {
+        var monthDate = (month ?? DateTime.Today).StartOfMonth();
+
+        var categories = await context.ExpenseCategories
+            .Where(c => !c.IsHidden)
+            .ToListAsync();
+
+        var result = new Dictionary<int, int>();
+        foreach (var category in categories)
+        {
+            result[category.ID] = await context.GetRemainingBudgetAmount(category, monthDate);
+        }
+        return result;
+    }
+
     [HttpGet("{id}/monthly-expenses")]
     public async Task<ActionResult<ExpenseCategoryMonthlyExpensesDto>> GetMonthlyExpenses(
         int id,


### PR DESCRIPTION
## Summary
Fixes the Add Income tab (Expenses page) and Add Income from Pending Expenses so they no longer treat income like an outgoing transaction split. Based on how the WPF desktop app allocates income.

- Total income amount shown at the top.
- List of all categories, each with an amount field, showing budgeted amount and remaining budget for the month.
- Clicking the remaining amount fills the amount field with that value.
- Clicking the percentage (for percentage-based categories) fills the amount field with that percent of total income (rounded to nearest cent).
- Categories sorted: percentage-based first, then by whether there's a pending/remaining budget amount, then alphabetically.
- Remaining-to-allocate shown at the bottom of the dialog.
- Submit is disabled until the full income amount is allocated.

## Changes
- New GET /api/expense-categories/remaining-budget?month= endpoint (reuses GetRemainingBudgetAmount).
- New IncomeAllocationList.vue reusable component implementing the allocation list/sorting/click-to-fill behavior.
- AddTransactionDialog.vue (Add Income tab) and ConvertPendingExpenseDialog.vue (income/credit pending expense conversion) now use this component instead of the generic transaction line-item UI.

## Testing
- \dotnet build\ for the web solution succeeds.
- \dotnet test\ for \SimplyBudgetWeb.Core.Tests\ — all 71 tests pass, including new tests for the \emaining-budget\ endpoint.
- \
pm run build\ (vue-tsc + vite) and \
pm run lint\ pass for the frontend.