### PR TITLE
Add data driven external link rules

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExternalLinksControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExternalLinksControllerTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class ExternalLinksControllerTests
+{
+    [Test]
+    public async Task GetAll_ReturnsRulesOrderedByName()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.ExternalLinkRules.AddRange(
+                new ExternalLinkRule { Name = "Target", RuleRegex = "target", Url = "https://www.target.com/orders" },
+                new ExternalLinkRule { Name = "Amazon", RuleRegex = @"\bamazon\b", Url = "https://www.amazon.com/cpe/yourpayments/transactions" });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExternalLinksController(context);
+
+        var result = await controller.GetAll();
+
+        await Assert.That(result.Length).IsEqualTo(2);
+        await Assert.That(result[0].Name).IsEqualTo("Amazon");
+        await Assert.That(result[0].Url).IsEqualTo("https://www.amazon.com/cpe/yourpayments/transactions");
+        await Assert.That(result[1].Name).IsEqualTo("Target");
+    }
+
+    [Test]
+    public async Task Create_AddsRule()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new ExternalLinksController(context);
+            var result = await controller.Create(new ExternalLinkRuleRequest("Costco", "costco", "https://www.costco.com/OrderStatusView"));
+            await Assert.That(result.Result).IsTypeOf<CreatedAtActionResult>();
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var rule = await context.ExternalLinkRules.SingleAsync();
+            await Assert.That(rule.Name).IsEqualTo("Costco");
+            await Assert.That(rule.RuleRegex).IsEqualTo("costco");
+            await Assert.That(rule.Url).IsEqualTo("https://www.costco.com/OrderStatusView");
+        });
+    }
+
+    [Test]
+    public async Task Create_WithInvalidRegex_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExternalLinksController(context);
+
+        var result = await controller.Create(new ExternalLinkRuleRequest("Bad", "[unclosed", "https://example.com"));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+        await Assert.That(await context.ExternalLinkRules.CountAsync()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Create_WithNonHttpUrl_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExternalLinksController(context);
+
+        var result = await controller.Create(new ExternalLinkRuleRequest("Bad", "amazon", "javascript:alert(1)"));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+        await Assert.That(await context.ExternalLinkRules.CountAsync()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Update_ModifiesRule()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int ruleId = await mocker.InDbScopeAsync(async context =>
+        {
+            var rule = new ExternalLinkRule { Name = "Amazon", RuleRegex = "amazon", Url = "https://www.amazon.com" };
+            context.ExternalLinkRules.Add(rule);
+            await context.SaveChangesAsync();
+            return rule.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new ExternalLinksController(context);
+            var result = await controller.Update(ruleId, new ExternalLinkRuleRequest("Amazon Orders", @"\bamazon\b", "https://www.amazon.com/gp/css/order-history"));
+            await Assert.That(result.Value?.Name).IsEqualTo("Amazon Orders");
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var rule = await context.ExternalLinkRules.SingleAsync();
+            await Assert.That(rule.RuleRegex).IsEqualTo(@"\bamazon\b");
+            await Assert.That(rule.Url).IsEqualTo("https://www.amazon.com/gp/css/order-history");
+        });
+    }
+
+    [Test]
+    public async Task Update_WithUnknownId_ReturnsNotFound()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExternalLinksController(context);
+
+        var result = await controller.Update(42, new ExternalLinkRuleRequest("Amazon", "amazon", "https://www.amazon.com"));
+
+        await Assert.That(result.Result).IsTypeOf<NotFoundResult>();
+    }
+
+    [Test]
+    public async Task Delete_RemovesRule()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int ruleId = await mocker.InDbScopeAsync(async context =>
+        {
+            var rule = new ExternalLinkRule { Name = "Amazon", RuleRegex = "amazon", Url = "https://www.amazon.com" };
+            context.ExternalLinkRules.Add(rule);
+            await context.SaveChangesAsync();
+            return rule.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new ExternalLinksController(context);
+            var result = await controller.Delete(ruleId);
+            await Assert.That(result).IsTypeOf<NoContentResult>();
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            await Assert.That(await context.ExternalLinkRules.CountAsync()).IsEqualTo(0);
+        });
+    }
+}

--- a/SimplyBudgetWeb.Data/BudgetWebContext.cs
+++ b/SimplyBudgetWeb.Data/BudgetWebContext.cs
@@ -26,6 +26,11 @@ public class BudgetWebContext(DbContextOptions<BudgetWebContext> options)
     public DbSet<PendingExpense> PendingExpenses => Set<PendingExpense>();
     public DbSet<PendingExpenseAssignee> PendingExpenseAssignees => Set<PendingExpenseAssignee>();
 
+    /// <summary>
+    /// Rules that drive the external links shown next to matching transactions and pending expenses.
+    /// </summary>
+    public DbSet<ExternalLinkRule> ExternalLinkRules => Set<ExternalLinkRule>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.HasDefaultSchema(Schema);

--- a/SimplyBudgetWeb.Data/ExternalLinkRule.cs
+++ b/SimplyBudgetWeb.Data/ExternalLinkRule.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using SimplyBudgetShared.Data;
+
+namespace SimplyBudgetWeb.Data;
+
+/// <summary>
+/// A data driven rule that displays an external link next to any transaction (or pending expense)
+/// whose description matches <see cref="RuleRegex"/>. This replaces the previously hard coded
+/// Amazon link and works much like <see cref="ExpenseCategoryRule"/>, except that a match results
+/// in a link to <see cref="Url"/> rather than a category suggestion.
+/// </summary>
+[Table("ExternalLinkRule")]
+public class ExternalLinkRule : BaseItem
+{
+    /// <summary>
+    /// Display name for the rule, also used as the accessible label/tooltip for the link.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Case insensitive regular expression matched against the item description.
+    /// </summary>
+    public string? RuleRegex { get; set; }
+
+    /// <summary>
+    /// The absolute URL opened when the link is clicked.
+    /// </summary>
+    public string? Url { get; set; }
+}

--- a/SimplyBudgetWeb.Data/Migrations/20260901045327_AddExternalLinkRules.Designer.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260901045327_AddExternalLinkRules.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetWeb.Data;
 
@@ -11,9 +12,11 @@ using SimplyBudgetWeb.Data;
 namespace SimplyBudgetWeb.Data.Migrations
 {
     [DbContext(typeof(BudgetWebContext))]
-    partial class BudgetWebContextModelSnapshot : ModelSnapshot
+    [Migration("20260901045327_AddExternalLinkRules")]
+    partial class AddExternalLinkRules
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SimplyBudgetWeb.Data/Migrations/20260901045327_AddExternalLinkRules.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260901045327_AddExternalLinkRules.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetWeb.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalLinkRules : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExternalLinkRule",
+                schema: "SimplyBudget",
+                columns: table => new
+                {
+                    ID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    RuleRegex = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Url = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExternalLinkRule", x => x.ID);
+                });
+
+            // Preserve the previously hard coded Amazon link as a rule.
+            migrationBuilder.InsertData(
+                schema: "SimplyBudget",
+                table: "ExternalLinkRule",
+                columns: ["Name", "RuleRegex", "Url"],
+                values: ["Amazon", @"\bamazon\b", "https://www.amazon.com/cpe/yourpayments/transactions"]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExternalLinkRule",
+                schema: "SimplyBudget");
+        }
+    }
+}

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -5,7 +5,7 @@ import { useSnackbarStore } from '@/stores/snackbar'
 import type { HistoryItemDto, HistoryItemUpdateRequest, ExpenseCategoryDto, AccountDto } from '@/types'
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
-import { AMAZON_TRANSACTIONS_URL, hasAmazonInDescription } from '@/utils/merchantLinks'
+import { useExternalLinkRules } from '@/utils/externalLinks'
 import { includesSearchText, tryParseSearchAmountInCents } from '@/utils/search'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
@@ -14,6 +14,7 @@ import CategorySelector from '@/components/CategorySelector.vue'
 
 const snackbar = useSnackbarStore()
 const route = useRoute()
+const { loadExternalLinkRules, externalLinksFor } = useExternalLinkRules()
 
 const { currentMonth } = useMonthQueryParam({ storageKey: 'history' })
 const search = ref('')
@@ -148,6 +149,7 @@ onMounted(() => {
   void fetchCategories()
   void fetchHistory()
   void fetchAccountBalances()
+  void loadExternalLinkRules()
 
   const rawCategoryId = route.query.categoryId
   const categoryIdQuery = Array.isArray(rawCategoryId) ? rawCategoryId[0] : rawCategoryId
@@ -215,15 +217,17 @@ function onDialogSuccess() {
                 <span class="expense-description">{{ item.description }}</span>
                 <v-chip v-if="item.isTransfer" size="small">Transfer</v-chip>
                 <v-btn
-                  v-if="hasAmazonInDescription(item.description)"
+                  v-for="link in externalLinksFor(item.description)"
+                  :key="link.url"
                   icon="mdi-open-in-new"
                   variant="text"
                   size="x-small"
                   color="primary"
-                  :href="AMAZON_TRANSACTIONS_URL"
+                  :href="link.url"
                   target="_blank"
                   rel="noopener noreferrer"
-                  aria-label="Open Amazon transactions page"
+                  :aria-label="`Open ${link.name} link`"
+                  :title="link.name"
                 />
               </span>
               <span class="font-weight-bold expense-amount">{{ formatCents(totalForItem(item)) }}</span>

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -5,13 +5,14 @@ import { useSnackbarStore } from '@/stores/snackbar'
 import type { PendingExpenseDto, AssigneeDto, ExpenseCategoryDto } from '@/types'
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
-import { AMAZON_TRANSACTIONS_URL, hasAmazonInDescription } from '@/utils/merchantLinks'
+import { useExternalLinkRules } from '@/utils/externalLinks'
 import { includesSearchText, tryParseSearchAmountInCents } from '@/utils/search'
 import ConvertPendingExpenseDialog from '@/components/ConvertPendingExpenseDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
 import CategorySelector from '@/components/CategorySelector.vue'
 
 const snackbar = useSnackbarStore()
+const { loadExternalLinkRules, externalLinksFor } = useExternalLinkRules()
 
 const { currentMonth } = useMonthQueryParam({ storageKey: 'pending-expenses' })
 const search = ref('')
@@ -270,6 +271,7 @@ onMounted(() => {
   void fetchAssignees()
   void fetchCategories()
   void fetchPendingExpenses()
+  void loadExternalLinkRules()
 })
 </script>
 
@@ -337,15 +339,17 @@ onMounted(() => {
                   <span class="pending-date">{{ new Date(item.date).toLocaleDateString() }}</span>
                   <span class="pending-description">{{ item.description }}</span>
                   <v-btn
-                    v-if="hasAmazonInDescription(item.description)"
+                    v-for="link in externalLinksFor(item.description)"
+                    :key="link.url"
                     icon="mdi-open-in-new"
                     variant="text"
                     size="x-small"
                     color="primary"
-                    :href="AMAZON_TRANSACTIONS_URL"
+                    :href="link.url"
                     target="_blank"
                     rel="noopener noreferrer"
-                    aria-label="Open Amazon transactions page"
+                    :aria-label="`Open ${link.name} link`"
+                    :title="link.name"
                     @click.stop
                   />
                   <v-chip v-if="item.suggestedCategoryName" size="small" variant="outlined" class="ml-1">

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -5,12 +5,14 @@ import { useSnackbarStore } from '@/stores/snackbar'
 import { useAuthStore } from '@/stores/auth'
 import type {
   RuleDto,
+  ExternalLinkRuleDto,
   ExpenseCategoryDto,
   AccountDto,
   CalculatorTaxOptionsDto,
   CurrentUserDto,
 } from '@/types'
 import { formatCents } from '@/utils/currency'
+import { resetExternalLinkRulesCache } from '@/utils/externalLinks'
 import CategorySelector from '@/components/CategorySelector.vue'
 
 const snackbar = useSnackbarStore()
@@ -20,7 +22,8 @@ const PANEL_PROFILE = 0
 const PANEL_TAX_OPTIONS = 1
 const PANEL_ACCOUNTS = 2
 const PANEL_RULES = 3
-const PANEL_CATEGORIES = 4
+const PANEL_EXTERNAL_LINKS = 4
+const PANEL_CATEGORIES = 5
 
 const openPanel = ref<number | undefined>(undefined)
 
@@ -56,6 +59,14 @@ const addRuleOpen = ref(false)
 const deleteRule = ref<RuleDto | null>(null)
 const editRule = ref<RuleDto | null>(null)
 const ruleForm = ref({ name: '', ruleRegex: '', expenseCategoryId: null as number | null })
+
+const externalLinks = ref<ExternalLinkRuleDto[]>([])
+const externalLinksLoading = ref(false)
+const externalLinksLoaded = ref(false)
+const addExternalLinkOpen = ref(false)
+const editExternalLink = ref<ExternalLinkRuleDto | null>(null)
+const deleteExternalLink = ref<ExternalLinkRuleDto | null>(null)
+const externalLinkForm = ref({ name: '', ruleRegex: '', url: '' })
 
 interface RuleGroup {
   key: string
@@ -382,6 +393,75 @@ async function handleDeleteRule() {
   }
 }
 
+async function fetchExternalLinks() {
+  externalLinksLoading.value = true
+  try {
+    externalLinks.value = await apiClient.get<ExternalLinkRuleDto[]>('/api/external-links') ?? []
+  } catch {
+    snackbar.enqueueSnackbar('Failed to load external links', { variant: 'error' })
+  } finally {
+    externalLinksLoading.value = false
+  }
+}
+
+function resetExternalLinkForm() {
+  externalLinkForm.value = { name: '', ruleRegex: '', url: '' }
+}
+
+function openAddExternalLink() {
+  resetExternalLinkForm()
+  addExternalLinkOpen.value = true
+}
+
+function openEditExternalLink(link: ExternalLinkRuleDto) {
+  editExternalLink.value = link
+  externalLinkForm.value = {
+    name: link.name ?? '',
+    ruleRegex: link.ruleRegex ?? '',
+    url: link.url ?? '',
+  }
+}
+
+async function handleAddExternalLink() {
+  try {
+    await apiClient.post('/api/external-links', { ...externalLinkForm.value })
+    snackbar.enqueueSnackbar('External link added', { variant: 'success' })
+    addExternalLinkOpen.value = false
+    resetExternalLinkForm()
+    resetExternalLinkRulesCache()
+    void fetchExternalLinks()
+  } catch (err) {
+    snackbar.enqueueSnackbar(err instanceof Error ? err.message : 'Failed to add external link', { variant: 'error' })
+  }
+}
+
+async function handleEditExternalLink() {
+  if (!editExternalLink.value) return
+  try {
+    await apiClient.put(`/api/external-links/${editExternalLink.value.id}`, { ...externalLinkForm.value })
+    snackbar.enqueueSnackbar('External link updated', { variant: 'success' })
+    editExternalLink.value = null
+    resetExternalLinkForm()
+    resetExternalLinkRulesCache()
+    void fetchExternalLinks()
+  } catch (err) {
+    snackbar.enqueueSnackbar(err instanceof Error ? err.message : 'Failed to update external link', { variant: 'error' })
+  }
+}
+
+async function handleDeleteExternalLink() {
+  if (!deleteExternalLink.value) return
+  try {
+    await apiClient.delete(`/api/external-links/${deleteExternalLink.value.id}`)
+    snackbar.enqueueSnackbar('External link deleted', { variant: 'success' })
+    deleteExternalLink.value = null
+    resetExternalLinkRulesCache()
+    void fetchExternalLinks()
+  } catch {
+    snackbar.enqueueSnackbar('Failed to delete external link', { variant: 'error' })
+  }
+}
+
 async function fetchManageCategories() {
   categoriesLoading.value = true
   try {
@@ -464,6 +544,12 @@ watch(addRuleOpen, (isOpen) => {
   }
 })
 
+watch(addExternalLinkOpen, (isOpen) => {
+  if (!isOpen) {
+    resetExternalLinkForm()
+  }
+})
+
 watch(openPanel, (panel) => {
   if (panel === PANEL_PROFILE && !profileLoaded.value) {
     void fetchCurrentUserProfile()
@@ -483,6 +569,12 @@ watch(openPanel, (panel) => {
   if (panel === PANEL_RULES && !rulesLoaded.value) {
     rulesLoaded.value = true
     void Promise.all([fetchRules(), fetchRuleCategories()])
+    return
+  }
+
+  if (panel === PANEL_EXTERNAL_LINKS && !externalLinksLoaded.value) {
+    externalLinksLoaded.value = true
+    void fetchExternalLinks()
     return
   }
 
@@ -692,6 +784,41 @@ watch(openPanel, (panel) => {
       <v-expansion-panel>
         <v-expansion-panel-title>
           <div>
+            <div class="text-subtitle-1 font-weight-medium">External Links</div>
+            <div class="text-body-2 text-medium-emphasis">Show a link on transactions whose description matches a pattern.</div>
+          </div>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <div v-if="externalLinksLoading" class="d-flex justify-center pa-8">
+            <v-progress-circular indeterminate aria-label="Loading external links" />
+          </div>
+          <div v-else>
+            <div class="d-flex justify-end mb-4">
+              <v-btn color="primary" @click="openAddExternalLink">Add External Link</v-btn>
+            </div>
+            <v-card v-if="externalLinks.length > 0">
+              <v-list>
+                <v-list-item v-for="link in externalLinks" :key="link.id">
+                  <v-list-item-title>{{ link.name }}</v-list-item-title>
+                  <v-list-item-subtitle>Pattern: {{ link.ruleRegex ?? '—' }}</v-list-item-subtitle>
+                  <v-list-item-subtitle>Link: {{ link.url ?? '—' }}</v-list-item-subtitle>
+                  <template #append>
+                    <div class="d-flex" style="gap: 4px;">
+                      <v-btn icon="mdi-pencil" variant="text" aria-label="Edit external link" @click="openEditExternalLink(link)" />
+                      <v-btn icon="mdi-delete" variant="text" color="error" aria-label="Delete external link" @click="deleteExternalLink = link" />
+                    </div>
+                  </template>
+                </v-list-item>
+              </v-list>
+            </v-card>
+            <v-alert v-else type="info" variant="tonal">No external links defined yet.</v-alert>
+          </div>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <div>
             <div class="text-subtitle-1 font-weight-medium">Expense Categories</div>
             <div class="text-body-2 text-medium-emphasis">Rename, hide, restore, or delete categories.</div>
           </div>
@@ -856,6 +983,50 @@ watch(openPanel, (panel) => {
           <v-spacer />
           <v-btn @click="deleteRule = null">Cancel</v-btn>
           <v-btn color="error" @click="handleDeleteRule">Delete</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="addExternalLinkOpen" max-width="500">
+      <v-card>
+        <v-card-title>Add External Link</v-card-title>
+        <v-card-text class="d-flex flex-column" style="gap: 16px;">
+          <v-text-field label="Name" v-model="externalLinkForm.name" />
+          <v-text-field label="Regex Pattern" v-model="externalLinkForm.ruleRegex" hint="Matched against the description, case insensitive" persistent-hint />
+          <v-text-field label="URL" v-model="externalLinkForm.url" />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="addExternalLinkOpen = false">Cancel</v-btn>
+          <v-btn color="primary" @click="handleAddExternalLink">Add</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog :model-value="!!editExternalLink" max-width="500" @update:model-value="(val: boolean) => !val && (editExternalLink = null)">
+      <v-card>
+        <v-card-title>Edit External Link</v-card-title>
+        <v-card-text class="d-flex flex-column" style="gap: 16px;">
+          <v-text-field label="Name" v-model="externalLinkForm.name" />
+          <v-text-field label="Regex Pattern" v-model="externalLinkForm.ruleRegex" hint="Matched against the description, case insensitive" persistent-hint />
+          <v-text-field label="URL" v-model="externalLinkForm.url" />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="editExternalLink = null">Cancel</v-btn>
+          <v-btn color="primary" @click="handleEditExternalLink">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog :model-value="!!deleteExternalLink" max-width="480" @update:model-value="(val: boolean) => !val && (deleteExternalLink = null)">
+      <v-card>
+        <v-card-title>Confirm Delete</v-card-title>
+        <v-card-text>Delete external link "{{ deleteExternalLink?.name }}"?</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="deleteExternalLink = null">Cancel</v-btn>
+          <v-btn color="error" @click="handleDeleteExternalLink">Delete</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -93,6 +93,13 @@ export interface RuleDto {
   categoryName: string | null
 }
 
+export interface ExternalLinkRuleDto {
+  id: number
+  name: string | null
+  ruleRegex: string | null
+  url: string | null
+}
+
 export interface ImportItemDto {
   date: string
   description: string | null

--- a/SimplyBudgetWeb.Web/src/utils/externalLinks.ts
+++ b/SimplyBudgetWeb.Web/src/utils/externalLinks.ts
@@ -1,0 +1,76 @@
+import { ref } from 'vue'
+import { apiClient } from '@/services/apiClient'
+import type { ExternalLinkRuleDto } from '@/types'
+
+export interface ExternalLinkMatch {
+  name: string
+  url: string
+}
+
+const compiledPatterns = new WeakMap<ExternalLinkRuleDto, RegExp | null>()
+
+function getPattern(rule: ExternalLinkRuleDto): RegExp | null {
+  if (compiledPatterns.has(rule)) return compiledPatterns.get(rule) ?? null
+
+  let pattern: RegExp | null = null
+  if (rule.ruleRegex) {
+    try {
+      pattern = new RegExp(rule.ruleRegex, 'i')
+    } catch {
+      // Ignore invalid patterns so a single bad rule cannot break the page.
+      pattern = null
+    }
+  }
+  compiledPatterns.set(rule, pattern)
+  return pattern
+}
+
+export function getExternalLinks(
+  rules: ExternalLinkRuleDto[],
+  description: string | null | undefined,
+): ExternalLinkMatch[] {
+  if (!description) return []
+
+  const matches: ExternalLinkMatch[] = []
+  for (const rule of rules) {
+    if (!rule.url) continue
+    const pattern = getPattern(rule)
+    if (pattern?.test(description)) {
+      matches.push({ name: rule.name ?? rule.url, url: rule.url })
+    }
+  }
+  return matches
+}
+
+const externalLinkRules = ref<ExternalLinkRuleDto[]>([])
+let loadPromise: Promise<void> | null = null
+
+/**
+ * Shared, lazily loaded set of external link rules. The rules change rarely, so they are
+ * fetched once per session and reused by every page that renders external links.
+ */
+export function useExternalLinkRules() {
+  function loadExternalLinkRules(): Promise<void> {
+    loadPromise ??= apiClient
+      .get<ExternalLinkRuleDto[]>('/api/external-links')
+      .then((result) => {
+        externalLinkRules.value = result ?? []
+      })
+      .catch(() => {
+        // External links are non-essential; fail silently rather than blocking the page.
+        externalLinkRules.value = []
+      })
+    return loadPromise
+  }
+
+  function externalLinksFor(description: string | null | undefined): ExternalLinkMatch[] {
+    return getExternalLinks(externalLinkRules.value, description)
+  }
+
+  return { externalLinkRules, loadExternalLinkRules, externalLinksFor }
+}
+
+export function resetExternalLinkRulesCache() {
+  loadPromise = null
+  externalLinkRules.value = []
+}

--- a/SimplyBudgetWeb.Web/src/utils/merchantLinks.ts
+++ b/SimplyBudgetWeb.Web/src/utils/merchantLinks.ts
@@ -1,8 +1,0 @@
-const amazonWordRegex = /\bamazon\b/i
-
-export const AMAZON_TRANSACTIONS_URL = 'https://www.amazon.com/cpe/yourpayments/transactions'
-
-export function hasAmazonInDescription(description: string | null | undefined): boolean {
-  if (!description) return false
-  return amazonWordRegex.test(description)
-}

--- a/SimplyBudgetWeb/Controllers/ExternalLinksController.cs
+++ b/SimplyBudgetWeb/Controllers/ExternalLinksController.cs
@@ -1,0 +1,106 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetWeb.Data;
+using System.Text.RegularExpressions;
+
+namespace SimplyBudgetWeb.Controllers;
+
+[ApiController]
+[Route("api/external-links")]
+public class ExternalLinksController(BudgetWebContext context) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ExternalLinkRuleDto[]> GetAll()
+    {
+        var rules = await context.ExternalLinkRules
+            .OrderBy(r => r.Name)
+            .ToListAsync();
+        return rules.Select(ToDto).ToArray();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ExternalLinkRuleDto>> Create([FromBody] ExternalLinkRuleRequest request)
+    {
+        if (Validate(request) is { } error) return error;
+
+        var rule = new ExternalLinkRule
+        {
+            Name = request.Name,
+            RuleRegex = request.RuleRegex,
+            Url = request.Url,
+        };
+        context.ExternalLinkRules.Add(rule);
+        await context.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetAll), new { }, ToDto(rule));
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ActionResult<ExternalLinkRuleDto>> Update(int id, [FromBody] ExternalLinkRuleRequest request)
+    {
+        if (Validate(request) is { } error) return error;
+
+        var rule = await context.ExternalLinkRules.FirstOrDefaultAsync(r => r.ID == id);
+        if (rule is null) return NotFound();
+
+        rule.Name = request.Name;
+        rule.RuleRegex = request.RuleRegex;
+        rule.Url = request.Url;
+
+        context.ExternalLinkRules.Update(rule);
+        await context.SaveChangesAsync();
+        return ToDto(rule);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var rule = await context.ExternalLinkRules.FindAsync(id);
+        if (rule is null) return NotFound();
+
+        context.ExternalLinkRules.Remove(rule);
+        await context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    private BadRequestObjectResult? Validate(ExternalLinkRuleRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.RuleRegex))
+        {
+            return BadRequest("A regular expression is required");
+        }
+
+        try
+        {
+            _ = Regex.Match("", request.RuleRegex, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
+        }
+        catch (ArgumentException)
+        {
+            return BadRequest("The regular expression is not valid");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Url) ||
+            !Uri.TryCreate(request.Url, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return BadRequest("An absolute http(s) URL is required");
+        }
+
+        return null;
+    }
+
+    private static ExternalLinkRuleDto ToDto(ExternalLinkRule rule) => new(
+        Id: rule.ID,
+        Name: rule.Name,
+        RuleRegex: rule.RuleRegex,
+        Url: rule.Url
+    );
+}
+
+public record ExternalLinkRuleDto(
+    int Id,
+    string? Name,
+    string? RuleRegex,
+    string? Url
+);
+
+public record ExternalLinkRuleRequest(string? Name, string? RuleRegex, string? Url);


### PR DESCRIPTION
Fixes #202

Replaces the hard coded Amazon external link with data driven external link rules, modeled on the existing import (categorization) rules.

## Changes
- New web-only `ExternalLinkRule` entity (Name, RuleRegex, Url) + EF migration. The migration seeds the previous Amazon link so existing behavior is preserved.
- New `api/external-links` CRUD controller with validation (regex must compile, URL must be an absolute http/https URL).
- Settings page gains an **External Links** panel to add/edit/delete rules.
- History and Pending Expenses rows now render a link for every rule whose regex matches the description (case insensitive), replacing `merchantLinks.ts`.

## Testing
- `dotnet test SimplyBudgetWeb.Core.Tests` (102 passed)
- `vue-tsc -b --force` and `npm run lint` in SimplyBudgetWeb.Web