### PR TITLE
Make calculator tax a configurable settings list

### DIFF
--- a/SimplyBudgetShared/Data/MetaData.cs
+++ b/SimplyBudgetShared/Data/MetaData.cs
@@ -8,6 +8,7 @@ namespace SimplyBudgetShared.Data;
 public class Metadata : BaseItem
 {
     public const string VERSION_KEY = "Version";
+    public const string CALCULATOR_TAX_OPTIONS_KEY = "CalculatorTaxOptions";
 
     //[Indexed]
     public string? Key { get; set; }

--- a/SimplyBudgetWeb.Core.Tests/Controllers/CalculatorTaxOptionsControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/CalculatorTaxOptionsControllerTests.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class CalculatorTaxOptionsControllerTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Test]
+    public async Task Get_WithNoSavedOptions_ReturnsDefaultTaxOption()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new CalculatorTaxOptionsController(context);
+
+        var result = await controller.Get();
+
+        await Assert.That(result.Options.Count).IsEqualTo(1);
+        await Assert.That(result.Options[0].Name).IsEqualTo("Tax");
+        await Assert.That(result.Options[0].Percentage).IsEqualTo(9.1m);
+        await Assert.That(result.Options[0].IsDefault).IsFalse();
+    }
+
+    [Test]
+    public async Task Update_PersistsAndReturnsNormalizedOptions()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new CalculatorTaxOptionsController(context);
+            var result = await controller.Update(new UpdateCalculatorTaxOptionsRequest(
+            [
+                new CalculatorTaxOptionDto("  State Tax  ", 6.2501m, false),
+                new CalculatorTaxOptionDto("County Tax", 2.5m, true),
+            ]));
+
+            await Assert.That(result.Result).IsTypeOf<OkObjectResult>();
+            var dto = (result.Result as OkObjectResult)?.Value as CalculatorTaxOptionsDto;
+            await Assert.That(dto).IsNotNull();
+            await Assert.That(dto!.Options.Count).IsEqualTo(2);
+            await Assert.That(dto.Options[0].Name).IsEqualTo("State Tax");
+            await Assert.That(dto.Options[0].Percentage).IsEqualTo(6.25m);
+            await Assert.That(dto.Options[1].IsDefault).IsTrue();
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var saved = await context.Metadatas
+                .AsNoTracking()
+                .SingleAsync(x => x.Key == Metadata.CALCULATOR_TAX_OPTIONS_KEY);
+
+            var options = JsonSerializer.Deserialize<IReadOnlyList<CalculatorTaxOptionDto>>(saved.Value!, JsonOptions);
+            await Assert.That(options).IsNotNull();
+            await Assert.That(options!.Count).IsEqualTo(2);
+            await Assert.That(options[0].Name).IsEqualTo("State Tax");
+            await Assert.That(options[1].IsDefault).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Update_WithMultipleDefaults_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new CalculatorTaxOptionsController(context);
+
+        var result = await controller.Update(new UpdateCalculatorTaxOptionsRequest(
+        [
+            new CalculatorTaxOptionDto("State Tax", 6m, true),
+            new CalculatorTaxOptionDto("County Tax", 2m, true),
+        ]));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+    }
+
+    [Test]
+    public async Task Update_WithDuplicateNames_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new CalculatorTaxOptionsController(context);
+
+        var result = await controller.Update(new UpdateCalculatorTaxOptionsRequest(
+        [
+            new CalculatorTaxOptionDto("Tax", 6m, false),
+            new CalculatorTaxOptionDto(" tax ", 5m, false),
+        ]));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+    }
+}

--- a/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
@@ -2,7 +2,13 @@
 import { computed, ref, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
-import type { ExpenseCategoryDto, TransactionRequest, TransferRequest } from '@/types'
+import type {
+  CalculatorTaxOptionDto,
+  CalculatorTaxOptionsDto,
+  ExpenseCategoryDto,
+  TransactionRequest,
+  TransferRequest,
+} from '@/types'
 import { formatCents, dollarsToCents, centsToDollars, parseLocalDate } from '@/utils/currency'
 import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
 import CategorySelector from '@/components/CategorySelector.vue'
@@ -41,7 +47,8 @@ const calculatorOpen = ref(false)
 const calculatorLineIndex = ref<number | null>(null)
 const calculatorInput = ref('')
 const calculatorItems = ref<number[]>([])
-const calculatorAddTax = ref(false)
+const calculatorTaxOptions = ref<CalculatorTaxOptionDto[]>([])
+const calculatorSelectedTaxKey = ref('none')
 
 function removeLine(index: number) {
   lines.value = lines.value.filter((_, i) => i !== index)
@@ -105,7 +112,22 @@ const dateAsMonth = computed(() => parseLocalDate(date.value))
 
 const calculatorTotalCents = computed(() => {
   const subtotal = calculatorItems.value.reduce((sum, amount) => sum + amount, 0)
-  return calculatorAddTax.value ? Math.round(subtotal * 1.091) : subtotal
+  const taxPercentage = selectedTaxPercentage.value
+  return taxPercentage === null
+    ? subtotal
+    : Math.round(subtotal * (1 + (taxPercentage / 100)))
+})
+
+const selectedTaxPercentage = computed<number | null>(() => {
+  if (calculatorSelectedTaxKey.value === 'none') return null
+  if (!calculatorSelectedTaxKey.value.startsWith('tax-')) return null
+
+  const selectedIndex = Number.parseInt(calculatorSelectedTaxKey.value.slice(4), 10)
+  const selectedTaxOption = Number.isInteger(selectedIndex)
+    ? calculatorTaxOptions.value[selectedIndex]
+    : undefined
+
+  return selectedTaxOption?.percentage ?? null
 })
 
 watch(
@@ -122,12 +144,12 @@ watch(
   { deep: true },
 )
 
-function openCalculator(index: number) {
+async function openCalculator(index: number) {
   calculatorLineIndex.value = index
   calculatorInput.value = ''
   calculatorItems.value = []
-  calculatorAddTax.value = false
   calculatorOpen.value = true
+  await loadCalculatorTaxOptions()
 }
 
 function closeCalculator() {
@@ -144,6 +166,19 @@ function addCalculatorItem() {
 
 function removeCalculatorItem(index: number) {
   calculatorItems.value.splice(index, 1)
+}
+
+async function loadCalculatorTaxOptions() {
+  try {
+    const response = await apiClient.get<CalculatorTaxOptionsDto>('/api/calculator-tax-options')
+    calculatorTaxOptions.value = response.options ?? []
+
+    const defaultTaxIndex = calculatorTaxOptions.value.findIndex(option => option.isDefault)
+    calculatorSelectedTaxKey.value = defaultTaxIndex >= 0 ? `tax-${defaultTaxIndex}` : 'none'
+  } catch {
+    calculatorTaxOptions.value = []
+    calculatorSelectedTaxKey.value = 'none'
+  }
 }
 
 function applyCalculator() {
@@ -344,12 +379,15 @@ async function submit() {
           </v-list-item>
         </v-list>
 
-        <v-checkbox
-          v-model="calculatorAddTax"
-          label="Add Tax"
-          density="compact"
-          hide-details
-        />
+        <v-radio-group v-model="calculatorSelectedTaxKey" density="compact" hide-details>
+          <v-radio label="None" value="none" />
+          <v-radio
+            v-for="(option, index) in calculatorTaxOptions"
+            :key="`${option.name}-${index}`"
+            :label="`${option.name} (+${option.percentage}%)`"
+            :value="`tax-${index}`"
+          />
+        </v-radio-group>
         <div class="text-h6">Total: {{ formatCents(calculatorTotalCents) }}</div>
       </v-card-text>
       <v-card-actions>

--- a/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/ConvertPendingExpenseDialog.vue
@@ -2,7 +2,13 @@
 import { ref, computed, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
-import type { ExpenseCategoryDto, PendingExpenseDto, ConvertPendingExpenseRequest } from '@/types'
+import type {
+  CalculatorTaxOptionDto,
+  CalculatorTaxOptionsDto,
+  ExpenseCategoryDto,
+  PendingExpenseDto,
+  ConvertPendingExpenseRequest,
+} from '@/types'
 import { formatCents, dollarsToCents, centsToDollars, parseLocalDate } from '@/utils/currency'
 import IncomeAllocationList from '@/components/IncomeAllocationList.vue'
 import CategorySelector from '@/components/CategorySelector.vue'
@@ -41,7 +47,8 @@ const calculatorOpen = ref(false)
 const calculatorLineIndex = ref<number | null>(null)
 const calculatorInput = ref('')
 const calculatorItems = ref<number[]>([])
-const calculatorAddTax = ref(false)
+const calculatorTaxOptions = ref<CalculatorTaxOptionDto[]>([])
+const calculatorSelectedTaxKey = ref('none')
 
 function isValidCategoryId(value: LineItem['expenseCategoryId']): value is number {
   return typeof value === 'number' && props.categories.some(category => category.id === value)
@@ -109,7 +116,22 @@ const canSubmit = computed(() => {
 
 const calculatorTotalCents = computed(() => {
   const subtotal = calculatorItems.value.reduce((sum, amount) => sum + amount, 0)
-  return calculatorAddTax.value ? Math.round(subtotal * 1.091) : subtotal
+  const taxPercentage = selectedTaxPercentage.value
+  return taxPercentage === null
+    ? subtotal
+    : Math.round(subtotal * (1 + (taxPercentage / 100)))
+})
+
+const selectedTaxPercentage = computed<number | null>(() => {
+  if (calculatorSelectedTaxKey.value === 'none') return null
+  if (!calculatorSelectedTaxKey.value.startsWith('tax-')) return null
+
+  const selectedIndex = Number.parseInt(calculatorSelectedTaxKey.value.slice(4), 10)
+  const selectedTaxOption = Number.isInteger(selectedIndex)
+    ? calculatorTaxOptions.value[selectedIndex]
+    : undefined
+
+  return selectedTaxOption?.percentage ?? null
 })
 
 watch(
@@ -151,12 +173,12 @@ function removeLine(index: number) {
   lines.value = lines.value.filter((_, i) => i !== index)
 }
 
-function openCalculator(index: number) {
+async function openCalculator(index: number) {
   calculatorLineIndex.value = index
   calculatorInput.value = ''
   calculatorItems.value = []
-  calculatorAddTax.value = false
   calculatorOpen.value = true
+  await loadCalculatorTaxOptions()
 }
 
 function closeCalculator() {
@@ -173,6 +195,19 @@ function addCalculatorItem() {
 
 function removeCalculatorItem(index: number) {
   calculatorItems.value.splice(index, 1)
+}
+
+async function loadCalculatorTaxOptions() {
+  try {
+    const response = await apiClient.get<CalculatorTaxOptionsDto>('/api/calculator-tax-options')
+    calculatorTaxOptions.value = response.options ?? []
+
+    const defaultTaxIndex = calculatorTaxOptions.value.findIndex(option => option.isDefault)
+    calculatorSelectedTaxKey.value = defaultTaxIndex >= 0 ? `tax-${defaultTaxIndex}` : 'none'
+  } catch {
+    calculatorTaxOptions.value = []
+    calculatorSelectedTaxKey.value = 'none'
+  }
 }
 
 function applyCalculator() {
@@ -375,12 +410,15 @@ async function saveNote() {
           </v-list-item>
         </v-list>
 
-        <v-checkbox
-          v-model="calculatorAddTax"
-          label="Add Tax"
-          density="compact"
-          hide-details
-        />
+        <v-radio-group v-model="calculatorSelectedTaxKey" density="compact" hide-details>
+          <v-radio label="None" value="none" />
+          <v-radio
+            v-for="(option, index) in calculatorTaxOptions"
+            :key="`${option.name}-${index}`"
+            :label="`${option.name} (+${option.percentage}%)`"
+            :value="`tax-${index}`"
+          />
+        </v-radio-group>
         <div class="text-h6">Total: {{ formatCents(calculatorTotalCents) }}</div>
       </v-card-text>
       <v-card-actions>

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -3,7 +3,13 @@ import { ref, computed, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import { useAuthStore } from '@/stores/auth'
-import type { RuleDto, ExpenseCategoryDto, AccountDto, CurrentUserDto } from '@/types'
+import type {
+  RuleDto,
+  ExpenseCategoryDto,
+  AccountDto,
+  CalculatorTaxOptionsDto,
+  CurrentUserDto,
+} from '@/types'
 import { formatCents } from '@/utils/currency'
 import CategorySelector from '@/components/CategorySelector.vue'
 
@@ -11,9 +17,10 @@ const snackbar = useSnackbarStore()
 const authStore = useAuthStore()
 
 const PANEL_PROFILE = 0
-const PANEL_ACCOUNTS = 1
-const PANEL_RULES = 2
-const PANEL_CATEGORIES = 3
+const PANEL_TAX_OPTIONS = 1
+const PANEL_ACCOUNTS = 2
+const PANEL_RULES = 3
+const PANEL_CATEGORIES = 4
 
 const openPanel = ref<number | undefined>(undefined)
 
@@ -21,6 +28,17 @@ const profileLoaded = ref(false)
 const profileLoading = ref(false)
 const profileSaving = ref(false)
 const profileDisplayName = ref(authStore.displayName ?? authStore.account?.name ?? '')
+
+interface TaxOptionFormRow {
+  name: string
+  percentage: string
+}
+
+const taxOptionsLoading = ref(false)
+const taxOptionsLoaded = ref(false)
+const taxOptionsSaving = ref(false)
+const taxOptions = ref<TaxOptionFormRow[]>([])
+const taxDefaultKey = ref('none')
 
 const accounts = ref<AccountDto[]>([])
 const accountsLoading = ref(false)
@@ -131,6 +149,92 @@ async function handleSaveDisplayName() {
     snackbar.enqueueSnackbar('Failed to update display name', { variant: 'error' })
   } finally {
     profileSaving.value = false
+  }
+}
+
+function applyTaxOptionsResponse(response: CalculatorTaxOptionsDto) {
+  const options = response.options ?? []
+  taxOptions.value = options.map(option => ({
+    name: option.name ?? '',
+    percentage: option.percentage.toString(),
+  }))
+
+  const defaultIndex = options.findIndex(option => option.isDefault)
+  taxDefaultKey.value = defaultIndex >= 0 ? `tax-${defaultIndex}` : 'none'
+}
+
+async function fetchTaxOptions() {
+  taxOptionsLoading.value = true
+  try {
+    const response = await apiClient.get<CalculatorTaxOptionsDto>('/api/calculator-tax-options')
+    applyTaxOptionsResponse(response)
+    taxOptionsLoaded.value = true
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load tax options', { variant: 'error' })
+  } finally {
+    taxOptionsLoading.value = false
+  }
+}
+
+function addTaxOption() {
+  taxOptions.value.push({ name: '', percentage: '' })
+}
+
+function removeTaxOption(index: number) {
+  taxOptions.value.splice(index, 1)
+
+  if (taxDefaultKey.value === `tax-${index}`) {
+    taxDefaultKey.value = 'none'
+    return
+  }
+
+  if (!taxDefaultKey.value.startsWith('tax-')) return
+  const selectedIndex = Number.parseInt(taxDefaultKey.value.slice(4), 10)
+  if (Number.isInteger(selectedIndex) && selectedIndex > index) {
+    taxDefaultKey.value = `tax-${selectedIndex - 1}`
+  }
+}
+
+async function handleSaveTaxOptions() {
+  const normalizedOptions = taxOptions.value.map((option, index) => {
+    const name = option.name.trim()
+    const percentage = Number.parseFloat(option.percentage)
+    return {
+      name,
+      percentage,
+      isDefault: taxDefaultKey.value === `tax-${index}`,
+    }
+  })
+
+  const firstMissingName = normalizedOptions.find(option => option.name.length === 0)
+  if (firstMissingName) {
+    snackbar.enqueueSnackbar('Every tax option must include a name', { variant: 'error' })
+    return
+  }
+
+  const invalidPercentage = normalizedOptions.find(option => !Number.isFinite(option.percentage) || option.percentage <= 0 || option.percentage > 100)
+  if (invalidPercentage) {
+    snackbar.enqueueSnackbar('Tax percentages must be greater than 0 and no more than 100', { variant: 'error' })
+    return
+  }
+
+  const names = normalizedOptions.map(option => option.name.toLocaleLowerCase())
+  if (new Set(names).size !== names.length) {
+    snackbar.enqueueSnackbar('Tax option names must be unique', { variant: 'error' })
+    return
+  }
+
+  taxOptionsSaving.value = true
+  try {
+    const response = await apiClient.put<CalculatorTaxOptionsDto>('/api/calculator-tax-options', {
+      options: normalizedOptions,
+    })
+    applyTaxOptionsResponse(response)
+    snackbar.enqueueSnackbar('Tax options updated', { variant: 'success' })
+  } catch (error) {
+    snackbar.enqueueSnackbar(error instanceof Error ? error.message : 'Failed to save tax options', { variant: 'error' })
+  } finally {
+    taxOptionsSaving.value = false
   }
 }
 
@@ -366,6 +470,11 @@ watch(openPanel, (panel) => {
     return
   }
 
+  if (panel === PANEL_TAX_OPTIONS && !taxOptionsLoaded.value) {
+    void fetchTaxOptions()
+    return
+  }
+
   if (panel === PANEL_ACCOUNTS && !accountsLoaded.value) {
     void fetchAccounts()
     return
@@ -408,6 +517,78 @@ watch(openPanel, (panel) => {
             />
             <div>
               <v-btn color="primary" :loading="profileSaving" @click="handleSaveDisplayName">Save Display Name</v-btn>
+            </div>
+          </div>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <div>
+            <div class="text-subtitle-1 font-weight-medium">Calculator Tax Options</div>
+            <div class="text-body-2 text-medium-emphasis">Manage named tax percentages used in amount calculators.</div>
+          </div>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <div v-if="taxOptionsLoading" class="d-flex justify-center pa-8">
+            <v-progress-circular indeterminate aria-label="Loading calculator tax options" />
+          </div>
+          <div v-else class="d-flex flex-column" style="gap: 12px;">
+            <v-radio-group
+              v-model="taxDefaultKey"
+              label="Default selected tax"
+              density="compact"
+              hide-details
+            >
+              <v-radio label="None" value="none" />
+              <v-radio
+                v-for="(option, index) in taxOptions"
+                :key="`default-tax-${index}`"
+                :label="option.name.trim() || `Tax option ${index + 1}`"
+                :value="`tax-${index}`"
+              />
+            </v-radio-group>
+
+            <v-alert v-if="taxOptions.length === 0" type="info" variant="tonal">
+              No tax options defined. Add one to make it available in the calculator.
+            </v-alert>
+
+            <div
+              v-for="(option, index) in taxOptions"
+              :key="`tax-option-${index}`"
+              class="d-flex align-center flex-wrap"
+              style="gap: 8px;"
+            >
+              <v-text-field
+                v-model="option.name"
+                label="Name"
+                density="compact"
+                hide-details
+                style="max-width: 240px;"
+              />
+              <v-text-field
+                v-model="option.percentage"
+                label="Percentage"
+                type="number"
+                step="0.001"
+                min="0"
+                density="compact"
+                hide-details
+                suffix="%"
+                style="max-width: 180px;"
+              />
+              <v-btn
+                icon="mdi-delete"
+                variant="text"
+                color="error"
+                aria-label="Remove tax option"
+                @click="removeTaxOption(index)"
+              />
+            </div>
+
+            <div class="d-flex flex-wrap" style="gap: 8px;">
+              <v-btn variant="outlined" @click="addTaxOption">Add Tax Option</v-btn>
+              <v-btn color="primary" :loading="taxOptionsSaving" @click="handleSaveTaxOptions">Save Tax Options</v-btn>
             </div>
           </div>
         </v-expansion-panel-text>

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -109,6 +109,16 @@ export interface CurrentUserDto {
   email: string | null
 }
 
+export interface CalculatorTaxOptionDto {
+  name: string
+  percentage: number
+  isDefault: boolean
+}
+
+export interface CalculatorTaxOptionsDto {
+  options: CalculatorTaxOptionDto[]
+}
+
 export interface PendingExpenseDto {
   id: number
   version: string

--- a/SimplyBudgetWeb/Controllers/CalculatorTaxOptionsController.cs
+++ b/SimplyBudgetWeb/Controllers/CalculatorTaxOptionsController.cs
@@ -1,0 +1,209 @@
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Controllers;
+
+[ApiController]
+[Route("api/calculator-tax-options")]
+public class CalculatorTaxOptionsController(BudgetWebContext context) : ControllerBase
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [HttpGet]
+    public async Task<CalculatorTaxOptionsDto> Get()
+    {
+        var serialized = await context.Metadatas
+            .Where(x => x.Key == Metadata.CALCULATOR_TAX_OPTIONS_KEY)
+            .OrderBy(x => x.ID)
+            .Select(x => x.Value)
+            .FirstOrDefaultAsync();
+
+        return new CalculatorTaxOptionsDto(ParseStoredOptions(serialized));
+    }
+
+    [HttpPut]
+    public async Task<ActionResult<CalculatorTaxOptionsDto>> Update([FromBody] UpdateCalculatorTaxOptionsRequest request)
+    {
+        if (request.Options is null)
+        {
+            return BadRequest("Options are required.");
+        }
+
+        if (!TryValidateAndNormalizeForSave(request.Options, out var normalizedOptions, out var validationError))
+        {
+            return BadRequest(validationError);
+        }
+
+        var serialized = JsonSerializer.Serialize(normalizedOptions, JsonOptions);
+        var existingMetadataRows = await context.Metadatas
+            .AsTracking()
+            .Where(x => x.Key == Metadata.CALCULATOR_TAX_OPTIONS_KEY)
+            .OrderBy(x => x.ID)
+            .ToListAsync();
+
+        if (existingMetadataRows.Count == 0)
+        {
+            context.Metadatas.Add(new Metadata
+            {
+                Key = Metadata.CALCULATOR_TAX_OPTIONS_KEY,
+                Value = serialized,
+            });
+        }
+        else
+        {
+            existingMetadataRows[0].Value = serialized;
+
+            if (existingMetadataRows.Count > 1)
+            {
+                context.Metadatas.RemoveRange(existingMetadataRows.Skip(1));
+            }
+        }
+
+        await context.SaveChangesAsync();
+        return Ok(new CalculatorTaxOptionsDto(normalizedOptions));
+    }
+
+    private static CalculatorTaxOptionDto[] ParseStoredOptions(string? serialized)
+    {
+        if (string.IsNullOrWhiteSpace(serialized))
+        {
+            return GetDefaultOptions();
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<IReadOnlyList<CalculatorTaxOptionDto>>(serialized, JsonOptions);
+            return NormalizeForRead(parsed);
+        }
+        catch (JsonException)
+        {
+            return GetDefaultOptions();
+        }
+    }
+
+    private static CalculatorTaxOptionDto[] NormalizeForRead(IReadOnlyList<CalculatorTaxOptionDto>? options)
+    {
+        if (options is null || options.Count == 0)
+        {
+            return GetDefaultOptions();
+        }
+
+        var normalized = new List<CalculatorTaxOptionDto>();
+        foreach (var option in options)
+        {
+            var name = option.Name?.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            if (name.Length > 100 || option.Percentage <= 0m || option.Percentage > 100m)
+            {
+                continue;
+            }
+
+            normalized.Add(new CalculatorTaxOptionDto(
+                Name: name,
+                Percentage: decimal.Round(option.Percentage, 3, MidpointRounding.AwayFromZero),
+                IsDefault: option.IsDefault
+            ));
+        }
+
+        if (normalized.Count == 0)
+        {
+            return GetDefaultOptions();
+        }
+
+        var defaultIndex = normalized.FindIndex(x => x.IsDefault);
+        if (defaultIndex >= 0)
+        {
+            normalized = [.. normalized.Select((option, index) => option with { IsDefault = index == defaultIndex })];
+        }
+
+        return [.. normalized];
+    }
+
+    private static bool TryValidateAndNormalizeForSave(
+        IReadOnlyList<CalculatorTaxOptionDto> options,
+        out CalculatorTaxOptionDto[] normalizedOptions,
+        out string? validationError)
+    {
+        normalizedOptions = [];
+        validationError = null;
+
+        if (options.Count > 20)
+        {
+            validationError = "No more than 20 tax options are allowed.";
+            return false;
+        }
+
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var normalized = new List<CalculatorTaxOptionDto>(options.Count);
+        var defaultCount = 0;
+
+        for (var index = 0; index < options.Count; index++)
+        {
+            var option = options[index];
+            var name = option.Name?.Trim() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                validationError = $"Tax option #{index + 1} must include a name.";
+                return false;
+            }
+
+            if (name.Length > 100)
+            {
+                validationError = $"Tax option '{name}' must be 100 characters or fewer.";
+                return false;
+            }
+
+            if (option.Percentage <= 0m || option.Percentage > 100m)
+            {
+                validationError = $"Tax option '{name}' must be greater than 0 and no more than 100.";
+                return false;
+            }
+
+            if (!seenNames.Add(name))
+            {
+                validationError = $"Tax option '{name}' is duplicated.";
+                return false;
+            }
+
+            if (option.IsDefault)
+            {
+                defaultCount++;
+            }
+
+            normalized.Add(new CalculatorTaxOptionDto(
+                Name: name,
+                Percentage: decimal.Round(option.Percentage, 3, MidpointRounding.AwayFromZero),
+                IsDefault: option.IsDefault
+            ));
+        }
+
+        if (defaultCount > 1)
+        {
+            validationError = "Only one tax option can be marked as default.";
+            return false;
+        }
+
+        normalizedOptions = [.. normalized];
+        return true;
+    }
+
+    private static CalculatorTaxOptionDto[] GetDefaultOptions() =>
+    [
+        new CalculatorTaxOptionDto("Tax", 9.1m, false),
+    ];
+}
+
+public record CalculatorTaxOptionsDto(IReadOnlyList<CalculatorTaxOptionDto> Options);
+
+public record UpdateCalculatorTaxOptionsRequest(IReadOnlyList<CalculatorTaxOptionDto>? Options);
+
+public record CalculatorTaxOptionDto(string Name, decimal Percentage, bool IsDefault);


### PR DESCRIPTION
## Summary\n- replace hard-coded calculator tax handling with API-backed named tax options\n- add Settings UI to add/remove tax options, choose an optional default, and persist changes\n- update both transaction calculators to show tax choices as radio options including `None`\n- add controller tests for default behavior, persistence, and validation\n\nCloses #208