### PR TITLE
Add estimated monthly income to budget summary

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/BudgetControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/BudgetControllerTests.cs
@@ -72,6 +72,127 @@ public class BudgetControllerTests
 
         await Assert.That(februaryBudget.TotalAccountAmount).IsEqualTo(1000);
         await Assert.That(aprilBudget.TotalAccountAmount).IsEqualTo(700);
+        await Assert.That(februaryBudget.EstimatedMonthlyIncome).IsEqualTo(333);
+        await Assert.That(aprilBudget.EstimatedMonthlyIncome).IsEqualTo(333);
         await Assert.That(februaryBudget.Categories.Single().Description).IsEqualTo("Tracks the checking account");
+    }
+
+    [Test]
+    public async Task Get_EstimatedMonthlyIncome_UsesPriorThreeMonthsAndExcludesIgnoredBudgetItems()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var primaryCategory = new ExpenseCategory
+            {
+                Name = "Primary",
+                Description = "Primary category",
+            };
+            var transferCategory = new ExpenseCategory
+            {
+                Name = "Transfer",
+                Description = "Transfer category",
+            };
+
+            context.ExpenseCategories.AddRange(primaryCategory, transferCategory);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.AddRange(
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 1, 3),
+                    Description = "January income",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = 3000,
+                            ExpenseCategoryId = primaryCategory.ID,
+                        },
+                    ],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 2, 8),
+                    Description = "February income",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = 6000,
+                            ExpenseCategoryId = primaryCategory.ID,
+                        },
+                    ],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 3, 15),
+                    Description = "March income",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = 9000,
+                            ExpenseCategoryId = primaryCategory.ID,
+                        },
+                    ],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 3, 18),
+                    Description = "Ignored income",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = 12000,
+                            ExpenseCategoryId = primaryCategory.ID,
+                            IgnoreBudget = true,
+                        },
+                    ],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 3, 20),
+                    Description = "Transfer",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = 5000,
+                            ExpenseCategoryId = primaryCategory.ID,
+                        },
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = -5000,
+                            ExpenseCategoryId = transferCategory.ID,
+                        },
+                    ],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 4, 5),
+                    Description = "Current month income",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = 15000,
+                            ExpenseCategoryId = primaryCategory.ID,
+                        },
+                    ],
+                });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
+        var controller = new BudgetController(context);
+
+        var aprilBudget = await controller.Get(new DateTime(2026, 4, 1));
+
+        await Assert.That(aprilBudget.EstimatedMonthlyIncome).IsEqualTo(6000);
     }
 }

--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -165,6 +165,7 @@ function openCategoryHistory(category: BudgetCategoryDto) {
     <v-card v-if="budget" class="pa-4 mb-4">
       <div class="d-flex flex-wrap" style="gap: 16px;">
         <span class="text-h5">Total Budget: <strong>{{ formatCents(budget.totalBudget) }}</strong></span>
+        <span class="text-h5">Estimated Monthly Income: <strong>{{ formatCents(budget.estimatedMonthlyIncome) }}</strong></span>
         <span class="text-h5">Total In Accounts: <strong>{{ formatCents(budget.totalAccountAmount) }}</strong></span>
       </div>
     </v-card>

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -22,6 +22,7 @@ export interface BudgetCategoryDto {
 export interface BudgetResponse {
   totalBudget: number
   totalAccountAmount: number
+  estimatedMonthlyIncome: number
   month: string
   categories: BudgetCategoryDto[]
 }

--- a/SimplyBudgetWeb/Controllers/BudgetController.cs
+++ b/SimplyBudgetWeb/Controllers/BudgetController.cs
@@ -16,6 +16,7 @@ public class BudgetController(BudgetWebContext context) : ControllerBase
         var monthDate = (month ?? DateTime.Today).StartOfMonth();
         var start = monthDate.StartOfMonth();
         var end = monthDate.EndOfMonth();
+        var estimatedMonthlyIncome = await CalculateEstimatedMonthlyIncome(monthDate);
         var totalAccountAmount = await context.ExpenseCategories
             .Where(x => x.AccountID != null)
             .Select(x => (int?)x.CurrentBalance)
@@ -78,9 +79,26 @@ public class BudgetController(BudgetWebContext context) : ControllerBase
         return new BudgetResponse(
             TotalBudget: totalBudget,
             TotalAccountAmount: totalAccountAmount,
+            EstimatedMonthlyIncome: estimatedMonthlyIncome,
             Month: monthDate.ToString("yyyy-MM"),
             Categories: categoryDtos
         );
+    }
+
+    private async Task<int> CalculateEstimatedMonthlyIncome(DateTime month)
+    {
+        var rangeStart = month.AddMonths(-3);
+        var priorItems = await context.ExpenseCategoryItems
+            .Where(x => x.Date >= rangeStart && x.Date < month)
+            .Include(x => x.Details)
+            .ToListAsync();
+
+        int totalIncome = priorItems
+            .Where(x => (x.Details?.Count ?? 0) > 0)
+            .Where(x => x.Details!.All(d => d.Amount > 0 && !d.IgnoreBudget))
+            .Sum(x => x.Details!.Sum(d => d.Amount));
+
+        return totalIncome / 3;
     }
 
     private static int CalculateAverage(IList<ExpenseCategoryItemDetail> categoryItems, DateTime month, int numMonths)
@@ -97,7 +115,12 @@ public class BudgetController(BudgetWebContext context) : ControllerBase
     }
 }
 
-public record BudgetResponse(int TotalBudget, int TotalAccountAmount, string Month, List<BudgetCategoryDto> Categories);
+public record BudgetResponse(
+    int TotalBudget,
+    int TotalAccountAmount,
+    int EstimatedMonthlyIncome,
+    string Month,
+    List<BudgetCategoryDto> Categories);
 
 public record BudgetCategoryDto(
     int Id,


### PR DESCRIPTION
## Summary
- add `estimatedMonthlyIncome` to the budget API response
- compute it as the average income from the prior 3 months
- exclude ignored-budget items and transfer entries from the calculation
- display Estimated Monthly Income on the budget page
- add controller tests covering the new income estimate behavior

Closes #45