### PR TITLE
Include amounts in list search filters

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
@@ -9,6 +9,30 @@ namespace SimplyBudgetWeb.Core.Tests.Controllers;
 public class ExpenseCategoriesControllerTests
 {
     [Test]
+    public async Task GetAll_FiltersByAmount()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.ExpenseCategories.AddRange(
+                new ExpenseCategory { Name = "Groceries", BudgetedAmount = 1234 },
+                new ExpenseCategory { Name = "Savings", BudgetedAmount = 3000 });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.GetAll(includeHidden: true, search: "12.34");
+
+        await Assert.That(result.Length).IsEqualTo(1);
+        await Assert.That(result[0].Name).IsEqualTo("Groceries");
+        await Assert.That(result[0].BudgetedAmount).IsEqualTo(1234);
+    }
+
+    [Test]
     public async Task Update_RenamesCategory()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
@@ -1,0 +1,51 @@
+using Moq.AutoMock;
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class HistoryControllerTests
+{
+    [Test]
+    public async Task GetAll_FiltersByAmount()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.AddRange(
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 1, 10),
+                    Description = "Small purchase",
+                    Details = [new ExpenseCategoryItemDetail { Amount = -1234, ExpenseCategoryId = category.ID }],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 1, 12),
+                    Description = "Large purchase",
+                    Details = [new ExpenseCategoryItemDetail { Amount = -2500, ExpenseCategoryId = category.ID }],
+                });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new HistoryController(context);
+
+        var result = await controller.GetAll(
+            month: new DateTime(2026, 1, 1),
+            search: "$12.34",
+            categoryId: null,
+            accountId: null);
+
+        await Assert.That(result.Length).IsEqualTo(1);
+        await Assert.That(result[0].Description).IsEqualTo("Small purchase");
+        await Assert.That(result[0].Details[0].Amount).IsEqualTo(-1234);
+    }
+}

--- a/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
@@ -40,7 +40,7 @@ public class HistoryControllerTests
 
         var result = await controller.GetAll(
             month: new DateTime(2026, 1, 1),
-            search: "$12.34",
+            search: "12.34",
             categoryId: null,
             accountId: null);
 

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -144,6 +144,30 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task GetAll_FiltersByAmount()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Utility bill", Amount = 1234 },
+                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Gas station", Amount = 2000 });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetAll(search: "12.34", assigneeId: null);
+
+        await Assert.That(result.Length).IsEqualTo(1);
+        await Assert.That(result[0].Description).IsEqualTo("Utility bill");
+        await Assert.That(result[0].Amount).IsEqualTo(1234);
+    }
+
+    [Test]
     public async Task GetAll_FiltersByAssignee()
     {
         AutoMocker mocker = new();
@@ -398,6 +422,34 @@ public class PendingExpensesControllerTests
         {
             var controller = new PendingExpensesController(context);
             await controller.DeleteAll(search: "Costco", assigneeId: null);
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var remaining = await context.PendingExpenses.ToListAsync();
+            await Assert.That(remaining.Count).IsEqualTo(1);
+            await Assert.That(remaining[0].Description).IsEqualTo("Gas station");
+        });
+    }
+
+    [Test]
+    public async Task DeleteAll_WithAmountSearch_OnlyRemovesMatchingPendingExpenses()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Utility bill", Amount = 1234 },
+                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Gas station", Amount = 2000 });
+            await context.SaveChangesAsync();
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new PendingExpensesController(context);
+            await controller.DeleteAll(search: "$12.34", assigneeId: null);
         }
 
         await mocker.InDbScopeAsync(async context =>

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -449,7 +449,7 @@ public class PendingExpensesControllerTests
         using (var context = mocker.Get<BudgetWebContext>())
         {
             var controller = new PendingExpensesController(context);
-            await controller.DeleteAll(search: "$12.34", assigneeId: null);
+            await controller.DeleteAll(search: "12.34", assigneeId: null);
         }
 
         await mocker.InDbScopeAsync(async context =>

--- a/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
+++ b/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Utilities;
 
 namespace SimplyBudgetWeb.Controllers;
 
@@ -21,7 +22,19 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
             query = query.Where(c => !c.IsHidden);
 
         if (!string.IsNullOrWhiteSpace(search))
-            query = query.Where(c => c.Name != null && c.Name.Contains(search));
+        {
+            var searchText = search.Trim();
+            var hasSearchAmount = SearchAmountParser.TryParseAmountInCents(searchText, out var searchAmountInCents);
+            var searchAmountAbs = Math.Abs(searchAmountInCents);
+
+            query = query.Where(c =>
+                (c.Name != null && c.Name.Contains(searchText)) ||
+                (c.CategoryName != null && c.CategoryName.Contains(searchText)) ||
+                (hasSearchAmount &&
+                 (Math.Abs(c.BudgetedAmount) == searchAmountAbs ||
+                  Math.Abs(c.CurrentBalance) == searchAmountAbs ||
+                  (c.Cap.HasValue && Math.Abs(c.Cap.Value) == searchAmountAbs))));
+        }
 
         var categories = await query.ToListAsync();
         var idsWithItems = await GetIdsWithItemsAsync(categories.Select(c => c.ID));

--- a/SimplyBudgetWeb/Controllers/HistoryController.cs
+++ b/SimplyBudgetWeb/Controllers/HistoryController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Utilities;
 
 namespace SimplyBudgetWeb.Controllers;
 
@@ -27,7 +28,17 @@ public class HistoryController(BudgetWebContext context) : ControllerBase
             .AsQueryable();
 
         if (!string.IsNullOrWhiteSpace(search))
-            query = query.Where(x => x.Description != null && x.Description.Contains(search));
+        {
+            var searchText = search.Trim();
+            var hasSearchAmount = SearchAmountParser.TryParseAmountInCents(searchText, out var searchAmountInCents);
+            var searchAmountAbs = Math.Abs(searchAmountInCents);
+
+            query = query.Where(x =>
+                (x.Description != null && x.Description.Contains(searchText)) ||
+                (hasSearchAmount &&
+                 (x.Details!.Any(d => Math.Abs(d.Amount) == searchAmountAbs) ||
+                  Math.Abs(x.Details!.Sum(d => d.Amount)) == searchAmountAbs)));
+        }
 
         if (categoryId.HasValue)
             query = query.Where(x => x.Details!.Any(d => d.ExpenseCategoryId == categoryId.Value));

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -4,6 +4,7 @@ using SimplyBudgetShared.Data;
 using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
 using SimplyBudgetWeb.Services;
+using SimplyBudgetWeb.Utilities;
 
 namespace SimplyBudgetWeb.Controllers;
 
@@ -37,7 +38,7 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         }
 
         if (!string.IsNullOrWhiteSpace(search))
-            query = query.Where(x => x.Description != null && x.Description.Contains(search));
+            query = ApplySearchFilter(query, search);
 
         if (assigneeId.HasValue)
             query = query.Where(x => x.AssigneeId == assigneeId.Value);
@@ -162,7 +163,7 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         }
 
         if (!string.IsNullOrWhiteSpace(search))
-            query = query.Where(x => x.Description != null && x.Description.Contains(search));
+            query = ApplySearchFilter(query, search);
 
         if (assigneeId.HasValue)
             query = query.Where(x => x.AssigneeId == assigneeId.Value);
@@ -265,6 +266,17 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         {
             return false;
         }
+    }
+
+    private static IQueryable<PendingExpense> ApplySearchFilter(IQueryable<PendingExpense> query, string search)
+    {
+        var searchText = search.Trim();
+        var hasSearchAmount = SearchAmountParser.TryParseAmountInCents(searchText, out var searchAmountInCents);
+        var searchAmountAbs = Math.Abs(searchAmountInCents);
+
+        return query.Where(x =>
+            (x.Description != null && x.Description.Contains(searchText)) ||
+            (hasSearchAmount && Math.Abs(x.Amount) == searchAmountAbs));
     }
 }
 

--- a/SimplyBudgetWeb/Utilities/SearchAmountParser.cs
+++ b/SimplyBudgetWeb/Utilities/SearchAmountParser.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+
+namespace SimplyBudgetWeb.Utilities;
+
+internal static class SearchAmountParser
+{
+    public static bool TryParseAmountInCents(string? value, out int amountInCents)
+    {
+        amountInCents = 0;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var trimmedValue = value.Trim();
+        if (!decimal.TryParse(trimmedValue, NumberStyles.Currency, CultureInfo.CurrentCulture, out var amount) &&
+            !decimal.TryParse(trimmedValue, NumberStyles.Currency, CultureInfo.InvariantCulture, out amount))
+        {
+            return false;
+        }
+
+        amountInCents = (int)Math.Round(amount * 100m, MidpointRounding.AwayFromZero);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary\n- include amount matching in search filters for history, pending expenses, and expense categories\n- keep existing name/description matching behavior and add currency parsing for search terms\n- add controller tests for amount-based search and delete-all filtering\n\n## Testing\n- dotnet test --project SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj