### PR TITLE
Filter out transfer rows from import

### DIFF
--- a/SimplyBudgetShared/Import/StcuCsvImport.cs
+++ b/SimplyBudgetShared/Import/StcuCsvImport.cs
@@ -12,10 +12,12 @@ public class StcuCsvImport : CsvImport<StcuRecord>
     protected override ExpenseCategoryItem? ConvertRow(StcuRecord row)
     {
         if (row.Amount is null) return null;
+        if (IsTransfer(row)) return null;
+
         switch (row.TransactionType?.ToLowerInvariant())
         {
             case "check":
-            case "debit" when !string.Equals(row.Type, "Transfer", StringComparison.Ordinal):
+            case "debit":
                 return new()
                 {
                     Date = row.EffectiveDate?.Date ?? row.PostingDate?.Date ?? DateTime.Today,
@@ -28,7 +30,6 @@ public class StcuCsvImport : CsvImport<StcuRecord>
                         }
                     ]
                 };
-            case "debit": return null;
             case "credit":
                 return new()
                 {
@@ -46,6 +47,10 @@ public class StcuCsvImport : CsvImport<StcuRecord>
                 throw new InvalidOperationException($"Unknown transaction type '{row.TransactionType}'");
         }
     }
+
+    private static bool IsTransfer(StcuRecord row)
+        => string.Equals(row.Type?.Trim(), "Transfer", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(row.Description?.Trim(), "efund transfer", StringComparison.OrdinalIgnoreCase);
 }
 
 public class StcuRecord

--- a/SimplyBudgetSharedTests/Import/StcuCsvImportTests.cs
+++ b/SimplyBudgetSharedTests/Import/StcuCsvImportTests.cs
@@ -78,6 +78,18 @@ public class StcuCsvImportTests
     }
 
     [TestMethod]
+    public async Task CanRead_Transactions_IgnoresEfundTransferDescription()
+    {
+        string csv = @"""2020112212345678,12345,123,123,123,123,123"",""11/22/2020"",""11/22/2020"",""Debit"",""-50.00000"","""",""500000000"",""efund transfer"","""",""Debit Card"",""10000.00000"","""",""efund transfer""";
+        using var stream = AsStream(csv);
+        var csvImport = new StcuCsvImport(stream);
+
+        var items = await csvImport.GetItems().ToListAsync();
+
+        Assert.AreEqual(0, items.Count);
+    }
+
+    [TestMethod]
     [Description("Issue 3")]
     public async Task Import_WithDifferentEffectiveAndPostingDate_UsesEffectiveDate()
     {

--- a/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
@@ -53,6 +53,22 @@ public class ImportControllerTests
     }
 
     [Test]
+    public async Task Parse_WithEfundTransferDescription_FiltersOutTransfer()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var csv = BuildCsv(@"""1"",""11/23/2020"",""11/23/2020"",""Debit"",""-200.00000"","""",""1"",""efund transfer"","""",""Debit Card"",""1"","""",""efund transfer""");
+        var result = await controller.Parse(new ImportRequest(csv));
+
+        var items = ((OkObjectResult)result.Result!).Value as ImportItemDto[];
+        await Assert.That(items!.Length).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Save_CreatesPendingExpensesForCheckedItems()
     {
         AutoMocker mocker = new();


### PR DESCRIPTION
## Summary\n- exclude STCU transfer rows before conversion using a centralized transfer check\n- treat the Type field case-insensitively and ignore the known `efund transfer` description\n- add parser and API parse tests to ensure these rows are not imported\n\nCloses #207