### PR TITLE
Apply category rules only to transactions, not income

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
@@ -136,6 +136,43 @@ public class ImportControllerTests
     }
 
     [Test]
+    public async Task Save_CreditItem_DoesNotApplySuggestedCategoryRule()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Income" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Payroll rule",
+                RuleRegex = "PAYROLL",
+                ExpenseCategoryID = category.ID
+            });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var items = new[]
+        {
+            new ImportItemDto(new DateTime(2026, 1, 1), "PAYROLL", 1_000_00, false, true),
+        };
+
+        var result = await controller.Save(items);
+
+        await Assert.That(((StatusCodeResult)result).StatusCode).IsEqualTo(201);
+        var saved = await context.PendingExpenses.SingleAsync();
+        await Assert.That(saved.IsDebit).IsFalse();
+        await Assert.That(saved.SuggestedCategoryId).IsNull();
+    }
+
+    [Test]
     public async Task Save_WithNoItemsChecked_CreatesNoPendingExpenses()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -567,7 +567,7 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
-    public async Task ReapplyRules_UpdatesSuggestedCategoriesFromLatestRules()
+    public async Task ReapplyRules_AppliesRulesOnlyToDebitPendingExpenses()
     {
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
@@ -593,8 +593,22 @@ public class PendingExpensesControllerTests
                     ExpenseCategoryID = groceriesCategory.ID
                 });
             context.PendingExpenses.AddRange(
-                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco haul", Amount = 45_00, SuggestedCategoryId = utilitiesCategory.ID },
-                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Electric bill", Amount = 90_00, SuggestedCategoryId = utilitiesCategory.ID });
+                new PendingExpense
+                {
+                    Date = new DateTime(2026, 1, 1),
+                    Description = "Costco haul",
+                    Amount = 45_00,
+                    SuggestedCategoryId = utilitiesCategory.ID,
+                    IsDebit = true
+                },
+                new PendingExpense
+                {
+                    Date = new DateTime(2026, 1, 2),
+                    Description = "Costco refund",
+                    Amount = 90_00,
+                    SuggestedCategoryId = utilitiesCategory.ID,
+                    IsDebit = false
+                });
             await context.SaveChangesAsync();
 
             return groceriesCategory.ID;
@@ -614,6 +628,7 @@ public class PendingExpensesControllerTests
 
         await Assert.That(updatedItems[0].SuggestedCategoryId).IsEqualTo(groceriesCategoryId);
         await Assert.That(updatedItems[1].SuggestedCategoryId).IsNull();
+        await Assert.That(updatedItems[1].IsDebit).IsFalse();
     }
 
     [Test]

--- a/SimplyBudgetWeb/Controllers/ImportController.cs
+++ b/SimplyBudgetWeb/Controllers/ImportController.cs
@@ -110,7 +110,9 @@ public class ImportController(BudgetWebContext context) : ControllerBase
                 Description = i.Description,
                 Amount = i.Amount,
                 IsDebit = i.IsDebit,
-                SuggestedCategoryId = ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(rules, i.Description),
+                SuggestedCategoryId = i.IsDebit
+                    ? ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(rules, i.Description)
+                    : null,
             })
             .ToList();
 

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -190,8 +190,9 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 
         foreach (var pendingExpense in pendingExpenses)
         {
-            pendingExpense.SuggestedCategoryId =
-                ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(rules, pendingExpense.Description);
+            pendingExpense.SuggestedCategoryId = pendingExpense.IsDebit
+                ? ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(rules, pendingExpense.Description)
+                : null;
         }
 
         await context.SaveChangesAsync();


### PR DESCRIPTION
## Summary\n- apply suggested-category rules only for debit pending expenses\n- skip rule matching for credit (income) pending expenses during import save and reapply\n- add regression tests for import save and pending-expense reapply behavior\n\nCloses #206