### PR TITLE
Preserve backend cooldown during backend deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -319,6 +319,7 @@ jobs:
     outputs:
       acr_login_server: ${{ steps.terraform-outputs.outputs.acr_login_server }}
       backend_container_app_name: ${{ steps.terraform-outputs.outputs.backend_container_app_name }}
+      backend_container_app_cooldown_period_seconds: ${{ steps.terraform-outputs.outputs.backend_container_app_cooldown_period_seconds }}
       backend_url: ${{ steps.terraform-outputs.outputs.backend_url }}
       resource_group_name: ${{ steps.terraform-outputs.outputs.resource_group_name }}
       static_web_app_name: ${{ steps.terraform-outputs.outputs.static_web_app_name }}
@@ -360,6 +361,7 @@ jobs:
         run: |
           echo "acr_login_server=$(terraform output -raw acr_login_server)" >> $GITHUB_OUTPUT
           echo "backend_container_app_name=$(terraform output -raw backend_container_app_name)" >> $GITHUB_OUTPUT
+          echo "backend_container_app_cooldown_period_seconds=$(terraform output -raw backend_container_app_cooldown_period_seconds)" >> $GITHUB_OUTPUT
           echo "resource_group_name=$(terraform output -raw resource_group_name)" >> $GITHUB_OUTPUT
           echo "static_web_app_name=$(terraform output -raw static_web_app_name)" >> $GITHUB_OUTPUT
           echo "static_web_app_api_key=$(terraform output -raw static_web_app_api_key)" >> $GITHUB_OUTPUT
@@ -388,6 +390,7 @@ jobs:
 
           $resourceGroupName = '${{ steps.terraform-outputs.outputs.resource_group_name }}'
           $backendContainerAppName = '${{ steps.terraform-outputs.outputs.backend_container_app_name }}'
+          $backendContainerAppCooldownPeriodSeconds = '${{ steps.terraform-outputs.outputs.backend_container_app_cooldown_period_seconds }}'
           $staticWebAppApiKey = '${{ steps.terraform-outputs.outputs.static_web_app_api_key }}'
 
           if ([string]::IsNullOrWhiteSpace($resourceGroupName)) {
@@ -411,6 +414,11 @@ jobs:
               $reasons += "Container App '$backendContainerAppName' was not found in resource group '$resourceGroupName'"
               $LASTEXITCODE = 0
             }
+          }
+
+          if ([string]::IsNullOrWhiteSpace($backendContainerAppCooldownPeriodSeconds)) {
+            $deployReady = $false
+            $reasons += 'Terraform output backend_container_app_cooldown_period_seconds is empty'
           }
 
           if ([string]::IsNullOrWhiteSpace($staticWebAppApiKey)) {
@@ -491,7 +499,8 @@ jobs:
           az containerapp update `
             --name ${{ needs.get-infrastructure-outputs.outputs.backend_container_app_name }} `
             --resource-group ${{ needs.get-infrastructure-outputs.outputs.resource_group_name }} `
-            --image ${{ needs.get-infrastructure-outputs.outputs.acr_login_server }}/simplybudgetweb:${{ github.sha }}
+            --image ${{ needs.get-infrastructure-outputs.outputs.acr_login_server }}/simplybudgetweb:${{ github.sha }} `
+            --set template.scale.cooldownPeriod=${{ needs.get-infrastructure-outputs.outputs.backend_container_app_cooldown_period_seconds }}
 
   # Deploy frontend to Azure Static Web Apps
   deploy-frontend:

--- a/Infra/outputs.tf
+++ b/Infra/outputs.tf
@@ -8,6 +8,11 @@ output "backend_container_app_name" {
   value       = module.prod.backend_container_app_name
 }
 
+output "backend_container_app_cooldown_period_seconds" {
+  description = "Cooldown period for backend container app autoscaling, in seconds"
+  value       = module.prod.backend_container_app_cooldown_period_seconds
+}
+
 output "resource_group_name" {
   description = "The name of the dedicated SimplyBudget resource group containing the app's non-shared resources"
   value       = module.prod.resource_group_name

--- a/Infra/prod/main.tf
+++ b/Infra/prod/main.tf
@@ -5,11 +5,12 @@ locals {
       "Environment" = local.environment
   })
 
-  sql_server_name            = var.existing_sql_server_name
-  sql_database_name          = var.existing_sql_database_name
-  database_schema_name       = var.database_schema_name
-  backend_container_app_name = "simplybudget-${lower(local.environment)}-backend"
-  static_web_app_name        = "simplybudget-${lower(local.environment)}-swa"
+  sql_server_name                               = var.existing_sql_server_name
+  sql_database_name                             = var.existing_sql_database_name
+  database_schema_name                          = var.database_schema_name
+  backend_container_app_name                    = "simplybudget-${lower(local.environment)}-backend"
+  backend_container_app_cooldown_period_seconds = 3600
+  static_web_app_name                           = "simplybudget-${lower(local.environment)}-swa"
 
   base_database_connection_string         = "Server=tcp:${data.azurerm_mssql_server.existing.fully_qualified_domain_name},1433;Initial Catalog=${data.azurerm_mssql_database.existing.name};Encrypt=True;TrustServerCertificate=False;Connection Timeout=120;"
   provisioning_database_connection_string = "Server=tcp:${data.azurerm_mssql_server.existing.fully_qualified_domain_name},1433;Initial Catalog=${data.azurerm_mssql_database.existing.name};Encrypt=True;TrustServerCertificate=False;Connection Timeout=300;"
@@ -338,7 +339,7 @@ module "backend_container_app" {
   # Keep the backend warm for 60 minutes of inactivity before KEDA scales it
   # down to 0 replicas (min_replicas defaults to 0), avoiding cold starts for
   # infrequent traffic.
-  cooldown_period_seconds = 3600
+  cooldown_period_seconds = local.backend_container_app_cooldown_period_seconds
 
   # AllowedOrigins must cover every hostname the frontend can be served from
   # (the SWA's auto-generated default hostname and the production custom

--- a/Infra/prod/outputs.tf
+++ b/Infra/prod/outputs.tf
@@ -12,6 +12,11 @@ output "backend_container_app_name" {
   value       = module.backend_container_app.name
 }
 
+output "backend_container_app_cooldown_period_seconds" {
+  description = "Cooldown period for backend container app autoscaling, in seconds"
+  value       = local.backend_container_app_cooldown_period_seconds
+}
+
 output "resource_group_name" {
   description = "The name of the dedicated SimplyBudget resource group containing the app's non-shared resources"
   value       = azurerm_resource_group.app.name


### PR DESCRIPTION
## Summary\n- keep backend container app cooldown at 3600s during image deployments\n- surface cooldown period as a Terraform output used by deployment workflow\n- set cooldown explicitly in `az containerapp update` so deploys do not reset it to default\n\n## Why\nThe infra config sets cooldown to 3600s, but backend deploy workflow updates were reverting this to the platform default.