### PR TITLE
Add clear button to search fields

### DIFF
--- a/SimplyBudgetDesktop/Views/BudgetView.xaml
+++ b/SimplyBudgetDesktop/Views/BudgetView.xaml
@@ -254,6 +254,7 @@
       <StackPanel Orientation="Horizontal" Margin="0,0,10,0" Grid.Column="9" VerticalAlignment="Bottom">
         <TextBox Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" 
                  materialDesign:HintAssist.Hint="Search"
+                 materialDesign:TextFieldAssist.HasClearButton="True"
                  Margin="5,0"
                  MinWidth="200">
           <TextBox.InputBindings>

--- a/SimplyBudgetDesktop/Views/HistoryView.xaml
+++ b/SimplyBudgetDesktop/Views/HistoryView.xaml
@@ -82,6 +82,7 @@
           Margin="5,0"
           VerticalAlignment="Center"
           materialDesign:HintAssist.Hint="Search"
+          materialDesign:TextFieldAssist.HasClearButton="True"
           Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}">
           <TextBox.InputBindings>
             <KeyBinding Key="Return" Command="{Binding DoSearchCommand}" />


### PR DESCRIPTION
Enables the MaterialDesign clear button on the search text boxes so users can quickly reset a search.

- `BudgetView.xaml`: search box now has `TextFieldAssist.HasClearButton`
- `HistoryView.xaml`: search box now has `TextFieldAssist.HasClearButton`

Fixes #205