### PR TITLE
Only apply category rules to transactions, not income

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Services/ExpenseCategoryRuleMatcherTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Services/ExpenseCategoryRuleMatcherTests.cs
@@ -1,0 +1,55 @@
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Services;
+
+namespace SimplyBudgetWeb.Core.Tests.Services;
+
+public class ExpenseCategoryRuleMatcherTests
+{
+    [Test]
+    public async Task GetSuggestedCategoryId_WhenNotTransaction_ReturnsNull()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule
+            {
+                Name = "Payroll rule",
+                RuleRegex = "PAYROLL",
+                ExpenseCategoryID = 7
+            }
+        ];
+
+        var suggestedCategoryId = ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(
+            rules,
+            "PAYROLL ACH",
+            isTransaction: false);
+
+        await Assert.That(suggestedCategoryId).IsNull();
+    }
+
+    [Test]
+    public async Task GetSuggestedCategoryId_WhenTransaction_ReturnsLastMatchingCategorizedRule()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule
+            {
+                Name = "Uncategorized",
+                RuleRegex = "Costco",
+                ExpenseCategoryID = null
+            },
+            new ExpenseCategoryRule
+            {
+                Name = "Categorized",
+                RuleRegex = "Costco",
+                ExpenseCategoryID = 42
+            }
+        ];
+
+        var suggestedCategoryId = ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(
+            rules,
+            "Costco gas",
+            isTransaction: true);
+
+        await Assert.That(suggestedCategoryId).IsEqualTo(42);
+    }
+}

--- a/SimplyBudgetWeb/Controllers/ImportController.cs
+++ b/SimplyBudgetWeb/Controllers/ImportController.cs
@@ -110,9 +110,10 @@ public class ImportController(BudgetWebContext context) : ControllerBase
                 Description = i.Description,
                 Amount = i.Amount,
                 IsDebit = i.IsDebit,
-                SuggestedCategoryId = i.IsDebit
-                    ? ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(rules, i.Description)
-                    : null,
+                SuggestedCategoryId = ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(
+                    rules,
+                    i.Description,
+                    isTransaction: i.IsDebit),
             })
             .ToList();
 

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -190,9 +190,10 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 
         foreach (var pendingExpense in pendingExpenses)
         {
-            pendingExpense.SuggestedCategoryId = pendingExpense.IsDebit
-                ? ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(rules, pendingExpense.Description)
-                : null;
+            pendingExpense.SuggestedCategoryId = ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(
+                rules,
+                pendingExpense.Description,
+                isTransaction: pendingExpense.IsDebit);
         }
 
         await context.SaveChangesAsync();

--- a/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatcher.cs
+++ b/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatcher.cs
@@ -5,8 +5,11 @@ namespace SimplyBudgetWeb.Services;
 
 public static class ExpenseCategoryRuleMatcher
 {
-    public static int? GetSuggestedCategoryId(IEnumerable<ExpenseCategoryRule> rules, string? description)
+    public static int? GetSuggestedCategoryId(IEnumerable<ExpenseCategoryRule> rules, string? description, bool isTransaction)
     {
+        if (!isTransaction)
+            return null;
+
         var descriptionToMatch = description ?? "";
         int? suggestedCategoryId = null;
 


### PR DESCRIPTION
## Summary
- centralize the transaction-only guard in `ExpenseCategoryRuleMatcher`
- update import save and pending-expense rule reapply flows to use the guarded matcher API
- add matcher regression tests to ensure income items never receive suggested categories

Closes #206