### PR TITLE
Create reusable category selector control

### DIFF
--- a/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
@@ -5,6 +5,7 @@ import { useSnackbarStore } from '@/stores/snackbar'
 import type { ExpenseCategoryDto, TransactionRequest, TransferRequest } from '@/types'
 import { formatCents, dollarsToCents, centsToDollars, parseLocalDate } from '@/utils/currency'
 import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
+import CategorySelector from '@/components/CategorySelector.vue'
 
 const props = defineProps<{
   modelValue: boolean
@@ -222,18 +223,12 @@ async function submit() {
           <template v-if="tab === 'transaction'">
             <span class="text-subtitle-2">Items</span>
             <div v-for="(item, index) in lines" :key="index" class="allocation-line d-flex align-center ga-1">
-              <v-combobox
+              <CategorySelector
                 label="Category"
-                :items="props.categories"
-                item-title="name"
-                item-value="id"
+                :categories="props.categories"
                 v-model="item.expenseCategoryId"
-                :return-object="false"
-                auto-select-first="exact"
-                clearable
-                hide-details
                 :error="item.expenseCategoryId !== null && !isValidCategoryId(item.expenseCategoryId)"
-                density="compact"
+                :allow-custom="true"
                 class="category-field"
               />
               <div class="amount-field d-flex align-center ga-1">
@@ -290,8 +285,8 @@ async function submit() {
 
           <template v-else>
             <v-text-field label="Amount ($)" type="number" step="0.01" min="0" v-model="transferAmount" />
-            <v-select label="From Category" :items="props.categories" item-title="name" item-value="id" v-model="fromCategoryId" />
-            <v-select label="To Category" :items="props.categories" item-title="name" item-value="id" v-model="toCategoryId" />
+            <CategorySelector label="From Category" :categories="props.categories" :clearable="false" v-model="fromCategoryId" />
+            <CategorySelector label="To Category" :categories="props.categories" :clearable="false" v-model="toCategoryId" />
           </template>
         </div>
       </v-card-text>

--- a/SimplyBudgetWeb.Web/src/components/CategorySelector.vue
+++ b/SimplyBudgetWeb.Web/src/components/CategorySelector.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ExpenseCategoryDto } from '@/types'
+
+type CategorySelectorValue = number | string | null
+
+const props = withDefaults(defineProps<{
+  modelValue: CategorySelectorValue
+  categories: ExpenseCategoryDto[]
+  label?: string
+  nullOptionLabel?: string | null
+  clearable?: boolean
+  hideDetails?: boolean | 'auto'
+  density?: 'default' | 'comfortable' | 'compact'
+  error?: boolean
+  allowCustom?: boolean
+  disabled?: boolean
+}>(), {
+  label: 'Category',
+  nullOptionLabel: null,
+  clearable: true,
+  hideDetails: true,
+  density: 'compact',
+  error: false,
+  allowCustom: false,
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: CategorySelectorValue]
+}>()
+
+interface CategoryOption {
+  id: number | null
+  name: string
+}
+
+const items = computed<CategoryOption[]>(() => {
+  const sortedCategories = props.categories
+    .map(category => ({
+      id: category.id,
+      name: category.name ?? `Category ${category.id}`,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+
+  if (props.nullOptionLabel === null) {
+    return sortedCategories
+  }
+
+  return [{ id: null, name: props.nullOptionLabel }, ...sortedCategories]
+})
+
+const validCategoryIds = computed(() => new Set(props.categories.map(category => category.id)))
+
+function updateValue(value: CategorySelectorValue) {
+  if (value === null) {
+    emit('update:modelValue', null)
+    return
+  }
+
+  if (typeof value === 'number') {
+    emit('update:modelValue', validCategoryIds.value.has(value) ? value : null)
+    return
+  }
+
+  const parsedValue = Number(value)
+  if (Number.isInteger(parsedValue) && validCategoryIds.value.has(parsedValue)) {
+    emit('update:modelValue', parsedValue)
+    return
+  }
+
+  emit('update:modelValue', props.allowCustom ? value : null)
+}
+</script>
+
+<template>
+  <v-combobox
+    :model-value="props.modelValue"
+    :label="props.label"
+    :items="items"
+    item-title="name"
+    item-value="id"
+    :return-object="false"
+    auto-select-first="exact"
+    :clearable="props.clearable"
+    :hide-details="props.hideDetails"
+    :density="props.density"
+    :error="props.error"
+    :disabled="props.disabled"
+    @update:model-value="updateValue"
+  />
+</template>

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -5,6 +5,7 @@ import { useSnackbarStore } from '@/stores/snackbar'
 import type { ExpenseCategoryDto, PendingExpenseDto, ConvertPendingExpenseRequest } from '@/types'
 import { formatCents, dollarsToCents, centsToDollars, parseLocalDate } from '@/utils/currency'
 import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
+import CategorySelector from '@/components/CategorySelector.vue'
 
 const props = defineProps<{
   modelValue: boolean
@@ -268,18 +269,12 @@ async function saveNote() {
           <template v-if="pendingExpense.isDebit">
             <span class="text-subtitle-2">Split expense across categories</span>
             <div v-for="(item, index) in lines" :key="index" class="allocation-line d-flex align-center ga-1">
-              <v-combobox
+              <CategorySelector
                 label="Category"
-                :items="sortedCategories"
-                item-title="name"
-                item-value="id"
+                :categories="sortedCategories"
                 v-model="item.expenseCategoryId"
-                :return-object="false"
-                auto-select-first="exact"
-                clearable
-                hide-details
                 :error="item.expenseCategoryId !== null && !isValidCategoryId(item.expenseCategoryId)"
-                density="compact"
+                :allow-custom="true"
                 class="category-field"
               />
               <div class="amount-field d-flex align-center ga-1">

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -10,6 +10,7 @@ import { includesSearchText, tryParseSearchAmountInCents } from '@/utils/search'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
 import { useRoute } from 'vue-router'
+import CategorySelector from '@/components/CategorySelector.vue'
 
 const snackbar = useSnackbarStore()
 const route = useRoute()
@@ -29,7 +30,6 @@ const monthLabel = computed(() =>
   currentMonth.value.toLocaleString('default', { month: 'long', year: 'numeric' }),
 )
 
-const categoryOptions = computed(() => [{ id: null, name: 'All' }, ...categories.value])
 const filteredItems = computed(() => {
   const searchText = search.value.trim()
   if (!searchText) return items.value
@@ -46,7 +46,6 @@ const filteredItems = computed(() => {
       || Math.abs(totalForItem(item)) === searchAmountAbs
   })
 })
-
 function monthGroupLabel(dateString: string) {
   return new Date(dateString).toLocaleDateString('default', { month: 'long', year: 'numeric' })
 }
@@ -136,15 +135,13 @@ function onDialogSuccess() {
 
       <v-text-field label="Search" v-model="search" density="compact" style="max-width: 200px;" hide-details />
 
-      <v-select
+      <CategorySelector
         label="Category"
-        :items="categoryOptions"
-        item-title="name"
-        item-value="id"
+        :categories="categories"
+        null-option-label="All"
+        :clearable="false"
         v-model="categoryId"
-        density="compact"
         style="max-width: 200px;"
-        hide-details
       />
     </v-card>
 

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -9,6 +9,7 @@ import { AMAZON_TRANSACTIONS_URL, hasAmazonInDescription } from '@/utils/merchan
 import { includesSearchText, tryParseSearchAmountInCents } from '@/utils/search'
 import ConvertPendingExpenseDialog from '@/components/ConvertPendingExpenseDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
+import CategorySelector from '@/components/CategorySelector.vue'
 
 const snackbar = useSnackbarStore()
 
@@ -33,7 +34,6 @@ const ruleForm = ref({ name: '', ruleRegex: '', expenseCategoryId: null as numbe
 // "All" plus the real filter options; used for both the toolbar filter and the
 // page-level assignee filter.
 const assigneeFilterOptions = computed(() => [{ id: null, name: 'All' }, ...assignees.value])
-const ruleCategoryOptions = computed(() => [{ id: null, name: 'None' }, ...categories.value])
 const filteredItems = computed(() => {
   const searchText = search.value.trim()
   if (!searchText) return items.value
@@ -48,7 +48,6 @@ const filteredItems = computed(() => {
     return Math.abs(item.amount) === searchAmountAbs
   })
 })
-
 // Items are returned sorted oldest-first, so consecutive entries belong to the same
 // month unless this changes; used to show a divider between months in the list.
 function monthGroupLabel(dateString: string) {
@@ -461,7 +460,13 @@ onMounted(() => {
         <v-card-text class="d-flex flex-column" style="gap: 16px;">
           <v-text-field label="Name" v-model="ruleForm.name" />
           <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
-          <v-select label="Target Category" :items="ruleCategoryOptions" item-title="name" item-value="id" v-model="ruleForm.expenseCategoryId" />
+          <CategorySelector
+            label="Target Category"
+            :categories="categories"
+            null-option-label="None"
+            :clearable="false"
+            v-model="ruleForm.expenseCategoryId"
+          />
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -5,6 +5,7 @@ import { useSnackbarStore } from '@/stores/snackbar'
 import { useAuthStore } from '@/stores/auth'
 import type { RuleDto, ExpenseCategoryDto, AccountDto, CurrentUserDto } from '@/types'
 import { formatCents } from '@/utils/currency'
+import CategorySelector from '@/components/CategorySelector.vue'
 
 const snackbar = useSnackbarStore()
 const authStore = useAuthStore()
@@ -37,8 +38,6 @@ const addRuleOpen = ref(false)
 const deleteRule = ref<RuleDto | null>(null)
 const editRule = ref<RuleDto | null>(null)
 const ruleForm = ref({ name: '', ruleRegex: '', expenseCategoryId: null as number | null })
-
-const categoryOptions = computed(() => [{ id: null, name: 'None' }, ...categories.value])
 
 interface RuleGroup {
   key: string
@@ -616,7 +615,13 @@ watch(openPanel, (panel) => {
         <v-card-text class="d-flex flex-column" style="gap: 16px;">
           <v-text-field label="Name" v-model="ruleForm.name" />
           <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
-          <v-select label="Target Category" :items="categoryOptions" item-title="name" item-value="id" v-model="ruleForm.expenseCategoryId" />
+          <CategorySelector
+            label="Target Category"
+            :categories="categories"
+            null-option-label="None"
+            :clearable="false"
+            v-model="ruleForm.expenseCategoryId"
+          />
         </v-card-text>
         <v-card-actions>
           <v-spacer />
@@ -632,7 +637,13 @@ watch(openPanel, (panel) => {
         <v-card-text class="d-flex flex-column" style="gap: 16px;">
           <v-text-field label="Name" v-model="ruleForm.name" />
           <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
-          <v-select label="Category" :items="categoryOptions" item-title="name" item-value="id" v-model="ruleForm.expenseCategoryId" />
+          <CategorySelector
+            label="Category"
+            :categories="categories"
+            null-option-label="None"
+            :clearable="false"
+            v-model="ruleForm.expenseCategoryId"
+          />
         </v-card-text>
         <v-card-actions>
           <v-spacer />


### PR DESCRIPTION
## Summary
- add a reusable `CategorySelector` component based on the pending-expenses dialog combobox behavior
- replace category selectors in Add Transaction, Convert Pending Expense, History filter, and rule dialogs in Settings/Pending Expenses
- keep optional `All`/`None` null options where needed while standardizing category sorting and selector behavior

## Validation
- `pnpm build` (SimplyBudgetWeb.Web)