### PR TITLE
Add descriptions to expense categories

### DIFF
--- a/SimplyBudgetDesktop.Tests/ViewModels/BudgetViewModelTests.cs
+++ b/SimplyBudgetDesktop.Tests/ViewModels/BudgetViewModelTests.cs
@@ -35,6 +35,7 @@ public partial class BudgetViewModelTests
             ID = 42,
             CategoryName = "CategoryName",
             Name = "Name",
+            Description = "Description",
             BudgetedAmount = 100
         });
         await context.SaveChangesAsync();
@@ -43,6 +44,7 @@ public partial class BudgetViewModelTests
         var expenseCategory = await ExpenseCategoryViewModelEx.Create(mocker.Get<Func<BudgetContext>>(), new ExpenseCategory { ID = 42 });
         expenseCategory.EditingCategory = "CategoryNameChanged";
         expenseCategory.EditingName = "NameChanged";
+        expenseCategory.EditingDescription = "DescriptionChanged";
         expenseCategory.EditAmount = 120;
         expenseCategory.EditIsAmountType = true;
 
@@ -53,6 +55,7 @@ public partial class BudgetViewModelTests
         var existing = await verificationContext.ExpenseCategories.FindAsync(42);
         Assert.AreEqual("CategoryNameChanged", existing?.CategoryName);
         Assert.AreEqual("NameChanged", existing!.Name);
+        Assert.AreEqual("DescriptionChanged", existing.Description);
         Assert.AreEqual(120, existing.BudgetedAmount);
         Assert.AreEqual(0, existing.BudgetedPercentage);
     }

--- a/SimplyBudgetDesktop/ViewModels/BudgetViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/BudgetViewModel.cs
@@ -123,6 +123,7 @@ public class BudgetViewModel : CollectionViewModelBase<ExpenseCategoryViewModelE
         if (await context.ExpenseCategories.FirstOrDefaultAsync(x => x.ID == category.ExpenseCategoryID) is ExpenseCategory dbCategory)
         {
             dbCategory.Name = category.EditingName;
+            dbCategory.Description = category.EditingDescription;
             dbCategory.CategoryName = category.EditingCategory;
             dbCategory.BudgetedPercentage = !category.EditIsAmountType ? category.EditAmount : 0;
             dbCategory.BudgetedAmount = category.EditIsAmountType ? category.EditAmount : 0;
@@ -130,6 +131,7 @@ public class BudgetViewModel : CollectionViewModelBase<ExpenseCategoryViewModelE
             dbCategory.AccountID = category.Account?.ID;
             await context.SaveChangesAsync();
             category.Name = dbCategory.Name;
+            category.Description = dbCategory.Description;
             category.CategoryName = dbCategory.CategoryName;
             category.BudgetedAmount = dbCategory.BudgetedAmount;
             category.BudgetedPercentage = dbCategory.BudgetedPercentage;

--- a/SimplyBudgetDesktop/ViewModels/ExpenseCategoryViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/ExpenseCategoryViewModel.cs
@@ -20,6 +20,7 @@ public class ExpenseCategoryViewModel : ObservableObject, IClipboardData
         if (expenseCategory is null) throw new ArgumentNullException(nameof(expenseCategory));
         if (viewModel is null) throw new ArgumentNullException(nameof(viewModel));
         viewModel.Name = expenseCategory.Name;
+        viewModel.Description = expenseCategory.Description;
         viewModel.Balance = expenseCategory.CurrentBalance;
         viewModel.BudgetedAmount = expenseCategory.BudgetedAmount;
         viewModel.BudgetedPercentage = expenseCategory.BudgetedPercentage;
@@ -45,6 +46,13 @@ public class ExpenseCategoryViewModel : ObservableObject, IClipboardData
     {
         get => _name;
         set => SetProperty(ref _name, value);
+    }
+
+    private string? _description;
+    public string? Description
+    {
+        get => _description;
+        set => SetProperty(ref _description, value);
     }
 
     private int _balance;

--- a/SimplyBudgetDesktop/ViewModels/ExpenseCategoryViewModelEx.cs
+++ b/SimplyBudgetDesktop/ViewModels/ExpenseCategoryViewModelEx.cs
@@ -133,6 +133,7 @@ public class ExpenseCategoryViewModelEx : ExpenseCategoryViewModel
             if (SetProperty(ref _isEditing, value) && value)
             {
                 EditingName = Name;
+                EditingDescription = Description;
                 EditingCategory = CategoryName;
                 EditIsAmountType = BudgetedPercentage <= 0;
                 EditAmount = BudgetedPercentage > 0 ? BudgetedPercentage : BudgetedAmount;
@@ -146,6 +147,13 @@ public class ExpenseCategoryViewModelEx : ExpenseCategoryViewModel
     {
         get => _editingName;
         set => SetProperty(ref _editingName, value);
+    }
+
+    private string? _editingDescription;
+    public string? EditingDescription
+    {
+        get => _editingDescription;
+        set => SetProperty(ref _editingDescription, value);
     }
 
     private string? _editingCategory;

--- a/SimplyBudgetDesktop/Views/BudgetView.xaml
+++ b/SimplyBudgetDesktop/Views/BudgetView.xaml
@@ -24,7 +24,8 @@
           <ColumnDefinition SharedSizeGroup="SixMonthAvg"/>
           <ColumnDefinition SharedSizeGroup="TwelveMonthAvg"/>
         </Grid.ColumnDefinitions>
-        <TextBlock Margin="0,0,10,0">
+        <StackPanel Margin="0,0,10,0">
+          <TextBlock>
           <TextBlock.Style>
             <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
               <Setter Property="Text">
@@ -42,7 +43,26 @@
               </Style.Triggers>
             </Style>
           </TextBlock.Style>
-        </TextBlock>
+          </TextBlock>
+          <TextBlock Text="{Binding Description}"
+                     FontSize="11"
+                     Opacity="0.7"
+                     TextWrapping="Wrap">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                <Setter Property="Visibility" Value="Visible"/>
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding Description}" Value="{x:Null}">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                  </DataTrigger>
+                  <DataTrigger Binding="{Binding Description}" Value="">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+        </StackPanel>
         <TextBlock Text="{Binding BudgetedAmountDisplay}" Margin="0,0,10,0" Grid.Column="1"
                    Visibility="{Binding IsChecked, ElementName=ShowBudgettedAmountCheckBox, Converter={StaticResource BooleanToVisibilityConverter}}"/>
         <TextBlock Text="{Binding Balance, Converter={StaticResource CurrentValueConverter}}" Margin="0,0,10,0" Grid.Column="2"
@@ -104,6 +124,7 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="2*" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
@@ -165,29 +186,36 @@
               <behaviors:SelectAllOnFocusBehavior />
             </i:Interaction.Behaviors>
           </TextBox>
+          <TextBox materialDesign:HintAssist.Hint="Description"
+                   materialDesign:HintAssist.IsFloating="True"
+                   Text="{Binding EditingDescription}"
+                   TextWrapping="Wrap"
+                   AcceptsReturn="True"
+                   Grid.Column="4"
+                   Margin="10,0,0,0"/>
           <ComboBox ItemsSource="{Binding Accounts}"
                     SelectedItem="{Binding Account}"
                     DisplayMemberPath="Name" 
-                    Grid.Column="4" 
+                    Grid.Column="5"
                     Margin="10,0"
                     MinWidth="80"
                     VerticalAlignment="Bottom"/>
 
           <Button Content="{materialDesign:PackIcon Kind=Delete}" 
-                  Grid.Column="5" 
+                  Grid.Column="6"
                   Style="{StaticResource MaterialDesignFlatButton}"
                   Command="{x:Static ApplicationCommands.Delete}"
                   CommandParameter="{Binding}"/>
 
           <Button Content="{materialDesign:PackIcon Kind=DeleteForever}" 
-                  Grid.Column="6" 
+                  Grid.Column="7"
                   ToolTip="Delete Permanently (only available when the category has no items)"
                   Style="{StaticResource MaterialDesignFlatButton}"
                   Command="{x:Static views:BudgetView.DeletePermanentlyCommand}"
                   CommandParameter="{Binding}"/>
 
           <Button Content="{materialDesign:PackIcon Kind=ContentSave}" 
-                  Grid.Column="7" 
+                  Grid.Column="8"
                   Style="{StaticResource MaterialDesignFlatButton}"
                   Command="{x:Static ApplicationCommands.Save}"
                   CommandParameter="{Binding}"/>

--- a/SimplyBudgetShared/Data/ExpenseCategory.cs
+++ b/SimplyBudgetShared/Data/ExpenseCategory.cs
@@ -12,6 +12,7 @@ public class ExpenseCategory : BaseItem, IBeforeCreate
     public Account? Account { get; set; }
 
     public string? Name { get; set; }
+    public string? Description { get; set; }
     public int BudgetedPercentage { get; set; }
     public int BudgetedAmount { get; set; }
     public int CurrentBalance { get; set; }

--- a/SimplyBudgetShared/DataTransfer/BudgetDataExportPackage.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataExportPackage.cs
@@ -2,7 +2,7 @@ namespace SimplyBudgetShared.DataTransfer;
 
 public sealed class BudgetDataExportPackage
 {
-    public const int CurrentFormatVersion = 1;
+    public const int CurrentFormatVersion = 2;
 
     public int FormatVersion { get; set; } = CurrentFormatVersion;
 
@@ -33,6 +33,7 @@ public record BudgetDataExportAccount(
 public record BudgetDataExportCategory(
     int Id,
     string? Name,
+    string? Description,
     string? CategoryName,
     int? AccountId,
     int BudgetedAmount,

--- a/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
@@ -28,6 +28,7 @@ public static class BudgetDataPortabilityService
                 .Select(x => new BudgetDataExportCategory(
                     x.ID,
                     x.Name,
+                    x.Description,
                     x.CategoryName,
                     x.AccountID,
                     x.BudgetedAmount,
@@ -138,6 +139,7 @@ public static class BudgetDataPortabilityService
             var importedCategories = categorySeed.Select(x => new ExpenseCategory
             {
                 Name = x.Name,
+                Description = x.Description,
                 CategoryName = x.CategoryName,
                 AccountID = ResolveOptionalReference(accountIdMap, x.AccountId, "account"),
                 BudgetedAmount = x.BudgetedAmount,

--- a/SimplyBudgetShared/Migrations/20260901022728_AddExpenseCategoryDescription.Designer.cs
+++ b/SimplyBudgetShared/Migrations/20260901022728_AddExpenseCategoryDescription.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetShared.Data;
 
@@ -10,9 +11,11 @@ using SimplyBudgetShared.Data;
 namespace SimplyBudgetShared.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260901022728_AddExpenseCategoryDescription")]
+    partial class AddExpenseCategoryDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/SimplyBudgetShared/Migrations/20260901022728_AddExpenseCategoryDescription.cs
+++ b/SimplyBudgetShared/Migrations/20260901022728_AddExpenseCategoryDescription.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetShared.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExpenseCategoryDescription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "ExpenseCategory",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "ExpenseCategory");
+        }
+    }
+}

--- a/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
+++ b/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
@@ -28,6 +28,7 @@ public class BudgetDataPortabilityServiceTests
         var groceries = new ExpenseCategory
         {
             Name = "Groceries",
+            Description = "Food and household essentials",
             CategoryName = "Food",
             AccountID = checking.ID,
             BudgetedAmount = 500_00
@@ -60,6 +61,7 @@ public class BudgetDataPortabilityServiceTests
         Assert.AreEqual(1, exportPackage.Rules.Count);
         Assert.AreEqual(1, exportPackage.Metadata.Count);
         Assert.IsTrue(exportPackage.Accounts.Single(x => x.Name == "Savings").IsDefault);
+        Assert.AreEqual("Food and household essentials", exportPackage.Categories.Single().Description);
     }
 
     [TestMethod]
@@ -85,8 +87,8 @@ public class BudgetDataPortabilityServiceTests
             ],
             Categories =
             [
-                new BudgetDataExportCategory(100, "Groceries", "Food", 10, 500_00, 0, 200_00, null, false),
-                new BudgetDataExportCategory(200, "Emergency Fund", "Savings", 20, 0, 10, 300_00, null, false)
+                new BudgetDataExportCategory(100, "Groceries", "Food and household essentials", "Food", 10, 500_00, 0, 200_00, null, false),
+                new BudgetDataExportCategory(200, "Emergency Fund", "Unexpected expenses", "Savings", 20, 0, 10, 300_00, null, false)
             ],
             Items =
             [
@@ -131,6 +133,8 @@ public class BudgetDataPortabilityServiceTests
 
         Assert.AreEqual(200_00, groceries.CurrentBalance);
         Assert.AreEqual(300_00, emergency.CurrentBalance);
+        Assert.AreEqual("Food and household essentials", groceries.Description);
+        Assert.AreEqual("Unexpected expenses", emergency.Description);
 
         var rules = await assertContext.ExpenseCategoryRules
             .Include(x => x.ExpenseCategory)

--- a/SimplyBudgetWeb.Core.Tests/Controllers/BudgetControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/BudgetControllerTests.cs
@@ -27,6 +27,7 @@ public class BudgetControllerTests
             var category = new ExpenseCategory
             {
                 Name = "Checking Category",
+                Description = "Tracks the checking account",
                 AccountID = account.ID,
             };
             context.ExpenseCategories.Add(category);
@@ -71,5 +72,6 @@ public class BudgetControllerTests
 
         await Assert.That(februaryBudget.TotalAccountAmount).IsEqualTo(1000);
         await Assert.That(aprilBudget.TotalAccountAmount).IsEqualTo(700);
+        await Assert.That(februaryBudget.Categories.Single().Description).IsEqualTo("Tracks the checking account");
     }
 }

--- a/SimplyBudgetWeb.Core.Tests/Controllers/DataPortabilityControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/DataPortabilityControllerTests.cs
@@ -29,6 +29,7 @@ public class DataPortabilityControllerTests
             var category = new ExpenseCategory
             {
                 Name = "Groceries",
+                Description = "Food and household essentials",
                 CategoryName = "Food",
                 AccountID = account.ID,
                 BudgetedAmount = 500_00
@@ -125,8 +126,8 @@ public class DataPortabilityControllerTests
             ],
             Categories =
             [
-                new BudgetDataExportCategory(10, "Groceries", "Food", 1, 500_00, 0, 125_00, null, false),
-                new BudgetDataExportCategory(20, "Emergency Fund", "Savings", 2, 0, 10, 875_00, null, false)
+                new BudgetDataExportCategory(10, "Groceries", "Food and household essentials", "Food", 1, 500_00, 0, 125_00, null, false),
+                new BudgetDataExportCategory(20, "Emergency Fund", "Unexpected expenses", "Savings", 2, 0, 10, 875_00, null, false)
             ],
             Items =
             [
@@ -183,6 +184,12 @@ public class DataPortabilityControllerTests
 
             var groceries = categories.Single(x => x.Name == "Groceries");
             var emergency = categories.Single(x => x.Name == "Emergency Fund");
+            if (groceries.Description != "Food and household essentials" ||
+                emergency.Description != "Unexpected expenses")
+            {
+                throw new Exception("Category descriptions were not imported.");
+            }
+
             if (groceries.CurrentBalance != 125_00 || emergency.CurrentBalance != 875_00)
             {
                 throw new Exception("Expected category balances to match imported export values.");

--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
@@ -33,6 +33,30 @@ public class ExpenseCategoriesControllerTests
     }
 
     [Test]
+    public async Task GetAll_FiltersByDescription()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.ExpenseCategories.AddRange(
+                new ExpenseCategory { Name = "Groceries", Description = "Food and household essentials" },
+                new ExpenseCategory { Name = "Savings", Description = "Long-term goals" });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.GetAll(includeHidden: true, search: "household");
+
+        await Assert.That(result.Length).IsEqualTo(1);
+        await Assert.That(result[0].Name).IsEqualTo("Groceries");
+        await Assert.That(result[0].Description).IsEqualTo("Food and household essentials");
+    }
+
+    [Test]
     public async Task Update_RenamesCategory()
     {
         AutoMocker mocker = new();
@@ -50,9 +74,11 @@ public class ExpenseCategoriesControllerTests
         var controller = new ExpenseCategoriesController(context);
 
         var result = await controller.Update(categoryId, new ExpenseCategoryRequest(
-            Name: "New Name", CategoryName: "New Group", BudgetedAmount: 0, BudgetedPercentage: 0, Cap: null, AccountId: null));
+            Name: "New Name", Description: "New Description", CategoryName: "New Group",
+            BudgetedAmount: 0, BudgetedPercentage: 0, Cap: null, AccountId: null));
 
         await Assert.That(result.Value!.Name).IsEqualTo("New Name");
+        await Assert.That(result.Value!.Description).IsEqualTo("New Description");
         await Assert.That(result.Value!.CategoryName).IsEqualTo("New Group");
     }
 

--- a/SimplyBudgetWeb.Data/Migrations/20260901022740_AddExpenseCategoryDescription.Designer.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260901022740_AddExpenseCategoryDescription.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetWeb.Data;
 
@@ -11,9 +12,11 @@ using SimplyBudgetWeb.Data;
 namespace SimplyBudgetWeb.Data.Migrations
 {
     [DbContext(typeof(BudgetWebContext))]
-    partial class BudgetWebContextModelSnapshot : ModelSnapshot
+    [Migration("20260901022740_AddExpenseCategoryDescription")]
+    partial class AddExpenseCategoryDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SimplyBudgetWeb.Data/Migrations/20260901022740_AddExpenseCategoryDescription.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260901022740_AddExpenseCategoryDescription.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetWeb.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExpenseCategoryDescription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                schema: "SimplyBudget",
+                table: "ExpenseCategory",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                schema: "SimplyBudget",
+                table: "ExpenseCategory");
+        }
+    }
+}

--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -164,6 +164,7 @@ function openCategoryHistory(category: BudgetCategoryDto) {
               >
                 <v-list-item-title>{{ cat.name ?? '(unnamed)' }}</v-list-item-title>
                 <v-list-item-subtitle>
+                  <div v-if="cat.description" class="mb-1">{{ cat.description }}</div>
                   <div class="budget-chip-row d-flex flex-wrap mt-1" style="gap: 4px;">
                     <v-chip size="small">Budget: {{ cat.usePercentage ? `${cat.budgetedPercentage}%` : formatCents(cat.budgetedAmount) }}</v-chip>
                     <v-chip size="small" color="error" variant="outlined">Spent: {{ formatCents(cat.monthlyExpenses) }}</v-chip>

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -97,7 +97,7 @@ const categoriesLoading = ref(false)
 const showHiddenCategories = ref(false)
 const manageCategories = ref<ExpenseCategoryDto[]>([])
 const editCategoryId = ref<number | null>(null)
-const editCategoryForm = ref({ name: '', categoryName: '' })
+const editCategoryForm = ref({ name: '', description: '', categoryName: '' })
 const deleteCategory = ref<ExpenseCategoryDto | null>(null)
 
 async function fetchCurrentUserProfile() {
@@ -294,13 +294,18 @@ async function fetchManageCategories() {
 
 function startEditCategory(category: ExpenseCategoryDto) {
   editCategoryId.value = category.id
-  editCategoryForm.value = { name: category.name ?? '', categoryName: category.categoryName ?? '' }
+  editCategoryForm.value = {
+    name: category.name ?? '',
+    description: category.description ?? '',
+    categoryName: category.categoryName ?? '',
+  }
 }
 
 async function handleSaveCategoryEdit(category: ExpenseCategoryDto) {
   try {
     await apiClient.put(`/api/expense-categories/${category.id}`, {
       name: editCategoryForm.value.name,
+      description: editCategoryForm.value.description,
       categoryName: editCategoryForm.value.categoryName,
       budgetedAmount: category.budgetedAmount,
       budgetedPercentage: category.budgetedPercentage,
@@ -532,7 +537,7 @@ watch(openPanel, (panel) => {
             <v-card v-for="category in manageCategories" :key="category.id" class="mb-2">
               <v-list-item>
                 <v-list-item-title>
-                  <div v-if="editCategoryId === category.id" class="d-flex align-center" style="gap: 8px;">
+                  <div v-if="editCategoryId === category.id" class="d-flex flex-wrap align-center" style="gap: 8px;">
                     <v-text-field
                       v-model="editCategoryForm.name"
                       label="Name"
@@ -550,6 +555,14 @@ watch(openPanel, (panel) => {
                       style="max-width: 220px;"
                       @keydown.enter="handleSaveCategoryEdit(category)"
                     />
+                    <v-text-field
+                      v-model="editCategoryForm.description"
+                      label="Description"
+                      density="compact"
+                      hide-details
+                      style="min-width: 260px;"
+                      @keydown.enter="handleSaveCategoryEdit(category)"
+                    />
                   </div>
                   <div v-else class="d-flex align-center" style="gap: 8px;">
                     <span>{{ category.name }}</span>
@@ -557,7 +570,8 @@ watch(openPanel, (panel) => {
                   </div>
                 </v-list-item-title>
                 <v-list-item-subtitle v-if="editCategoryId !== category.id">
-                  {{ category.categoryName ?? 'No group' }}
+                  <div>{{ category.categoryName ?? 'No group' }}</div>
+                  <div v-if="category.description">{{ category.description }}</div>
                 </v-list-item-subtitle>
                 <template #append>
                   <div v-if="editCategoryId === category.id" class="d-flex" style="gap: 4px;">

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -3,6 +3,7 @@
 export interface BudgetCategoryDto {
   id: number
   name: string | null
+  description: string | null
   categoryName: string | null
   accountId: number | null
   budgetedAmount: number
@@ -28,6 +29,7 @@ export interface BudgetResponse {
 export interface ExpenseCategoryDto {
   id: number
   name: string | null
+  description: string | null
   categoryName: string | null
   accountId: number | null
   budgetedAmount: number
@@ -184,6 +186,7 @@ export interface BudgetDataExportAccountDto {
 export interface BudgetDataExportCategoryDto {
   id: number
   name: string | null
+  description: string | null
   categoryName: string | null
   accountId: number | null
   budgetedAmount: number

--- a/SimplyBudgetWeb/Controllers/BudgetController.cs
+++ b/SimplyBudgetWeb/Controllers/BudgetController.cs
@@ -52,6 +52,7 @@ public class BudgetController(BudgetWebContext context) : ControllerBase
             categoryDtos.Add(new BudgetCategoryDto(
                 Id: category.ID,
                 Name: category.Name,
+                Description: category.Description,
                 CategoryName: category.CategoryName,
                 AccountId: category.AccountID,
                 BudgetedAmount: category.BudgetedAmount,
@@ -101,6 +102,7 @@ public record BudgetResponse(int TotalBudget, int TotalAccountAmount, string Mon
 public record BudgetCategoryDto(
     int Id,
     string? Name,
+    string? Description,
     string? CategoryName,
     int? AccountId,
     int BudgetedAmount,

--- a/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
+++ b/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
@@ -29,6 +29,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
 
             query = query.Where(c =>
                 (c.Name != null && c.Name.Contains(searchText)) ||
+                (c.Description != null && c.Description.Contains(searchText)) ||
                 (c.CategoryName != null && c.CategoryName.Contains(searchText)) ||
                 (hasSearchAmount &&
                  (Math.Abs(c.BudgetedAmount) == searchAmountAbs ||
@@ -145,6 +146,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         var category = new ExpenseCategory
         {
             Name = request.Name,
+            Description = request.Description,
             CategoryName = request.CategoryName,
             BudgetedAmount = request.BudgetedAmount,
             BudgetedPercentage = request.BudgetedPercentage,
@@ -163,6 +165,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         if (category is null) return NotFound();
 
         category.Name = request.Name;
+        category.Description = request.Description;
         category.CategoryName = request.CategoryName;
         category.BudgetedAmount = request.BudgetedAmount;
         category.BudgetedPercentage = request.BudgetedPercentage;
@@ -233,6 +236,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
     private static ExpenseCategoryDto ToDto(ExpenseCategory c, bool hasItems) => new(
         Id: c.ID,
         Name: c.Name,
+        Description: c.Description,
         CategoryName: c.CategoryName,
         AccountId: c.AccountID,
         BudgetedAmount: c.BudgetedAmount,
@@ -248,6 +252,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
 public record ExpenseCategoryDto(
     int Id,
     string? Name,
+    string? Description,
     string? CategoryName,
     int? AccountId,
     int BudgetedAmount,
@@ -261,6 +266,7 @@ public record ExpenseCategoryDto(
 
 public record ExpenseCategoryRequest(
     string? Name,
+    string? Description,
     string? CategoryName,
     int BudgetedAmount,
     int BudgetedPercentage,


### PR DESCRIPTION
## Summary
- add an optional description field to expense categories across desktop and web
- include descriptions in category API responses, editing, display, and search
- version the portable data format and preserve descriptions through export/import
- add SQLite and SQL Server migrations plus coverage

Closes #203