### PR TITLE
Add month selector support to budget page

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type { BudgetResponse, BudgetCategoryDto, ExpenseCategoryDto, ExpenseCategoryMonthlyExpensesDto } from '@/types'
 import { formatCents, formatMonth, parseMonth } from '@/utils/currency'
 import { useRouter } from 'vue-router'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
+import MonthPickerNav from '@/components/MonthPickerNav.vue'
+import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 
 const snackbar = useSnackbarStore()
 const router = useRouter()
 
-const currentMonth = new Date()
+const { currentMonth } = useMonthQueryParam({ storageKey: 'budget' })
 const budget = ref<BudgetResponse | null>(null)
 const loading = ref(false)
 const dialogOpen = ref(false)
@@ -66,7 +68,7 @@ const budgetLineLabel = computed(() => {
 async function fetchBudget() {
   loading.value = true
   try {
-    const month = formatMonth(currentMonth)
+    const month = formatMonth(currentMonth.value)
     budget.value = await apiClient.get<BudgetResponse>(`/api/budget?month=${month}-01`)
   } catch {
     snackbar.enqueueSnackbar('Failed to load budget', { variant: 'error' })
@@ -85,6 +87,8 @@ onMounted(() => {
   void fetchBudget()
   void fetchCategories()
 })
+
+watch(currentMonth, fetchBudget)
 
 function onDialogSuccess() {
   void fetchBudget()
@@ -112,7 +116,7 @@ async function openCategoryChart(category: BudgetCategoryDto) {
   categoryChart.value = null
 
   try {
-    const month = formatMonth(currentMonth)
+    const month = formatMonth(currentMonth.value)
     categoryChart.value = await apiClient.get<ExpenseCategoryMonthlyExpensesDto>(
       `/api/expense-categories/${category.id}/monthly-expenses?month=${month}-01&months=12`,
     )
@@ -130,6 +134,10 @@ function openCategoryHistory(category: BudgetCategoryDto) {
 
 <template>
   <div>
+    <v-card class="pa-4 mb-4 d-flex flex-wrap align-center" style="gap: 16px;">
+      <MonthPickerNav v-model="currentMonth" />
+    </v-card>
+
     <v-card v-if="budget" class="pa-4 mb-4">
       <div class="d-flex flex-wrap" style="gap: 16px;">
         <span class="text-h5">Total Budget: <strong>{{ formatCents(budget.totalBudget) }}</strong></span>


### PR DESCRIPTION
## Summary
- add the standard month selector control to the Budget page toolbar
- store/sync the selected month using the shared `useMonthQueryParam` composable
- request budget totals, category balances, and category monthly chart data for the selected month so averages reflect the target month

## Validation
- `pnpm build`
- `pnpm exec eslint src/pages/Budget.vue`