### PR TITLE
Allow applying remaining transaction amount

### DIFF
--- a/SimplyBudgetDesktop.Tests/ViewModels/AddItemViewModelTests.cs
+++ b/SimplyBudgetDesktop.Tests/ViewModels/AddItemViewModelTests.cs
@@ -209,6 +209,28 @@ public class AddItemViewModelTests
     }
 
     [TestMethod]
+    public void ApplyRemainingCommand_Transaction_AppliesToLastEmptyLineItem()
+    {
+        var mocker = new AutoMocker().WithDefaults();
+        using var _ = mocker.WithDbScope();
+
+        var vm = mocker.CreateInstance<AddItemViewModel>();
+
+        vm.SelectedType = AddType.Transaction;
+        vm.AddItemCommand.Execute(null);
+        vm.AddItemCommand.Execute(null);
+        vm.TotalAmount = 100_00;
+        vm.LineItems[0].Amount = 25_00;
+        vm.LineItems[2].Amount = 10_00;
+
+        vm.ApplyRemainingCommand.Execute(null);
+
+        Assert.AreEqual(65_00, vm.LineItems[1].Amount);
+        Assert.AreEqual(10_00, vm.LineItems[2].Amount);
+        Assert.AreEqual(0, vm.RemainingAmount);
+    }
+
+    [TestMethod]
     public async Task SubmitCommand_TransactionIgnoreBudget_CreatesTransaction()
     {
         var mocker = new AutoMocker().WithDefaults();

--- a/SimplyBudgetDesktop/ViewModels/AddItemViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/AddItemViewModel.cs
@@ -146,6 +146,21 @@ public partial class AddItemViewModel : ValidationViewModel,
     }
 
     [RelayCommand]
+    private void OnApplyRemaining()
+    {
+        if (SelectedType != AddType.Transaction || RemainingAmount <= 0)
+        {
+            return;
+        }
+
+        var lineItem = LineItems.LastOrDefault(x => x.Amount == 0);
+        if (lineItem is not null)
+        {
+            lineItem.Amount = RemainingAmount;
+        }
+    }
+
+    [RelayCommand]
     private void OnAutoAllocate()
     {
         int total = RemainingAmount;

--- a/SimplyBudgetDesktop/Views/AddItemView.xaml
+++ b/SimplyBudgetDesktop/Views/AddItemView.xaml
@@ -281,7 +281,8 @@
             </Grid>
 
             <TextBlock HorizontalAlignment="Right"
-                       Grid.Row="2">
+                       Grid.Row="2"
+                       Text="{Binding RemainingAmount, StringFormat='Remaining: {0}', Converter={StaticResource CurrentValueConverter}}">
                 <TextBlock.Style>
                     <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
                         <Setter Property="Visibility" Value="Collapsed" />
@@ -292,11 +293,28 @@
                                     <Condition Binding="{Binding LineItems.Count, Converter={StaticResource AtLeastValueConverter}, ConverterParameter='2'}" Value="True" />
                                 </MultiDataTrigger.Conditions>
                                 <Setter Property="Visibility" Value="Visible" />
-                                <Setter Property="Text" Value="{Binding RemainingAmount, StringFormat='Remaining: {0}', Converter={StaticResource CurrentValueConverter}}" />
                             </MultiDataTrigger>
+                            <DataTrigger Binding="{Binding RemainingAmount, Converter={StaticResource AtLeastValueConverter}, ConverterParameter='1'}" Value="True">
+                                <Setter Property="Cursor" Value="Hand" />
+                                <Setter Property="TextDecorations" Value="Underline" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+                <TextBlock.InputBindings>
+                    <MouseBinding MouseAction="LeftClick" Command="{Binding ApplyRemainingCommand}" />
+                </TextBlock.InputBindings>
+            </TextBlock>
+
+            <TextBlock HorizontalAlignment="Right"
+                       Grid.Row="2"
+                       Text="{Binding RemainingAmount, StringFormat='Remaining: {0}', Converter={StaticResource CurrentValueConverter}}">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
                             <DataTrigger Binding="{Binding SelectedType}" Value="Income">
                                 <Setter Property="Visibility" Value="Visible" />
-                                <Setter Property="Text" Value="{Binding RemainingAmount, StringFormat='Remaining: {0}', Converter={StaticResource CurrentValueConverter}}" />
                             </DataTrigger>
                             <MultiDataTrigger>
                                 <MultiDataTrigger.Conditions>


### PR DESCRIPTION
## Summary
- make the remaining transaction amount clickable when splitting a transaction
- apply the positive remaining amount to the last line item without an amount
- keep the income remaining display unchanged and add focused view-model coverage

## Testing
- `dotnet test SimplyBudgetDesktop.Tests/SimplyBudgetDesktop.Tests.csproj --filter "FullyQualifiedName~AddItemViewModelTests" --no-restore`

Closes #204