### PR TITLE
Limit auto-added split lines to remaining allocation

### DIFF
--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -109,12 +109,33 @@ const calculatorTotalCents = computed(() => {
 watch(
   lines,
   currentLines => {
-    if (
+    if (!props.pendingExpense?.isDebit) return
+
+    const nonEmptyLines = currentLines.filter(line => !isEmptyLine(line))
+    const shouldAddEmptyLine = (
       remainingCents.value > 0
-      && currentLines.length > 0
-      && currentLines.every(line => dollarsToCents(line.amount) > 0)
-    ) {
-      currentLines.push(emptyLine())
+      && nonEmptyLines.length > 0
+      && nonEmptyLines.every(isCompleteLine)
+    )
+
+    const nextLines = shouldAddEmptyLine
+      ? [...nonEmptyLines, emptyLine()]
+      : nonEmptyLines.length > 0
+        ? nonEmptyLines
+        : [emptyLine()]
+
+    const didChange = (
+      currentLines.length !== nextLines.length
+      || currentLines.some((line, index) => {
+        const nextLine = nextLines[index]
+        return !nextLine
+          || line.expenseCategoryId !== nextLine.expenseCategoryId
+          || line.amount !== nextLine.amount
+      })
+    )
+
+    if (didChange) {
+      lines.value = nextLines
     }
   },
   { deep: true },


### PR DESCRIPTION
## Summary\n- update pending expense conversion split-line auto-add behavior\n- only append a new empty line while there is remaining amount and all entered lines are complete\n- remove empty lines once allocation is complete so only entered items are kept\n\n## Validation\n- pnpm build (SimplyBudgetWeb.Web)