### PR TITLE
Refine income allocation UX: cap remaining-fill, disable at zero, fix month timezone bug, sticky footer

### DIFF
--- a/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type { ExpenseCategoryDto, TransactionRequest, TransferRequest } from '@/types'
-import { formatCents, dollarsToCents, centsToDollars } from '@/utils/currency'
+import { formatCents, dollarsToCents, centsToDollars, parseLocalDate } from '@/utils/currency'
 import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
 
 const props = defineProps<{
@@ -95,10 +95,7 @@ const canSubmitIncome = computed(() =>
   incomeTotalCents.value > 0 && incomeRemainingCents.value === 0,
 )
 
-const dateAsMonth = computed(() => {
-  const parsed = new Date(date.value)
-  return Number.isNaN(parsed.getTime()) ? new Date() : parsed
-})
+const dateAsMonth = computed(() => parseLocalDate(date.value))
 
 const calculatorTotalCents = computed(() => {
   const subtotal = calculatorItems.value.reduce((sum, amount) => sum + amount, 0)
@@ -207,7 +204,7 @@ async function submit() {
   <v-dialog :model-value="props.modelValue" max-width="600" @update:model-value="(val: boolean) => !val && close()">
     <v-card>
       <v-card-title>Add Transaction</v-card-title>
-      <v-card-text>
+      <v-card-text class="dialog-scroll-area">
         <v-tabs v-model="tab" class="mb-4">
           <v-tab value="transaction">Transaction</v-tab>
           <v-tab value="income">Income</v-tab>
@@ -294,6 +291,14 @@ async function submit() {
           </template>
         </div>
       </v-card-text>
+      <div v-if="tab === 'income'" class="px-4 pt-2">
+        <span
+          class="text-body-2"
+          :class="incomeRemainingCents === 0 ? 'text-success' : 'text-warning'"
+        >
+          Remaining to allocate: {{ formatCents(incomeRemainingCents) }}
+        </span>
+      </div>
       <v-card-actions>
         <v-spacer />
         <v-btn @click="close">Cancel</v-btn>
@@ -360,6 +365,11 @@ async function submit() {
 </template>
 
 <style scoped>
+.dialog-scroll-area {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
 .allocation-line {
   min-height: 40px;
 }

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type { ExpenseCategoryDto, PendingExpenseDto, ConvertPendingExpenseRequest } from '@/types'
-import { formatCents, dollarsToCents, centsToDollars } from '@/utils/currency'
+import { formatCents, dollarsToCents, centsToDollars, parseLocalDate } from '@/utils/currency'
 import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
 
 const props = defineProps<{
@@ -74,10 +74,7 @@ const sortedCategories = computed(() =>
   [...props.categories].sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
 )
 
-const dateAsMonth = computed(() => {
-  const parsed = new Date(date.value)
-  return Number.isNaN(parsed.getTime()) ? new Date() : parsed
-})
+const dateAsMonth = computed(() => parseLocalDate(date.value))
 
 const incomeRemainingCents = computed(() => {
   if (!props.pendingExpense) return 0
@@ -205,7 +202,7 @@ async function submit() {
   <v-dialog :model-value="props.modelValue" max-width="600" @update:model-value="(val: boolean) => !val && close()">
     <v-card v-if="pendingExpense">
       <v-card-title>Convert Pending Expense</v-card-title>
-      <v-card-text>
+      <v-card-text class="dialog-scroll-area">
         <div class="d-flex flex-column ga-3">
           <v-text-field label="Description" v-model="description" hide-details />
           <v-text-field label="Date" type="date" v-model="date" hide-details />
@@ -268,12 +265,6 @@ async function submit() {
               />
             </div>
 
-            <span
-              class="text-body-2"
-              :class="remainingCents === 0 ? 'text-success' : 'text-warning'"
-            >
-              Remaining to allocate: {{ formatCents(remainingCents) }}
-            </span>
             <span v-if="hasPartialLines" class="text-body-2 text-error">
               Each line item must have a category and an amount greater than zero.
             </span>
@@ -290,6 +281,14 @@ async function submit() {
           </template>
         </div>
       </v-card-text>
+      <div class="px-4 pt-2">
+        <span
+          class="text-body-2"
+          :class="remainingCents === 0 ? 'text-success' : 'text-warning'"
+        >
+          Remaining to allocate: {{ formatCents(remainingCents) }}
+        </span>
+      </div>
       <v-card-actions>
         <v-spacer />
         <v-btn @click="close">Cancel</v-btn>
@@ -348,6 +347,11 @@ async function submit() {
 </template>
 
 <style scoped>
+.dialog-scroll-area {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
 .allocation-line {
   min-height: 40px;
 }

--- a/SimplyBudgetWeb.Web/src/components/IncomeAllocationList.vue
+++ b/SimplyBudgetWeb.Web/src/components/IncomeAllocationList.vue
@@ -77,7 +77,13 @@ const remainingCents = computed(() => props.totalCents - allocatedCents.value)
 defineExpose({ remainingCents })
 
 function applyRemainingBudget(category: ExpenseCategoryDto) {
-  setAmount(category.id, centsToDollars(remainingBudgetFor(category)))
+  const budgetRemaining = remainingBudgetFor(category)
+  if (budgetRemaining <= 0) return
+  // Cap at the smaller of the category's remaining budget or what's left to allocate overall
+  // (including this row's own current amount, since that's being replaced, not added to).
+  const availableToAllocate = remainingCents.value + amountCentsFor(category.id)
+  const amount = Math.max(0, Math.min(budgetRemaining, availableToAllocate))
+  setAmount(category.id, centsToDollars(amount))
 }
 
 function applyPercentage(category: ExpenseCategoryDto) {
@@ -103,9 +109,17 @@ function applyPercentage(category: ExpenseCategoryDto) {
           </template>
           <template v-else>
             Budget: {{ formatCents(category.budgetedAmount) }} &middot; Remaining:
-            <a href="#" class="allocation-link" @click.prevent="applyRemainingBudget(category)">
+            <a
+              v-if="remainingBudgetFor(category) > 0"
+              href="#"
+              class="allocation-link"
+              @click.prevent="applyRemainingBudget(category)"
+            >
               {{ formatCents(remainingBudgetFor(category)) }}
             </a>
+            <span v-else class="allocation-link-disabled">
+              {{ formatCents(remainingBudgetFor(category)) }}
+            </span>
           </template>
         </div>
       </div>
@@ -120,13 +134,6 @@ function applyPercentage(category: ExpenseCategoryDto) {
         density="compact"
         class="amount-field"
       />
-    </div>
-
-    <div
-      class="text-body-2 mt-2"
-      :class="remainingCents === 0 ? 'text-success' : 'text-warning'"
-    >
-      Remaining to allocate: {{ formatCents(remainingCents) }}
     </div>
   </div>
 </template>
@@ -146,5 +153,10 @@ function applyPercentage(category: ExpenseCategoryDto) {
 
 .allocation-link {
   text-decoration: underline;
+}
+
+.allocation-link-disabled {
+  text-decoration: underline;
+  opacity: 0.5;
 }
 </style>

--- a/SimplyBudgetWeb.Web/src/utils/currency.ts
+++ b/SimplyBudgetWeb.Web/src/utils/currency.ts
@@ -11,6 +11,17 @@ export function parseMonth(yearMonth: string): Date {
   return new Date(year, month - 1, 1)
 }
 
+/**
+ * Parses a `yyyy-MM-dd` (or `yyyy-MM`) date-input string as a local date, avoiding the
+ * UTC-midnight interpretation that `new Date(string)` uses for ISO date-only strings (which
+ * shifts to the previous day/month in negative-UTC-offset timezones).
+ */
+export function parseLocalDate(dateString: string): Date {
+  const [year, month, day] = dateString.split('-').map(Number)
+  if (!year || !month) return new Date()
+  return new Date(year, month - 1, day || 1)
+}
+
 export function dollarsToCents(s: string): number {
   return Math.round((parseFloat(s) || 0) * 100)
 }


### PR DESCRIPTION
Follow-up refinements to the income allocation UI (from #178):

1. Clicking a category's "remaining" link now fills `min(remaining budget, total remaining to allocate)` instead of always filling the full remaining budget amount.
2. When a category's remaining budget for the month is `$0`, its remaining-amount link is disabled (rendered as plain, non-interactive text).
3. Fixed a timezone bug where the month passed to the remaining-budget lookup was computed via `new Date(dateString)`, which parses ISO date-only strings as UTC midnight. In negative-UTC-offset timezones this rolled the date back to the previous day/month, so income already allocated to a category in the target month wasn't reflected in its remaining-budget amount. Added a `parseLocalDate()` helper that parses `yyyy-MM-dd` strings as local dates instead, and used it in both `AddTransactionDialog.vue` and `ConvertPendingExpenseDialog.vue`.
4. The "Remaining to allocate" summary and the Apply/Cancel action buttons are now pinned outside the scrollable category list, so they stay visible regardless of scroll position within the dialog.

Verified with `npm run build` and `npm run lint` (both pass) and `dotnet build` on the full solution (no backend changes required for this pass — the month bug was a frontend parsing issue).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>