### PR TITLE
Allow rules to add notes

### DIFF
--- a/SimplyBudgetDesktop/ViewModels/ExpenseCategoryRuleViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/ExpenseCategoryRuleViewModel.cs
@@ -14,6 +14,9 @@ public partial class ExpenseCategoryRuleViewModel : ObservableObject
     private string? _ruleRegex;
 
     [ObservableProperty]
+    private string? _notes;
+
+    [ObservableProperty]
     private int? _expenseCategoryId;
 
     public ExpenseCategoryRuleViewModel()
@@ -28,6 +31,7 @@ public partial class ExpenseCategoryRuleViewModel : ObservableObject
         ExistingRuleId = rule.ID;
         Name = rule.Name;
         RuleRegex = rule.RuleRegex;
+        Notes = rule.Notes;
         ExpenseCategoryId = rule.ExpenseCategoryID;
     }
 }

--- a/SimplyBudgetDesktop/ViewModels/SettingsViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/SettingsViewModel.cs
@@ -70,6 +70,7 @@ public partial class SettingsViewModel : CollectionViewModelBase<ExpenseCategory
                 {
                     existingRule.Name = ruleViewModel.Name;
                     existingRule.RuleRegex = ruleViewModel.RuleRegex;
+                    existingRule.Notes = ruleViewModel.Notes;
                     existingRule.ExpenseCategoryID = ruleViewModel.ExpenseCategoryId;
                 }
                 //TODO Else?
@@ -80,6 +81,7 @@ public partial class SettingsViewModel : CollectionViewModelBase<ExpenseCategory
                 {
                     Name = ruleViewModel.Name,
                     RuleRegex = ruleViewModel.RuleRegex,
+                    Notes = ruleViewModel.Notes,
                     ExpenseCategoryID = ruleViewModel.ExpenseCategoryId
                 };
                 context.ExpenseCategoryRules.Add(rule);

--- a/SimplyBudgetDesktop/Views/SettingsView.xaml
+++ b/SimplyBudgetDesktop/Views/SettingsView.xaml
@@ -78,6 +78,7 @@
       <DataGrid.Columns>
         <DataGridTextColumn Header="Name" Binding="{Binding Name}" />
         <DataGridTextColumn Header="Regex Rule" Binding="{Binding RuleRegex}" />
+        <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" />
         <materialDesign:DataGridComboBoxColumn 
             Header="Expense Category" 
             ItemsSourceBinding="{Binding DataContext.ExpenseCategories, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"

--- a/SimplyBudgetShared/Data/ExpenseCategoryRule.cs
+++ b/SimplyBudgetShared/Data/ExpenseCategoryRule.cs
@@ -8,6 +8,12 @@ public class ExpenseCategoryRule : BaseItem
     public string? Name { get; set; }
     public string? RuleRegex { get; set; }
 
+    /// <summary>
+    /// Optional note applied to matching transactions. Allows a rule to add context
+    /// (for example what a business is) without needing to set an expense category.
+    /// </summary>
+    public string? Notes { get; set; }
+
     public int? ExpenseCategoryID { get; set; }
     public ExpenseCategory? ExpenseCategory { get; set; }
 }

--- a/SimplyBudgetShared/DataTransfer/BudgetDataExportPackage.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataExportPackage.cs
@@ -62,7 +62,8 @@ public record BudgetDataExportRule(
     int Id,
     string? Name,
     string? RuleRegex,
-    int? ExpenseCategoryId
+    int? ExpenseCategoryId,
+    string? Notes = null
 );
 
 public record BudgetDataExportMetadata(

--- a/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
@@ -55,7 +55,7 @@ public static class BudgetDataPortabilityService
             Rules = await context.ExpenseCategoryRules
                 .AsNoTracking()
                 .OrderBy(x => x.ID)
-                .Select(x => new BudgetDataExportRule(x.ID, x.Name, x.RuleRegex, x.ExpenseCategoryID))
+                .Select(x => new BudgetDataExportRule(x.ID, x.Name, x.RuleRegex, x.ExpenseCategoryID, x.Notes))
                 .ToListAsync(cancellationToken),
             Metadata = await context.Metadatas
                 .AsNoTracking()
@@ -197,6 +197,7 @@ public static class BudgetDataPortabilityService
                 {
                     Name = x.Name,
                     RuleRegex = x.RuleRegex,
+                    Notes = x.Notes,
                     ExpenseCategoryID = ResolveOptionalReference(categoryIdMap, x.ExpenseCategoryId, "category")
                 })
                 .ToList();

--- a/SimplyBudgetShared/Migrations/20260901045749_AddExpenseCategoryRuleNotes.Designer.cs
+++ b/SimplyBudgetShared/Migrations/20260901045749_AddExpenseCategoryRuleNotes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetShared.Data;
 
@@ -10,9 +11,11 @@ using SimplyBudgetShared.Data;
 namespace SimplyBudgetShared.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260901045749_AddExpenseCategoryRuleNotes")]
+    partial class AddExpenseCategoryRuleNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/SimplyBudgetShared/Migrations/20260901045749_AddExpenseCategoryRuleNotes.cs
+++ b/SimplyBudgetShared/Migrations/20260901045749_AddExpenseCategoryRuleNotes.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetShared.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExpenseCategoryRuleNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Notes",
+                table: "ExpenseCategoryRules",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Notes",
+                table: "ExpenseCategoryRules");
+        }
+    }
+}

--- a/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
+++ b/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
@@ -42,6 +42,7 @@ public class BudgetDataPortabilityServiceTests
         {
             Name = "Grocery Rule",
             RuleRegex = "GROCERY",
+            Notes = "Local grocery store",
             ExpenseCategoryID = groceries.ID
         });
         setupContext.Metadatas.Add(new Metadata { Key = "Version", Value = "test" });
@@ -64,6 +65,7 @@ public class BudgetDataPortabilityServiceTests
         Assert.IsTrue(exportPackage.Accounts.Single(x => x.Name == "Savings").IsDefault);
         Assert.AreEqual("February salary", exportPackage.Items.Single().Notes);
         Assert.AreEqual("Food and household essentials", exportPackage.Categories.Single().Description);
+        Assert.AreEqual("Local grocery store", exportPackage.Rules.Single().Notes);
     }
 
     [TestMethod]
@@ -105,7 +107,7 @@ public class BudgetDataPortabilityServiceTests
             ],
             Rules =
             [
-                new BudgetDataExportRule(9000, "Market Rule", "MARKET", 100)
+                new BudgetDataExportRule(9000, "Market Rule", "MARKET", 100, "Farmers market")
             ],
             Metadata =
             [
@@ -143,6 +145,7 @@ public class BudgetDataPortabilityServiceTests
             .ToListAsync();
         Assert.AreEqual(1, rules.Count);
         Assert.AreEqual("Groceries", rules[0].ExpenseCategory?.Name);
+        Assert.AreEqual("Farmers market", rules[0].Notes);
 
         Assert.AreEqual(1, await assertContext.Metadatas.CountAsync());
         Assert.AreEqual(2, await assertContext.ExpenseCategoryItems.CountAsync());

--- a/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
@@ -152,6 +152,40 @@ public class ImportControllerTests
     }
 
     [Test]
+    public async Task Save_WithNoteOnlyRule_SetsPendingExpenseNotes()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Square rule",
+                RuleRegex = "SQ \\*",
+                Notes = "Square payment",
+                ExpenseCategoryID = null
+            });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var items = new[]
+        {
+            new ImportItemDto(new DateTime(2026, 1, 1), "SQ *COFFEE", 5_00, true, true),
+        };
+
+        var result = await controller.Save(items);
+
+        await Assert.That(((StatusCodeResult)result).StatusCode).IsEqualTo(201);
+        var saved = await context.PendingExpenses.SingleAsync();
+        await Assert.That(saved.SuggestedCategoryId).IsNull();
+        await Assert.That(saved.Notes).IsEqualTo("Square payment");
+    }
+
+    [Test]
     public async Task Save_CreditItem_DoesNotApplySuggestedCategoryRule()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -632,6 +632,53 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task ReapplyRules_AppliesRuleNotesWithoutOverwritingExistingNotes()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Square rule",
+                RuleRegex = "SQ \\*",
+                Notes = "Square payment",
+                ExpenseCategoryID = null
+            });
+            context.PendingExpenses.AddRange(
+                new PendingExpense
+                {
+                    Date = new DateTime(2026, 1, 1),
+                    Description = "SQ *COFFEE",
+                    Amount = 5_00,
+                    IsDebit = true
+                },
+                new PendingExpense
+                {
+                    Date = new DateTime(2026, 1, 2),
+                    Description = "SQ *BAKERY",
+                    Amount = 8_00,
+                    IsDebit = true,
+                    Notes = "User written note"
+                });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        await controller.ReapplyRules();
+
+        var updatedItems = await context.PendingExpenses
+            .OrderBy(x => x.Date)
+            .ToListAsync();
+
+        await Assert.That(updatedItems[0].Notes).IsEqualTo("Square payment");
+        await Assert.That(updatedItems[1].Notes).IsEqualTo("User written note");
+    }
+
+    [Test]
     public async Task Convert_WithNoItems_ReturnsBadRequest()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Core.Tests/Services/ExpenseCategoryRuleMatcherTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Services/ExpenseCategoryRuleMatcherTests.cs
@@ -52,4 +52,74 @@ public class ExpenseCategoryRuleMatcherTests
 
         await Assert.That(suggestedCategoryId).IsEqualTo(42);
     }
+
+    [Test]
+    public async Task Match_WhenNotTransaction_ReturnsNoNotes()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule
+            {
+                Name = "Payroll rule",
+                RuleRegex = "PAYROLL",
+                Notes = "Employer deposit"
+            }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "PAYROLL ACH", isTransaction: false);
+
+        await Assert.That(result.SuggestedCategoryId).IsNull();
+        await Assert.That(result.Notes).IsNull();
+    }
+
+    [Test]
+    public async Task Match_WhenRuleHasNotesWithoutCategory_ReturnsNotes()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule
+            {
+                Name = "Unknown business",
+                RuleRegex = "SQ \\*",
+                Notes = "Square payment - check the merchant",
+                ExpenseCategoryID = null
+            }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "SQ *COFFEE SHOP", isTransaction: true);
+
+        await Assert.That(result.SuggestedCategoryId).IsNull();
+        await Assert.That(result.Notes).IsEqualTo("Square payment - check the merchant");
+    }
+
+    [Test]
+    public async Task Match_WhenMultipleRulesMatch_CombinesDistinctNotes()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule { RuleRegex = "Costco", Notes = "Warehouse club" },
+            new ExpenseCategoryRule { RuleRegex = "gas", Notes = "Fuel", ExpenseCategoryID = 42 },
+            new ExpenseCategoryRule { RuleRegex = "Costco gas", Notes = "warehouse club" }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "Costco gas", isTransaction: true);
+
+        await Assert.That(result.SuggestedCategoryId).IsEqualTo(42);
+        await Assert.That(result.Notes)
+            .IsEqualTo($"Warehouse club{Environment.NewLine}Fuel");
+    }
+
+    [Test]
+    public async Task Match_WhenNoRuleHasNotes_ReturnsNullNotes()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule { RuleRegex = "Costco", ExpenseCategoryID = 42, Notes = "   " }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "Costco gas", isTransaction: true);
+
+        await Assert.That(result.SuggestedCategoryId).IsEqualTo(42);
+        await Assert.That(result.Notes).IsNull();
+    }
 }

--- a/SimplyBudgetWeb.Data/Migrations/20260901045816_AddExpenseCategoryRuleNotes.Designer.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260901045816_AddExpenseCategoryRuleNotes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetWeb.Data;
 
@@ -11,9 +12,11 @@ using SimplyBudgetWeb.Data;
 namespace SimplyBudgetWeb.Data.Migrations
 {
     [DbContext(typeof(BudgetWebContext))]
-    partial class BudgetWebContextModelSnapshot : ModelSnapshot
+    [Migration("20260901045816_AddExpenseCategoryRuleNotes")]
+    partial class AddExpenseCategoryRuleNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SimplyBudgetWeb.Data/Migrations/20260901045816_AddExpenseCategoryRuleNotes.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260901045816_AddExpenseCategoryRuleNotes.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetWeb.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExpenseCategoryRuleNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Notes",
+                schema: "SimplyBudget",
+                table: "ExpenseCategoryRules",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Notes",
+                schema: "SimplyBudget",
+                table: "ExpenseCategoryRules");
+        }
+    }
+}

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -55,7 +55,7 @@ const rulesLoaded = ref(false)
 const addRuleOpen = ref(false)
 const deleteRule = ref<RuleDto | null>(null)
 const editRule = ref<RuleDto | null>(null)
-const ruleForm = ref({ name: '', ruleRegex: '', expenseCategoryId: null as number | null })
+const ruleForm = ref({ name: '', ruleRegex: '', notes: '', expenseCategoryId: null as number | null })
 
 interface RuleGroup {
   key: string
@@ -320,7 +320,7 @@ async function fetchRuleCategories() {
 }
 
 function resetRuleForm() {
-  ruleForm.value = { name: '', ruleRegex: '', expenseCategoryId: null }
+  ruleForm.value = { name: '', ruleRegex: '', notes: '', expenseCategoryId: null }
 }
 
 function openAddRule() {
@@ -333,6 +333,7 @@ function openEditRule(rule: RuleDto) {
   ruleForm.value = {
     name: rule.name ?? '',
     ruleRegex: rule.ruleRegex ?? '',
+    notes: rule.notes ?? '',
     expenseCategoryId: rule.expenseCategoryId ?? null,
   }
 }
@@ -342,6 +343,7 @@ async function handleAddRule() {
     await apiClient.post('/api/rules', {
       name: ruleForm.value.name,
       ruleRegex: ruleForm.value.ruleRegex,
+      notes: ruleForm.value.notes,
       expenseCategoryId: ruleForm.value.expenseCategoryId,
     })
     snackbar.enqueueSnackbar('Rule added', { variant: 'success' })
@@ -359,6 +361,7 @@ async function handleEditRule() {
     await apiClient.put(`/api/rules/${editRule.value.id}`, {
       name: ruleForm.value.name,
       ruleRegex: ruleForm.value.ruleRegex,
+      notes: ruleForm.value.notes,
       expenseCategoryId: ruleForm.value.expenseCategoryId,
     })
     snackbar.enqueueSnackbar('Rule updated', { variant: 'success' })
@@ -675,6 +678,7 @@ watch(openPanel, (panel) => {
                 <v-list-item v-for="rule in group.rules" :key="rule.id">
                   <v-list-item-title>{{ rule.name }}</v-list-item-title>
                   <v-list-item-subtitle>Pattern: {{ rule.ruleRegex ?? '—' }}</v-list-item-subtitle>
+                  <v-list-item-subtitle v-if="rule.notes">Notes: {{ rule.notes }}</v-list-item-subtitle>
                   <template #append>
                     <div class="d-flex" style="gap: 4px;">
                       <v-btn icon="mdi-pencil" variant="text" aria-label="Edit rule" @click="openEditRule(rule)" />
@@ -810,6 +814,14 @@ watch(openPanel, (panel) => {
         <v-card-text class="d-flex flex-column" style="gap: 16px;">
           <v-text-field label="Name" v-model="ruleForm.name" />
           <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
+          <v-textarea
+            label="Notes"
+            rows="2"
+            auto-grow
+            hint="Added to matching pending expenses. A rule can add notes without setting a category."
+            persistent-hint
+            v-model="ruleForm.notes"
+          />
           <CategorySelector
             label="Target Category"
             :categories="categories"
@@ -832,6 +844,14 @@ watch(openPanel, (panel) => {
         <v-card-text class="d-flex flex-column" style="gap: 16px;">
           <v-text-field label="Name" v-model="ruleForm.name" />
           <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
+          <v-textarea
+            label="Notes"
+            rows="2"
+            auto-grow
+            hint="Added to matching pending expenses. A rule can add notes without setting a category."
+            persistent-hint
+            v-model="ruleForm.notes"
+          />
           <CategorySelector
             label="Category"
             :categories="categories"

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -89,6 +89,7 @@ export interface RuleDto {
   id: number
   name: string | null
   ruleRegex: string | null
+  notes: string | null
   expenseCategoryId: number | null
   categoryName: string | null
 }
@@ -234,6 +235,7 @@ export interface BudgetDataExportRuleDto {
   name: string | null
   ruleRegex: string | null
   expenseCategoryId: number | null
+  notes: string | null
 }
 
 export interface BudgetDataExportMetadataDto {

--- a/SimplyBudgetWeb/Controllers/ImportController.cs
+++ b/SimplyBudgetWeb/Controllers/ImportController.cs
@@ -104,16 +104,21 @@ public class ImportController(BudgetWebContext context) : ControllerBase
 
         var pendingExpenses = items
             .Where(i => i.IsChecked)
-            .Select(i => new PendingExpense
+            .Select(i =>
             {
-                Date = i.Date,
-                Description = i.Description,
-                Amount = i.Amount,
-                IsDebit = i.IsDebit,
-                SuggestedCategoryId = ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(
+                var match = ExpenseCategoryRuleMatcher.Match(
                     rules,
                     i.Description,
-                    isTransaction: i.IsDebit),
+                    isTransaction: i.IsDebit);
+                return new PendingExpense
+                {
+                    Date = i.Date,
+                    Description = i.Description,
+                    Amount = i.Amount,
+                    IsDebit = i.IsDebit,
+                    SuggestedCategoryId = match.SuggestedCategoryId,
+                    Notes = match.Notes,
+                };
             })
             .ToList();
 

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -190,10 +190,16 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 
         foreach (var pendingExpense in pendingExpenses)
         {
-            pendingExpense.SuggestedCategoryId = ExpenseCategoryRuleMatcher.GetSuggestedCategoryId(
+            var match = ExpenseCategoryRuleMatcher.Match(
                 rules,
                 pendingExpense.Description,
                 isTransaction: pendingExpense.IsDebit);
+
+            pendingExpense.SuggestedCategoryId = match.SuggestedCategoryId;
+
+            // Never clobber notes a user has already written for this pending expense.
+            if (match.Notes is not null && string.IsNullOrWhiteSpace(pendingExpense.Notes))
+                pendingExpense.Notes = match.Notes;
         }
 
         await context.SaveChangesAsync();

--- a/SimplyBudgetWeb/Controllers/RulesController.cs
+++ b/SimplyBudgetWeb/Controllers/RulesController.cs
@@ -25,6 +25,7 @@ public class RulesController(BudgetWebContext context) : ControllerBase
         {
             Name = request.Name,
             RuleRegex = request.RuleRegex,
+            Notes = request.Notes,
             ExpenseCategoryID = request.ExpenseCategoryId,
         };
         context.ExpenseCategoryRules.Add(rule);
@@ -42,6 +43,7 @@ public class RulesController(BudgetWebContext context) : ControllerBase
 
         rule.Name = request.Name;
         rule.RuleRegex = request.RuleRegex;
+        rule.Notes = request.Notes;
         rule.ExpenseCategoryID = request.ExpenseCategoryId;
 
         await context.SaveChangesAsync();
@@ -63,6 +65,7 @@ public class RulesController(BudgetWebContext context) : ControllerBase
         Id: r.ID,
         Name: r.Name,
         RuleRegex: r.RuleRegex,
+        Notes: r.Notes,
         ExpenseCategoryId: r.ExpenseCategoryID,
         CategoryName: r.ExpenseCategory?.Name
     );
@@ -72,8 +75,9 @@ public record RuleDto(
     int Id,
     string? Name,
     string? RuleRegex,
+    string? Notes,
     int? ExpenseCategoryId,
     string? CategoryName
 );
 
-public record RuleRequest(string? Name, string? RuleRegex, int? ExpenseCategoryId);
+public record RuleRequest(string? Name, string? RuleRegex, int? ExpenseCategoryId, string? Notes = null);

--- a/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatchResult.cs
+++ b/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatchResult.cs
@@ -1,0 +1,17 @@
+namespace SimplyBudgetWeb.Services;
+
+/// <summary>
+/// The combined result of applying the expense category rules to a single transaction.
+/// </summary>
+/// <param name="SuggestedCategoryId">
+/// The category suggested by the last matching rule that specified a category, or null when no
+/// matching rule specified one.
+/// </param>
+/// <param name="Notes">
+/// The notes contributed by all matching rules, joined by new lines, or null when no matching
+/// rule specified notes.
+/// </param>
+public record ExpenseCategoryRuleMatchResult(int? SuggestedCategoryId, string? Notes)
+{
+    public static ExpenseCategoryRuleMatchResult None { get; } = new(null, null);
+}

--- a/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatcher.cs
+++ b/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatcher.cs
@@ -6,22 +6,45 @@ namespace SimplyBudgetWeb.Services;
 public static class ExpenseCategoryRuleMatcher
 {
     public static int? GetSuggestedCategoryId(IEnumerable<ExpenseCategoryRule> rules, string? description, bool isTransaction)
+        => Match(rules, description, isTransaction).SuggestedCategoryId;
+
+    /// <summary>
+    /// Applies the rules to a transaction description. A rule matches on its regex alone, so a
+    /// rule may contribute notes without setting an expense category (and vice versa).
+    /// </summary>
+    public static ExpenseCategoryRuleMatchResult Match(
+        IEnumerable<ExpenseCategoryRule> rules,
+        string? description,
+        bool isTransaction)
     {
         if (!isTransaction)
-            return null;
+            return ExpenseCategoryRuleMatchResult.None;
 
         var descriptionToMatch = description ?? "";
         int? suggestedCategoryId = null;
+        List<string> notes = [];
 
         foreach (var rule in rules)
         {
-            if (rule.ExpenseCategoryID is null || string.IsNullOrWhiteSpace(rule.RuleRegex))
+            if (string.IsNullOrWhiteSpace(rule.RuleRegex))
                 continue;
 
-            if (Regex.IsMatch(descriptionToMatch, rule.RuleRegex, RegexOptions.IgnoreCase))
+            if (!Regex.IsMatch(descriptionToMatch, rule.RuleRegex, RegexOptions.IgnoreCase))
+                continue;
+
+            if (rule.ExpenseCategoryID is not null)
                 suggestedCategoryId = rule.ExpenseCategoryID;
+
+            if (!string.IsNullOrWhiteSpace(rule.Notes))
+            {
+                var note = rule.Notes.Trim();
+                if (!notes.Contains(note, StringComparer.OrdinalIgnoreCase))
+                    notes.Add(note);
+            }
         }
 
-        return suggestedCategoryId;
+        return new ExpenseCategoryRuleMatchResult(
+            suggestedCategoryId,
+            notes.Count > 0 ? string.Join(Environment.NewLine, notes) : null);
     }
 }


### PR DESCRIPTION
Rules can now carry notes that get applied to matching transactions, whether or not the rule sets an expense category.

## Changes
- Added `Notes` to `ExpenseCategoryRule` (+ EF migrations for both the desktop SQLite and web SQL Server contexts).
- `ExpenseCategoryRuleMatcher.Match` now returns both the suggested category and the combined notes. Rules match on their regex alone, so a note-only rule (no category) is now honored.
- Import save applies rule notes to newly created pending expenses; `reapply-rules` applies rule notes but never overwrites notes a user already wrote.
- Rules API/UI (Settings page) and the desktop rules grid can view and edit rule notes.
- Rule notes are included in data export/import.

## Testing
- `dotnet test SimplyBudgetWeb.Core.Tests` (97 passed)
- `dotnet test SimplyBudgetSharedTests` (61 passed)
- `dotnet test SimplyBudgetDesktop.Tests` (44 passed)
- `pnpm build` and `pnpm lint` in SimplyBudgetWeb.Web

Fixes #196