### PR TITLE
Don't update remaining amounts until blur or Enter

### DIFF
--- a/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
@@ -6,6 +6,7 @@ import type { ExpenseCategoryDto, TransactionRequest, TransferRequest } from '@/
 import { formatCents, dollarsToCents, centsToDollars, parseLocalDate } from '@/utils/currency'
 import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
 import CategorySelector from '@/components/CategorySelector.vue'
+import AmountField from '@/components/AmountField.vue'
 
 const props = defineProps<{
   modelValue: boolean
@@ -232,15 +233,7 @@ async function submit() {
                 class="category-field"
               />
               <div class="amount-field d-flex align-center ga-1">
-                <v-text-field
-                  label="Amount ($)"
-                  type="number"
-                  step="0.01"
-                  min="0"
-                  v-model="item.amount"
-                  hide-details
-                  density="compact"
-                />
+                <AmountField v-model="item.amount" />
                 <v-btn
                   icon="mdi-calculator"
                   size="small"

--- a/SimplyBudgetWeb.Web/src/components/AmountField.vue
+++ b/SimplyBudgetWeb.Web/src/components/AmountField.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+const props = withDefaults(defineProps<{
+  modelValue: string
+  label?: string
+  density?: 'default' | 'comfortable' | 'compact'
+}>(), {
+  label: 'Amount ($)',
+  density: 'compact',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+// The displayed value is kept local while editing so that dependent totals
+// (such as remaining amounts) only update on blur or when Enter is pressed.
+const draft = ref(props.modelValue)
+
+watch(() => props.modelValue, value => {
+  draft.value = value
+})
+
+function commit() {
+  if (draft.value === props.modelValue) return
+  emit('update:modelValue', draft.value)
+}
+</script>
+
+<template>
+  <v-text-field
+    :label="props.label"
+    type="number"
+    step="0.01"
+    min="0"
+    v-model="draft"
+    hide-details
+    :density="props.density"
+    @blur="commit"
+    @keyup.enter="commit"
+  />
+</template>

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -6,6 +6,7 @@ import type { ExpenseCategoryDto, PendingExpenseDto, ConvertPendingExpenseReques
 import { formatCents, dollarsToCents, centsToDollars, parseLocalDate } from '@/utils/currency'
 import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
 import CategorySelector from '@/components/CategorySelector.vue'
+import AmountField from '@/components/AmountField.vue'
 
 const props = defineProps<{
   modelValue: boolean
@@ -278,15 +279,7 @@ async function saveNote() {
                 class="category-field"
               />
               <div class="amount-field d-flex align-center ga-1">
-                <v-text-field
-                  label="Amount ($)"
-                  type="number"
-                  step="0.01"
-                  min="0"
-                  v-model="item.amount"
-                  hide-details
-                  density="compact"
-                />
+                <AmountField v-model="item.amount" />
                 <v-btn
                   icon="mdi-calculator"
                   size="small"

--- a/SimplyBudgetWeb.Web/src/components/IncomeAllocationList.vue
+++ b/SimplyBudgetWeb.Web/src/components/IncomeAllocationList.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import type { ExpenseCategoryDto } from '@/types'
 import { formatCents, dollarsToCents, centsToDollars } from '@/utils/currency'
+import AmountField from '@/components/AmountField.vue'
 
 const props = defineProps<{
   /** Total income amount (in cents) being allocated. */
@@ -145,15 +146,9 @@ function applyPercentage(category: ExpenseCategoryDto) {
           </template>
         </div>
       </div>
-      <v-text-field
-        label="Amount ($)"
-        type="number"
-        step="0.01"
-        min="0"
+      <AmountField
         :model-value="amountFor(category.id)"
         @update:model-value="(val: string) => setAmount(category.id, val)"
-        hide-details
-        density="compact"
         class="amount-field"
       />
     </div>


### PR DESCRIPTION
Fixes #199

Line item amount inputs now hold their value locally while editing and only publish the change on blur or when Enter is pressed. This keeps the `Remaining to allocate` totals (and the per-category remaining suggestions) stable while typing, so they can be used to fill in line items.

- Added `AmountField.vue`, a small wrapper around `v-text-field` that commits on `blur`/`Enter`.
- Used it for the transaction line items in `AddTransactionDialog`, the split lines in `ConvertPendingExpenseDialog`, and the per-category amounts in `IncomeAllocationList`.

Validated with `pnpm run build` (vue-tsc + vite) and `pnpm run lint`.