### PR TITLE
Expose expense item notes in creation and history UI

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
@@ -1,4 +1,6 @@
 using Moq.AutoMock;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetWeb.Controllers;
 using SimplyBudgetWeb.Data;
@@ -149,5 +151,61 @@ public class HistoryControllerTests
 
         await Assert.That(result.Length).IsEqualTo(1);
         await Assert.That(result[0].Notes).IsEqualTo("Business membership renewal");
+    }
+
+    [Test]
+    public async Task Update_UpdatesNotesAndReturnsUpdatedItem()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        var itemId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            var item = new ExpenseCategoryItem
+            {
+                Date = new DateTime(2026, 1, 10),
+                Description = "Costco",
+                Notes = "Original note",
+                Details = [new ExpenseCategoryItemDetail { Amount = -1234, ExpenseCategoryId = category.ID }],
+            };
+            context.ExpenseCategoryItems.Add(item);
+            await context.SaveChangesAsync();
+
+            return item.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new HistoryController(context);
+            var result = await controller.Update(itemId, new HistoryItemUpdateRequest("  Updated note  "));
+
+            var dto = (result.Value as HistoryItemDto) ?? ((OkObjectResult?)result.Result)?.Value as HistoryItemDto;
+            await Assert.That(dto).IsNotNull();
+            await Assert.That(dto!.Notes).IsEqualTo("Updated note");
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var stored = await context.ExpenseCategoryItems.SingleAsync(x => x.ID == itemId);
+            await Assert.That(stored.Notes).IsEqualTo("Updated note");
+        });
+    }
+
+    [Test]
+    public async Task Update_WithUnknownId_ReturnsNotFound()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new HistoryController(context);
+
+        var result = await controller.Update(999, new HistoryItemUpdateRequest("Some note"));
+
+        await Assert.That(result.Result).IsTypeOf<NotFoundResult>();
     }
 }

--- a/SimplyBudgetWeb.Core.Tests/Controllers/TransactionsControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/TransactionsControllerTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Moq.AutoMock;
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class TransactionsControllerTests
+{
+    [Test]
+    public async Task AddTransaction_PersistsNotes()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        var categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries", CurrentBalance = 500_00 };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new TransactionsController(context);
+            var result = await controller.AddTransaction(new TransactionRequest(
+                Description: "Costco",
+                Date: new DateTime(2026, 1, 10),
+                Items: [new TransactionItemRequest(categoryId, 45_00)],
+                Notes: "  Membership renewal  "));
+
+            await Assert.That(result).IsTypeOf<StatusCodeResult>();
+            await Assert.That(((StatusCodeResult)result).StatusCode).IsEqualTo(201);
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var item = await context.ExpenseCategoryItems
+                .Include(x => x.Details)
+                .SingleAsync();
+            await Assert.That(item.Notes).IsEqualTo("Membership renewal");
+            await Assert.That(item.Details!.Single().Amount).IsEqualTo(-45_00);
+        });
+    }
+
+    [Test]
+    public async Task AddIncome_WithWhitespaceNotes_StoresNullNotes()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        var categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Refunds", CurrentBalance = 0 };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new TransactionsController(context);
+            await controller.AddIncome(new TransactionRequest(
+                Description: "Refund",
+                Date: new DateTime(2026, 1, 10),
+                Items: [new TransactionItemRequest(categoryId, 20_00)],
+                Notes: "   "));
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var item = await context.ExpenseCategoryItems.SingleAsync();
+            await Assert.That(item.Notes).IsNull();
+        });
+    }
+}

--- a/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/AddTransactionDialog.vue
@@ -36,6 +36,7 @@ const emptyLine = (): LineItem => ({ expenseCategoryId: null, amount: '' })
 const tab = ref<'transaction' | 'income' | 'transfer'>('transaction')
 const description = ref('')
 const date = ref(new Date().toISOString().split('T')[0])
+const notes = ref('')
 const lines = ref<LineItem[]>([emptyLine()])
 const incomeTotal = ref('')
 const incomeAllocations = ref<Record<number, string>>({})
@@ -57,6 +58,7 @@ function removeLine(index: number) {
 function resetForm() {
   description.value = ''
   date.value = new Date().toISOString().split('T')[0]
+  notes.value = ''
   lines.value = [emptyLine()]
   incomeTotal.value = ''
   incomeAllocations.value = {}
@@ -192,6 +194,8 @@ function applyCalculator() {
 async function submit() {
   submitting.value = true
   try {
+    const normalizedNotes = notes.value.trim().length > 0 ? notes.value.trim() : null
+
     if (tab.value === 'transaction') {
       if (!canSubmitLines.value) return
       const payload: TransactionRequest = {
@@ -203,6 +207,7 @@ async function submit() {
             expenseCategoryId: l.expenseCategoryId,
             amount: dollarsToCents(l.amount),
           })),
+        notes: normalizedNotes,
       }
       await apiClient.post('/api/transactions/transaction', payload)
       snackbar.enqueueSnackbar('Transaction added', { variant: 'success' })
@@ -217,6 +222,7 @@ async function submit() {
             amount: dollarsToCents(amount),
           }))
           .filter(item => item.amount > 0),
+        notes: normalizedNotes,
       }
       await apiClient.post('/api/transactions/income', payload)
       snackbar.enqueueSnackbar('Income added', { variant: 'success' })
@@ -255,6 +261,13 @@ async function submit() {
         <div class="d-flex flex-column ga-3">
           <v-text-field label="Description" v-model="description" hide-details />
           <v-text-field label="Date" type="date" v-model="date" hide-details />
+          <v-textarea
+            label="Notes"
+            v-model="notes"
+            rows="2"
+            auto-grow
+            density="compact"
+          />
 
           <template v-if="tab === 'transaction'">
             <span class="text-subtitle-2">Items</span>

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
-import type { HistoryItemDto, ExpenseCategoryDto, AccountDto } from '@/types'
+import type { HistoryItemDto, HistoryItemUpdateRequest, ExpenseCategoryDto, AccountDto } from '@/types'
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 import { AMAZON_TRANSACTIONS_URL, hasAmazonInDescription } from '@/utils/merchantLinks'
@@ -23,6 +23,9 @@ const categories = ref<ExpenseCategoryDto[]>([])
 const accounts = ref<AccountDto[]>([])
 const loading = ref(false)
 const accountLoading = ref(false)
+const editNotesItem = ref<HistoryItemDto | null>(null)
+const editNotesDraft = ref('')
+const savingNotes = ref(false)
 const deleteItem = ref<HistoryItemDto | null>(null)
 const dialogOpen = ref(false)
 
@@ -103,6 +106,39 @@ async function handleDelete() {
 
 function totalForItem(item: HistoryItemDto) {
   return item.details.reduce((sum, d) => sum + d.amount, 0)
+}
+
+function openNotesEditor(item: HistoryItemDto) {
+  editNotesItem.value = item
+  editNotesDraft.value = item.notes ?? ''
+}
+
+function closeNotesEditor() {
+  if (savingNotes.value) return
+  editNotesItem.value = null
+  editNotesDraft.value = ''
+}
+
+async function saveNotes() {
+  if (!editNotesItem.value) return
+  savingNotes.value = true
+  try {
+    const notesRaw = editNotesDraft.value ?? ''
+    const payload: HistoryItemUpdateRequest = {
+      notes: notesRaw.trim().length > 0 ? notesRaw.trim() : null,
+    }
+    const updated = await apiClient.put<HistoryItemDto>(`/api/history/${editNotesItem.value.id}`, payload)
+    const index = items.value.findIndex(x => x.id === updated.id)
+    if (index >= 0) {
+      items.value[index] = updated
+    }
+    snackbar.enqueueSnackbar('Transaction notes updated', { variant: 'success' })
+    closeNotesEditor()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to update notes', { variant: 'error' })
+  } finally {
+    savingNotes.value = false
+  }
 }
 
 watch([currentMonth, categoryId], fetchHistory)
@@ -214,6 +250,11 @@ function onDialogSuccess() {
               </template>
               <v-list density="compact">
                 <v-list-item
+                  prepend-icon="mdi-note-edit-outline"
+                  :title="item.notes ? 'Edit notes' : 'Add note'"
+                  @click="openNotesEditor(item)"
+                />
+                <v-list-item
                   prepend-icon="mdi-delete"
                   title="Delete transaction"
                   base-color="error"
@@ -236,6 +277,29 @@ function onDialogSuccess() {
     />
 
     <AddTransactionDialog v-model="dialogOpen" :categories="categories" @success="onDialogSuccess" />
+
+    <v-dialog :model-value="!!editNotesItem" max-width="560" @update:model-value="(val: boolean) => !val && closeNotesEditor()">
+      <v-card>
+        <v-card-title>{{ editNotesItem?.notes ? 'Edit Notes' : 'Add Notes' }}</v-card-title>
+        <v-card-text>
+          <div class="text-body-2 mb-2 text-medium-emphasis">
+            {{ editNotesItem?.description ?? '(No description)' }}
+          </div>
+          <v-textarea
+            v-model="editNotesDraft"
+            label="Notes"
+            rows="4"
+            auto-grow
+            autofocus
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn :disabled="savingNotes" @click="closeNotesEditor">Cancel</v-btn>
+          <v-btn color="primary" :loading="savingNotes" @click="saveNotes">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
 
     <v-dialog :model-value="!!deleteItem" max-width="480" @update:model-value="(val: boolean) => !val && (deleteItem = null)">
       <v-card>

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -72,6 +72,10 @@ export interface HistoryItemDto {
   details: HistoryDetailDto[]
 }
 
+export interface HistoryItemUpdateRequest {
+  notes: string | null
+}
+
 export interface HistoryDetailDto {
   id: number
   expenseCategoryId: number
@@ -166,6 +170,7 @@ export interface TransactionRequest {
   description: string
   date: string
   items: TransactionItemRequest[]
+  notes: string | null
 }
 
 export interface TransferRequest {

--- a/SimplyBudgetWeb/Controllers/HistoryController.cs
+++ b/SimplyBudgetWeb/Controllers/HistoryController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using SimplyBudgetShared.Data;
 using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
 using SimplyBudgetWeb.Utilities;
@@ -52,20 +53,22 @@ public class HistoryController(BudgetWebContext context) : ControllerBase
             .ThenBy(x => x.ID)
             .ToListAsync();
 
-        return items.Select(item => new HistoryItemDto(
-            Id: item.ID,
-            Date: item.Date,
-            Description: item.Description,
-            Notes: item.Notes,
-            IsTransfer: item.IsTransfer,
-            Details: (item.Details ?? []).Select(d => new HistoryDetailDto(
-                Id: d.ID,
-                ExpenseCategoryId: d.ExpenseCategoryId,
-                CategoryName: d.ExpenseCategory?.Name,
-                Amount: d.Amount,
-                IgnoreBudget: d.IgnoreBudget
-            )).ToArray()
-        )).ToArray();
+        return items.Select(ToDto).ToArray();
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ActionResult<HistoryItemDto>> Update(int id, [FromBody] HistoryItemUpdateRequest request)
+    {
+        var item = await context.ExpenseCategoryItems
+            .AsTracking()
+            .Include(x => x.Details!)
+                .ThenInclude(d => d.ExpenseCategory)
+            .FirstOrDefaultAsync(x => x.ID == id);
+        if (item is null) return NotFound();
+
+        item.Notes = NormalizeNotes(request.Notes);
+        await context.SaveChangesAsync();
+        return ToDto(item);
     }
 
     [HttpDelete("{id}")]
@@ -80,6 +83,24 @@ public class HistoryController(BudgetWebContext context) : ControllerBase
         await context.SaveChangesAsync();
         return NoContent();
     }
+
+    private static HistoryItemDto ToDto(ExpenseCategoryItem item) => new(
+        Id: item.ID,
+        Date: item.Date,
+        Description: item.Description,
+        Notes: item.Notes,
+        IsTransfer: item.IsTransfer,
+        Details: (item.Details ?? []).Select(d => new HistoryDetailDto(
+            Id: d.ID,
+            ExpenseCategoryId: d.ExpenseCategoryId,
+            CategoryName: d.ExpenseCategory?.Name,
+            Amount: d.Amount,
+            IgnoreBudget: d.IgnoreBudget
+        )).ToArray()
+    );
+
+    private static string? NormalizeNotes(string? notes)
+        => string.IsNullOrWhiteSpace(notes) ? null : notes.Trim();
 }
 
 public record HistoryItemDto(
@@ -98,3 +119,5 @@ public record HistoryDetailDto(
     int Amount,
     bool IgnoreBudget
 );
+
+public record HistoryItemUpdateRequest(string? Notes);

--- a/SimplyBudgetWeb/Controllers/TransactionsController.cs
+++ b/SimplyBudgetWeb/Controllers/TransactionsController.cs
@@ -11,20 +11,34 @@ public class TransactionsController(BudgetWebContext context) : ControllerBase
     [HttpPost("transaction")]
     public async Task<IActionResult> AddTransaction([FromBody] TransactionRequest request)
     {
-        await context.AddTransaction(
+        var item = await context.AddTransaction(
             request.Description,
             request.Date,
             request.Items.Select(i => (i.Amount, i.ExpenseCategoryId)).ToArray());
+
+        var notes = NormalizeNotes(request.Notes);
+        if (notes is not null)
+        {
+            item.Notes = notes;
+            await context.SaveChangesAsync();
+        }
         return StatusCode(201);
     }
 
     [HttpPost("income")]
     public async Task<IActionResult> AddIncome([FromBody] TransactionRequest request)
     {
-        await context.AddIncome(
+        var item = await context.AddIncome(
             request.Description,
             request.Date,
             request.Items.Select(i => (i.Amount, i.ExpenseCategoryId)).ToArray());
+
+        var notes = NormalizeNotes(request.Notes);
+        if (notes is not null)
+        {
+            item.Notes = notes;
+            await context.SaveChangesAsync();
+        }
         return StatusCode(201);
     }
 
@@ -40,11 +54,14 @@ public class TransactionsController(BudgetWebContext context) : ControllerBase
         await context.AddTransfer(request.Description, request.Date, request.Amount, fromCategory, toCategory);
         return StatusCode(201);
     }
+
+    private static string? NormalizeNotes(string? notes)
+        => string.IsNullOrWhiteSpace(notes) ? null : notes.Trim();
 }
 
 public record TransactionItemRequest(int ExpenseCategoryId, int Amount);
 
-public record TransactionRequest(string Description, DateTime Date, TransactionItemRequest[] Items);
+public record TransactionRequest(string Description, DateTime Date, TransactionItemRequest[] Items, string? Notes = null);
 
 public record TransferRequest(
     string Description,


### PR DESCRIPTION
## Summary
- add note support when creating transactions/income from the web UI
- add a history endpoint and UI flow to add/edit notes on existing expense items
- normalize whitespace-only notes to null on save
- add backend tests for transaction note persistence and history note updates

## Testing
- dotnet test --project SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj
- pnpm run build (SimplyBudgetWeb.Web)