### PR TITLE
Refresh expired auth tokens, otherwise sign out to the login page

### DIFF
--- a/SimplyBudgetWeb.Web/src/router/index.ts
+++ b/SimplyBudgetWeb.Web/src/router/index.ts
@@ -7,6 +7,7 @@ import Settings from '@/pages/Settings.vue'
 import Import from '@/pages/Import.vue'
 import PendingExpenses from '@/pages/PendingExpenses.vue'
 import { useAuthStore } from '@/stores/auth'
+import { setLoginNavigator } from '@/services/sessionNavigation'
 
 // Pages are imported eagerly (not lazy) so the initial navigation resolves
 // synchronously and the Layout/header render on first paint without an
@@ -30,6 +31,15 @@ const router = createRouter({
       ],
     },
   ],
+})
+
+// Allows the auth store to bounce the user back to the sign in page when their
+// session expires and cannot be refreshed. Not awaited, because this can be
+// triggered from inside a navigation guard where a nested await would deadlock.
+setLoginNavigator(() => {
+  if (router.currentRoute.value.name !== 'login') {
+    void router.replace({ name: 'login' })
+  }
 })
 
 // Landing page becomes the login page for anonymous users: any navigation to a

--- a/SimplyBudgetWeb.Web/src/services/apiClient.ts
+++ b/SimplyBudgetWeb.Web/src/services/apiClient.ts
@@ -1,7 +1,23 @@
 let getTokenFn: (() => Promise<string>) | null = null
+let onUnauthorizedFn: (() => void | Promise<void>) | null = null
 
 export function setTokenProvider(fn: () => Promise<string>) {
   getTokenFn = fn
+}
+
+/**
+ * Registers the callback invoked when the API rejects a request because the
+ * caller is no longer authenticated (expired/invalid token).
+ */
+export function setUnauthorizedHandler(fn: () => void | Promise<void>) {
+  onUnauthorizedFn = fn
+}
+
+export class SessionExpiredError extends Error {
+  constructor(message = 'Your session has expired. Please sign in again.') {
+    super(message)
+    this.name = 'SessionExpiredError'
+  }
 }
 
 interface DeleteOptions {
@@ -10,6 +26,12 @@ interface DeleteOptions {
 
 class ApiClient {
   private baseUrl = __API_BASE_URL__ || ''
+
+  private async throwIfUnauthorized(response: Response): Promise<void> {
+    if (response.status !== 401) return
+    await onUnauthorizedFn?.()
+    throw new SessionExpiredError()
+  }
 
   private parseFileName(contentDisposition: string | null): string | null {
     if (!contentDisposition) return null
@@ -25,10 +47,10 @@ class ApiClient {
 
   private async getHeaders(): Promise<HeadersInit> {
     if (getTokenFn) {
-      try {
-        const token = await getTokenFn()
-        return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
-      } catch { /* fall through */ }
+      // Any failure here (including an unrecoverable session) propagates: all
+      // API endpoints require auth, so an anonymous request would only 401.
+      const token = await getTokenFn()
+      return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
     }
     return { 'Content-Type': 'application/json' }
   }
@@ -42,6 +64,7 @@ class ApiClient {
   async get<T>(url: string): Promise<T> {
     const headers = await this.getHeaders()
     const response = await fetch(this.baseUrl + url, { headers })
+    await this.throwIfUnauthorized(response)
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
     const text = await response.text()
     return text ? JSON.parse(text) : undefined as T
@@ -53,6 +76,7 @@ class ApiClient {
       method: 'POST', headers,
       body: this.buildJsonBody(data),
     })
+    await this.throwIfUnauthorized(response)
     if (!response.ok) {
       const error = await response.text()
       throw new Error(error || `HTTP error! status: ${response.status}`)
@@ -65,6 +89,7 @@ class ApiClient {
   async download(url: string): Promise<{ blob: Blob; fileName: string | null }> {
     const headers = await this.getHeaders()
     const response = await fetch(this.baseUrl + url, { headers })
+    await this.throwIfUnauthorized(response)
     if (!response.ok) {
       const error = await response.text()
       throw new Error(error || `HTTP error! status: ${response.status}`)
@@ -82,6 +107,7 @@ class ApiClient {
       method: 'PUT', headers,
       body: this.buildJsonBody(data),
     })
+    await this.throwIfUnauthorized(response)
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
     if (response.status === 204) return undefined as T
     return response.json()
@@ -96,6 +122,7 @@ class ApiClient {
         }
       : headers
     const response = await fetch(this.baseUrl + url, { method: 'DELETE', headers: requestHeaders })
+    await this.throwIfUnauthorized(response)
     if (!response.ok) {
       const error = await response.text()
       throw new Error(error || `HTTP error! status: ${response.status}`)

--- a/SimplyBudgetWeb.Web/src/services/sessionNavigation.ts
+++ b/SimplyBudgetWeb.Web/src/services/sessionNavigation.ts
@@ -1,0 +1,11 @@
+// Small indirection so non-component code (the auth store) can send the user
+// back to the sign in page without importing the router and creating a cycle.
+let navigateToLoginFn: (() => void) | null = null
+
+export function setLoginNavigator(fn: () => void) {
+  navigateToLoginFn = fn
+}
+
+export function navigateToLogin() {
+  navigateToLoginFn?.()
+}

--- a/SimplyBudgetWeb.Web/src/stores/auth.ts
+++ b/SimplyBudgetWeb.Web/src/stores/auth.ts
@@ -6,11 +6,14 @@ import {
   type AccountInfo,
 } from '@azure/msal-browser'
 import { msalConfig, loginRequest, apiScopes } from '@/authConfig'
-import { apiClient, setTokenProvider } from '@/services/apiClient'
+import { apiClient, setTokenProvider, setUnauthorizedHandler, SessionExpiredError } from '@/services/apiClient'
+import { useSnackbarStore } from '@/stores/snackbar'
+import { navigateToLogin } from '@/services/sessionNavigation'
 import type { CurrentUserDto } from '@/types'
 
 const msalInstance = new PublicClientApplication(msalConfig)
 let initialized: Promise<void> | null = null
+let sessionExpiring: Promise<void> | null = null
 
 export const useAuthStore = defineStore('auth', () => {
   const account = ref<AccountInfo | null>(null)
@@ -46,17 +49,79 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function getToken(): Promise<string> {
+    const activeAccount = account.value ?? msalInstance.getAllAccounts()[0] ?? null
+    if (!activeAccount) {
+      await handleSessionExpired()
+      throw new SessionExpiredError('You are not signed in. Please sign in again.')
+    }
+
     try {
+      // acquireTokenSilent renews an expired access token using the cached refresh token.
       const result = await msalInstance.acquireTokenSilent({
         ...apiScopes,
-        account: account.value ?? undefined,
+        account: activeAccount,
       })
       return result.accessToken
     } catch (e) {
-      if (e instanceof InteractionRequiredAuthError) {
-        await msalInstance.acquireTokenRedirect(apiScopes)
+      if (!(e instanceof InteractionRequiredAuthError)) {
+        // Transient/cache issue: make one more explicit refresh attempt before giving up.
+        try {
+          const result = await msalInstance.acquireTokenSilent({
+            ...apiScopes,
+            account: activeAccount,
+            forceRefresh: true,
+          })
+          return result.accessToken
+        } catch (retryError) {
+          if (!(retryError instanceof InteractionRequiredAuthError)) {
+            throw retryError
+          }
+        }
       }
-      throw e
+
+      // The session cannot be refreshed without user interaction: sign the user
+      // out locally and send them back to the sign in page.
+      await handleSessionExpired()
+      throw new SessionExpiredError()
+    }
+  }
+
+  /**
+   * Called when the token can no longer be refreshed (or the API rejects it).
+   * Clears the local session and returns the user to the sign in page.
+   */
+  async function handleSessionExpired(): Promise<void> {
+    if (sessionExpiring) {
+      await sessionExpiring
+      return
+    }
+
+    const expiring = (async () => {
+      const wasAuthenticated = account.value !== null
+      account.value = null
+      customDisplayName.value = null
+
+      try {
+        await msalInstance.clearCache()
+      } catch {
+        // Best effort - the local session is already considered gone.
+      }
+      refreshAccount()
+
+      if (wasAuthenticated) {
+        useSnackbarStore().enqueueSnackbar(
+          'Your session has expired. Please sign in again.',
+          { variant: 'warning' },
+        )
+      }
+      navigateToLogin()
+    })()
+
+    sessionExpiring = expiring
+    try {
+      await expiring
+    } finally {
+      sessionExpiring = null
     }
   }
 
@@ -68,6 +133,7 @@ export const useAuthStore = defineStore('auth', () => {
           await msalInstance.handleRedirectPromise()
           refreshAccount()
           setTokenProvider(getToken)
+          setUnauthorizedHandler(handleSessionExpired)
           await refreshCurrentUserProfile()
         } finally {
           isInitializing.value = false
@@ -94,6 +160,7 @@ export const useAuthStore = defineStore('auth', () => {
     login,
     logout,
     getToken,
+    handleSessionExpired,
     refreshCurrentUserProfile,
     setDisplayName,
   }


### PR DESCRIPTION
Fixes #198

When a user's access token expires, the app now tries to refresh it before doing anything else. Only if the session genuinely cannot be renewed is the user signed out and returned to the sign in page.

## Behavior

1. **Refresh first** — `getToken` resolves the active MSAL account and calls `acquireTokenSilent`, which renews an expired access token from the cached refresh token. Non-interactive failures (transient network/cache issues) get one additional `forceRefresh: true` attempt.
2. **Sign out only when refresh is impossible** — on `InteractionRequiredAuthError` (or when no account is present), `handleSessionExpired()` clears the account state and the MSAL cache, shows a "Your session has expired. Please sign in again." snackbar, and redirects to `/login`. It is guarded against concurrent invocation so parallel API calls trigger a single sign out.
3. **API 401s** — every `apiClient` response is checked for 401 and routed through the same handler, surfacing a `SessionExpiredError` instead of a raw `HTTP error! status: 401`.

Previously an expired session triggered a forced `acquireTokenRedirect` from inside the token provider, and 401 responses were reported to the user as generic HTTP errors.

## Notes

- Token acquisition failures no longer fall through to an unauthenticated request. Since every API endpoint requires auth, that request would always 401, which would have been misread as an expired session and caused a destructive sign out on a transient error.
- `services/sessionNavigation.ts` is a small indirection that lets the auth store navigate to the login route without creating a router/store import cycle.

## Validation

- `pnpm build` (vue-tsc typecheck + vite build) passes
- `pnpm lint` passes
