### PR TITLE
Clarify remaining budget calculation and enhance income allocation display

### DIFF
--- a/SimplyBudgetShared/Data/BudgetContextExtensions.cs
+++ b/SimplyBudgetShared/Data/BudgetContextExtensions.cs
@@ -242,6 +242,49 @@ public static class BudgetContextExtensions
         return !await context.ExpenseCategoryRules.AnyAsync(x => x.ExpenseCategoryID == expenseCategory.ID);
     }
 
+    public static async Task<int> GetCurrentMonthAllocatedAmount(this BudgetContext context, ExpenseCategory expenseCategory, DateTime month)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (expenseCategory is null)
+        {
+            throw new ArgumentNullException(nameof(expenseCategory));
+        }
+
+        var start = month.StartOfMonth();
+        var end = month.EndOfMonth();
+
+        return await context.ExpenseCategoryItemDetails
+            .Include(x => x.ExpenseCategoryItem)
+            .Where(x => x.ExpenseCategoryId == expenseCategory.ID)
+            .Where(x => x.Amount > 0)
+            .Where(x => x.ExpenseCategoryItem!.Date >= start && x.ExpenseCategoryItem.Date <= end)
+            .Where(x => x.IgnoreBudget == false)
+            .SumAsync(x => x.Amount);
+    }
+
+    public static int CalculateRemainingBudgetAmount(ExpenseCategory expenseCategory, int currentlyAllocatedAmount)
+    {
+        if (expenseCategory is null)
+        {
+            throw new ArgumentNullException(nameof(expenseCategory));
+        }
+
+        if (expenseCategory.UsePercentage) return 0;
+
+        var remaining = expenseCategory.BudgetedAmount - currentlyAllocatedAmount;
+
+        if (expenseCategory.Cap is int cap)
+        {
+            remaining = Math.Min(remaining, cap - currentlyAllocatedAmount);
+        }
+
+        return Math.Max(0, remaining);
+    }
+
     public static async Task<int> GetRemainingBudgetAmount(this BudgetContext context, ExpenseCategory expenseCategory, DateTime month)
     {
         if (context is null)
@@ -256,22 +299,7 @@ public static class BudgetContextExtensions
 
         if (expenseCategory.UsePercentage) return 0;
 
-        var start = month.StartOfMonth();
-        var end = month.EndOfMonth();
-
-        var allocatedAmount =
-            await context.ExpenseCategoryItemDetails
-                .Include(x => x.ExpenseCategoryItem)
-                .Where(x => x.ExpenseCategoryId == expenseCategory.ID)
-                .Where(x => x.Amount > 0)
-                .Where(x => x.ExpenseCategoryItem!.Date >= start && x.ExpenseCategoryItem.Date <= end)
-                .Where(x => x.IgnoreBudget == false)
-                .SumAsync(x => x.Amount);
-        int remaining = Math.Max(0, expenseCategory.BudgetedAmount - allocatedAmount);
-        if (expenseCategory.Cap is int cap)
-        {
-            return Math.Min(remaining, Math.Max(0, cap - expenseCategory.CurrentBalance));
-        }
-        return remaining;
+        var currentlyAllocatedAmount = await context.GetCurrentMonthAllocatedAmount(expenseCategory, month);
+        return CalculateRemainingBudgetAmount(expenseCategory, currentlyAllocatedAmount);
     }
 }

--- a/SimplyBudgetSharedTests/Data/BudgetContextExtensionsTests.cs
+++ b/SimplyBudgetSharedTests/Data/BudgetContextExtensionsTests.cs
@@ -314,7 +314,7 @@ public class BudgetContextExtensionsTests
 
     [TestMethod]
     [Description("Issue 10")]
-    public async Task GetRemainingBudgetAmount_WithExpenseCategoryCap_ReturnsRemainingAmount()
+    public async Task GetRemainingBudgetAmount_WithExpenseCategoryCap_UsesCapAgainstMonthlyAllocation()
     {
         // Arrange
         AutoMocker mocker = new();
@@ -323,32 +323,7 @@ public class BudgetContextExtensionsTests
         var category = new ExpenseCategory
         {
             CurrentBalance = 100,
-            BudgetedAmount = 50,
-            Cap = 120
-        };
-
-        var now = DateTime.Now;
-        using var setupContext = factory.Create();
-        setupContext.AddRange(category);
-        await setupContext.SaveChangesAsync();
-
-        //Act/Assert
-        using var context = factory.Create();
-        Assert.AreEqual(20, await context.GetRemainingBudgetAmount(category, now));
-    }
-
-    [TestMethod]
-    [Description("Issue 10")]
-    public async Task GetRemainingBudgetAmount_WhenCurrentIsOverCap_ReturnsZero()
-    {
-        // Arrange
-        AutoMocker mocker = new();
-        using var factory = mocker.WithDbScope();
-
-        var category = new ExpenseCategory
-        {
-            CurrentBalance = 100,
-            BudgetedAmount = 50,
+            BudgetedAmount = 100,
             Cap = 80
         };
 
@@ -356,6 +331,33 @@ public class BudgetContextExtensionsTests
         using var setupContext = factory.Create();
         setupContext.AddRange(category);
         await setupContext.SaveChangesAsync();
+        await setupContext.AddIncome("", now, (30, category.ID));
+
+        //Act/Assert
+        using var context = factory.Create();
+        Assert.AreEqual(50, await context.GetRemainingBudgetAmount(category, now));
+    }
+
+    [TestMethod]
+    [Description("Issue 10")]
+    public async Task GetRemainingBudgetAmount_WhenMonthlyAllocationIsOverCap_ReturnsZero()
+    {
+        // Arrange
+        AutoMocker mocker = new();
+        using var factory = mocker.WithDbScope();
+
+        var category = new ExpenseCategory
+        {
+            CurrentBalance = 100,
+            BudgetedAmount = 100,
+            Cap = 80
+        };
+
+        var now = DateTime.Now;
+        using var setupContext = factory.Create();
+        setupContext.AddRange(category);
+        await setupContext.SaveChangesAsync();
+        await setupContext.AddIncome("", now, (90, category.ID));
 
         //Act/Assert
         using var context = factory.Create();

--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
@@ -257,8 +257,10 @@ public class ExpenseCategoriesControllerTests
 
         var result = await controller.GetRemainingBudget(new DateTime(2026, 1, 15));
 
-        await Assert.That(result[groceriesId]).IsEqualTo(20000);
-        await Assert.That(result[savingsId]).IsEqualTo(0);
+        await Assert.That(result[groceriesId].CurrentAmount).IsEqualTo(10000);
+        await Assert.That(result[groceriesId].RemainingAmount).IsEqualTo(20000);
+        await Assert.That(result[savingsId].CurrentAmount).IsEqualTo(0);
+        await Assert.That(result[savingsId].RemainingAmount).IsEqualTo(0);
     }
 
     [Test]

--- a/SimplyBudgetWeb.Web/src/components/IncomeAllocationList.vue
+++ b/SimplyBudgetWeb.Web/src/components/IncomeAllocationList.vue
@@ -18,13 +18,18 @@ const emit = defineEmits<{
   'update:modelValue': [value: Record<number, string>]
 }>()
 
-const remainingBudgetByCategory = ref<Record<number, number>>({})
+interface RemainingBudgetByCategoryDto {
+  currentAmount: number
+  remainingAmount: number
+}
+
+const remainingBudgetByCategory = ref<Record<number, RemainingBudgetByCategoryDto>>({})
 
 async function loadRemainingBudget() {
   const year = props.month.getFullYear()
   const month = String(props.month.getMonth() + 1).padStart(2, '0')
   try {
-    remainingBudgetByCategory.value = await apiClient.get<Record<number, number>>(
+    remainingBudgetByCategory.value = await apiClient.get<Record<number, RemainingBudgetByCategoryDto>>(
       `/api/expense-categories/remaining-budget?month=${year}-${month}-01`,
     ) ?? {}
   } catch {
@@ -46,24 +51,19 @@ function amountCentsFor(categoryId: number): number {
   return dollarsToCents(amountFor(categoryId))
 }
 
+function currentAmountFor(category: ExpenseCategoryDto): number {
+  if (category.usePercentage) return amountCentsFor(category.id)
+  return remainingBudgetByCategory.value[category.id]?.currentAmount ?? 0
+}
+
 function remainingBudgetFor(category: ExpenseCategoryDto): number {
-  return remainingBudgetByCategory.value[category.id] ?? 0
+  return remainingBudgetByCategory.value[category.id]?.remainingAmount ?? 0
 }
 
 function maxSuggestedAmountFor(category: ExpenseCategoryDto): number {
   const budgetRemaining = remainingBudgetFor(category)
   const availableToAllocate = remainingCents.value + amountCentsFor(category.id)
   return Math.max(0, Math.min(budgetRemaining, availableToAllocate))
-}
-
-function remainingSuggestionFor(category: ExpenseCategoryDto): number {
-  const budgetRemaining = remainingBudgetFor(category)
-  if (category.cap === null) return budgetRemaining
-
-  // For capped categories, the remaining suggestion should represent the extra amount
-  // that can still be added on top of the current value without exceeding the cap.
-  const currentAmount = amountCentsFor(category.id)
-  return Math.max(0, maxSuggestedAmountFor(category) - currentAmount)
 }
 
 function percentageAmountFor(category: ExpenseCategoryDto): number {
@@ -111,26 +111,36 @@ function applyPercentage(category: ExpenseCategoryDto) {
       class="income-allocation-row d-flex align-center ga-2"
     >
       <div class="category-info">
-        <div>{{ category.name }}</div>
+        <div>
+          {{ category.name }}
+          <span class="text-caption text-medium-emphasis">
+            &middot; Budget:
+            <template v-if="category.usePercentage">
+              {{ category.budgetedPercentage }}%
+            </template>
+            <template v-else>
+              {{ formatCents(category.budgetedAmount) }}
+            </template>
+          </span>
+        </div>
         <div class="text-caption text-medium-emphasis">
+          Current: {{ formatCents(currentAmountFor(category)) }} &middot; Remaining:
           <template v-if="category.usePercentage">
-            Budget:
             <a href="#" class="allocation-link" @click.prevent="applyPercentage(category)">
               {{ category.budgetedPercentage }}%
             </a>
           </template>
           <template v-else>
-            Budget: {{ formatCents(category.budgetedAmount) }} &middot; Remaining:
             <a
-              v-if="remainingSuggestionFor(category) > 0"
+              v-if="remainingBudgetFor(category) > 0"
               href="#"
               class="allocation-link"
               @click.prevent="applyRemainingBudget(category)"
             >
-              {{ formatCents(remainingSuggestionFor(category)) }}
+              {{ formatCents(remainingBudgetFor(category)) }}
             </a>
             <span v-else class="allocation-link-disabled">
-              {{ formatCents(remainingSuggestionFor(category)) }}
+              {{ formatCents(remainingBudgetFor(category)) }}
             </span>
           </template>
         </div>

--- a/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
+++ b/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
@@ -50,13 +50,11 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
     }
 
     /// <summary>
-    /// Returns, for every visible (non-hidden, non-percentage) category, how much of its
-    /// budgeted amount for the given month has not yet been allocated. Used by the income
-    /// allocation UI to show/pre-fill the remaining budget for each category. Percentage-based
-    /// categories always report 0 here since their allocation is computed from the income total.
+    /// Returns, for every visible (non-hidden) category, the month's currently allocated amount
+    /// and remaining budget amount used by the income-allocation UI.
     /// </summary>
     [HttpGet("remaining-budget")]
-    public async Task<Dictionary<int, int>> GetRemainingBudget([FromQuery] DateTime? month)
+    public async Task<Dictionary<int, RemainingBudgetDto>> GetRemainingBudget([FromQuery] DateTime? month)
     {
         var monthDate = (month ?? DateTime.Today).StartOfMonth();
 
@@ -64,10 +62,16 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
             .Where(c => !c.IsHidden)
             .ToListAsync();
 
-        var result = new Dictionary<int, int>();
+        var result = new Dictionary<int, RemainingBudgetDto>();
         foreach (var category in categories)
         {
-            result[category.ID] = await context.GetRemainingBudgetAmount(category, monthDate);
+            var currentAmount = category.UsePercentage
+                ? 0
+                : await context.GetCurrentMonthAllocatedAmount(category, monthDate);
+
+            result[category.ID] = new RemainingBudgetDto(
+                CurrentAmount: currentAmount,
+                RemainingAmount: BudgetContextExtensions.CalculateRemainingBudgetAmount(category, currentAmount));
         }
         return result;
     }
@@ -276,4 +280,9 @@ public record ExpenseCategoryMonthlyExpensesDto(
 public record ExpenseCategoryMonthlyExpensePointDto(
     string Month,
     int Amount
+);
+
+public record RemainingBudgetDto(
+    int CurrentAmount,
+    int RemainingAmount
 );


### PR DESCRIPTION
The logic for determining an expense category's remaining budget for a given month has been refactored. The process of querying the database for the current month's allocated amount is now explicitly separated from the pure calculation logic that applies budgeted amounts and caps. This ensures that category caps are consistently applied against the monthly allocation rather than the overall balance.

The income allocation UI has been updated to reflect this change, now displaying both the 'Current' amount allocated for the month and the 'Remaining' budget amount for each category, providing clearer context for users.
