### PR TITLE
Preserve pending expense notes when converting

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -789,6 +789,43 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task Convert_UsesPendingNotesWhenRequestNotesAreWhitespace()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var category = new ExpenseCategory { Name = "Groceries" };
+            context.ExpenseCategories.Add(category);
+            var pending = new PendingExpense
+            {
+                Date = new DateTime(2026, 1, 5),
+                Description = "Costco",
+                Amount = 45_00,
+                IsDebit = true,
+                Notes = "Copied from pending note"
+            };
+            context.PendingExpenses.Add(pending);
+            await context.SaveChangesAsync();
+
+            var controller = new PendingExpensesController(context);
+            await controller.Convert(pending.ID, new ConvertPendingExpenseRequest(
+                "Costco",
+                new DateTime(2026, 1, 5),
+                [new ConvertPendingExpenseItemRequest(category.ID, 45_00)],
+                System.Convert.ToBase64String(pending.Version),
+                Notes: "   "));
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var item = await context.ExpenseCategoryItems.SingleAsync();
+            await Assert.That(item.Notes).IsEqualTo("Copied from pending note");
+        });
+    }
+
+    [Test]
     public async Task Convert_Debit_CanSplitAcrossMultipleCategories()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -218,6 +218,10 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 
         var items = request.Items.Select(i => (i.Amount, i.ExpenseCategoryId)).ToArray();
 
+        var convertedItemNotes = string.IsNullOrWhiteSpace(request.Notes)
+            ? pending.Notes
+            : request.Notes;
+
         ExpenseCategoryItem item;
         if (pending.IsDebit)
         {
@@ -227,7 +231,7 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         {
             item = await context.AddIncome(request.Description, request.Date, request.IgnoreBudget, items);
         }
-        item.Notes = request.Notes ?? pending.Notes;
+        item.Notes = convertedItemNotes;
 
         context.PendingExpenses.Remove(pending);
         try


### PR DESCRIPTION
## Summary
- preserve pending-expense notes during conversion when convert payload notes are blank/whitespace
- continue allowing explicit edited notes from the convert request to override pending notes
- add regression coverage for whitespace-note conversion fallback

## Testing
- dotnet test --project SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj