### PR TITLE
Fix 400 error when assigning a pending expense to the current user

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -313,6 +313,51 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task Update_AssignsToSelf_WhenAssigneeAlreadyTrackedInContext()
+    {
+        // Regression test for a 400 error: "The navigation 'PendingExpense.Assignee' cannot have
+        // 'IsLoaded' set to false because the referenced entity is non-null and is therefore
+        // loaded." CurrentUserSyncMiddleware runs earlier in the same request and already tracks
+        // (AsTracking) the current user's PendingExpenseAssignee row in the shared, scoped
+        // DbContext before the controller action executes. When the pending expense is assigned
+        // to that same (already-tracked) assignee, EF Core's relationship fixup automatically
+        // sets the Assignee navigation to the tracked entity after SaveChangesAsync, so it is
+        // non-null by the time the controller tries to refresh it.
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        var (pendingId, selfAssigneeId, version) = await mocker.InDbScopeAsync(async context =>
+        {
+            var selfAssignee = new PendingExpenseAssignee { Name = "Me", ObjectId = "me-oid" };
+            context.PendingExpenseAssignees.Add(selfAssignee);
+            var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+            return (pending.ID, selfAssignee.ID, System.Convert.ToBase64String(pending.Version));
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            // Simulate CurrentUserSyncMiddleware tracking the current user's assignee row in
+            // this same DbContext instance before the controller action runs.
+            await context.PendingExpenseAssignees.AsTracking().SingleAsync(x => x.ID == selfAssigneeId);
+
+            var controller = new PendingExpensesController(context);
+            var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(selfAssigneeId, null, version));
+
+            var dto = (result.Value as PendingExpenseDto) ?? ((OkObjectResult)result.Result!).Value as PendingExpenseDto;
+            await Assert.That(dto!.AssigneeId).IsEqualTo(selfAssigneeId);
+            await Assert.That(dto.AssigneeName).IsEqualTo("Me");
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var pending = await context.PendingExpenses.SingleAsync(x => x.ID == pendingId);
+            await Assert.That(pending.AssigneeId).IsEqualTo(selfAssigneeId);
+        });
+    }
+
+    [Test]
     public async Task Update_WithUnknownAssignee_ReturnsBadRequest()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -110,11 +110,14 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
             return Conflict(ConcurrencyConflictMessage);
         }
 
-        // AssigneeId may have changed since the initial .Include(x => x.Assignee) load, and
-        // Reference(...).LoadAsync() is normally a no-op once a navigation is marked as loaded.
-        // Reset the loaded flag so it re-queries using the (possibly new/cleared) AssigneeId.
-        context.Entry(pending).Reference(x => x.Assignee).IsLoaded = false;
-        await context.Entry(pending).Reference(x => x.Assignee).LoadAsync();
+        // AssigneeId may have changed since the initial .Include(x => x.Assignee) load, so the
+        // Assignee navigation may now be stale (pointing at the old assignee, or non-null when
+        // it should be cleared). Explicitly refresh it to match the current AssigneeId; setting
+        // the navigation directly keeps EF's IsLoaded tracking consistent (unlike forcing
+        // IsLoaded = false on an already-loaded, non-null reference, which throws).
+        pending.Assignee = request.AssigneeId.HasValue
+            ? await context.PendingExpenseAssignees.FindAsync(request.AssigneeId.Value)
+            : null;
 
         return ToDto(pending);
     }


### PR DESCRIPTION
## Problem
Assigning a pending expense to yourself returned a 400 response:

> The navigation 'PendingExpense.Assignee' cannot have 'IsLoaded' set to false because the referenced entity is non-null and is therefore loaded.

## Root cause
`CurrentUserSyncMiddleware` runs on every authenticated request and tracks (`AsTracking`) the current user's `PendingExpenseAssignee` row in the same scoped `DbContext` used for the rest of the request pipeline. When a pending expense is assigned to that same, already-tracked assignee, EF Core's relationship fixup sets the `Assignee` navigation to the tracked entity right after `SaveChangesAsync`. By the time `PendingExpensesController.Update` tried to force a reload via `Reference(x => x.Assignee).IsLoaded = false`, the navigation was already non-null — and EF Core throws when you try to mark an already-loaded, non-null reference as not loaded.

## Fix
Replace the `IsLoaded = false` / `LoadAsync()` hack with directly reassigning the `Assignee` navigation to match the (possibly changed/cleared) `AssigneeId`. This keeps EF's tracking state consistent and avoids ever calling the problematic `IsLoaded` setter.

## Testing
- Added `Update_AssignsToSelf_WhenAssigneeAlreadyTrackedInContext`, which reproduces the middleware's behavior (tracking the target assignee in the `DbContext` before calling `Update`) and fails with the original `InvalidOperationException` against the old code.
- `dotnet test SimplyBudgetWeb.Core.Tests` — all 78 tests pass (was 77 + 1 new regression test).
- `dotnet build SimplyBudgetWeb` — builds with 0 warnings/errors.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>