### PR TITLE
Include category descriptions in expense searches

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
@@ -154,6 +154,49 @@ public class HistoryControllerTests
     }
 
     [Test]
+    public async Task GetAll_ReturnsAndSearchesCategoryDescription()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries", Description = "Costco and Aldi runs" };
+            var otherCategory = new ExpenseCategory { Name = "Utilities", Description = "Power and water" };
+            context.ExpenseCategories.AddRange(category, otherCategory);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.AddRange(
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 1, 10),
+                    Description = "Weekly shopping",
+                    Details = [new ExpenseCategoryItemDetail { Amount = -1234, ExpenseCategoryId = category.ID }],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2026, 1, 11),
+                    Description = "Electric bill",
+                    Details = [new ExpenseCategoryItemDetail { Amount = -5678, ExpenseCategoryId = otherCategory.ID }],
+                });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new HistoryController(context);
+
+        var result = await controller.GetAll(
+            month: new DateTime(2026, 1, 1),
+            search: "Aldi",
+            categoryId: null,
+            accountId: null);
+
+        await Assert.That(result.Length).IsEqualTo(1);
+        await Assert.That(result[0].Description).IsEqualTo("Weekly shopping");
+        await Assert.That(result[0].Details[0].CategoryDescription).IsEqualTo("Costco and Aldi runs");
+    }
+
+    [Test]
     public async Task Update_UpdatesNotesAndReturnsUpdatedItem()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -144,6 +144,34 @@ public class PendingExpensesControllerTests
     }
 
     [Test]
+    public async Task GetAll_FiltersBySuggestedCategoryDescription()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries", Description = "Costco and Aldi runs" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.PendingExpenses.AddRange(
+                new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Weekly shopping", Amount = 100, SuggestedCategoryId = category.ID },
+                new PendingExpense { Date = new DateTime(2026, 1, 2), Description = "Gas station", Amount = 200 });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new PendingExpensesController(context);
+
+        var result = await controller.GetAll(search: "Aldi", assigneeId: null);
+
+        await Assert.That(result.Length).IsEqualTo(1);
+        await Assert.That(result[0].Description).IsEqualTo("Weekly shopping");
+        await Assert.That(result[0].SuggestedCategoryDescription).IsEqualTo("Costco and Aldi runs");
+    }
+
+    [Test]
     public async Task GetAll_FiltersByAmount()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -45,6 +45,7 @@ const filteredItems = computed(() => {
   return items.value.filter((item) => {
     if (includesSearchText(item.description, normalizedSearchText)) return true
     if (includesSearchText(item.notes, normalizedSearchText)) return true
+    if (item.details.some((detail) => includesSearchText(detail.categoryDescription, normalizedSearchText))) return true
     if (searchAmountAbs === null) return false
 
     return item.details.some((detail) => Math.abs(detail.amount) === searchAmountAbs)

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -45,6 +45,7 @@ const filteredItems = computed(() => {
 
   return items.value.filter((item) => {
     if (includesSearchText(item.description, normalizedSearchText)) return true
+    if (includesSearchText(item.suggestedCategoryDescription, normalizedSearchText)) return true
     if (searchAmountAbs === null) return false
     return Math.abs(item.amount) === searchAmountAbs
   })

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -81,6 +81,7 @@ export interface HistoryDetailDto {
   id: number
   expenseCategoryId: number
   categoryName: string | null
+  categoryDescription: string | null
   amount: number
   ignoreBudget: boolean
 }
@@ -144,6 +145,7 @@ export interface PendingExpenseDto {
   assigneeName: string | null
   suggestedCategoryId: number | null
   suggestedCategoryName: string | null
+  suggestedCategoryDescription: string | null
 }
 
 export interface OldestPendingExpenseMonthDto {

--- a/SimplyBudgetWeb/Controllers/HistoryController.cs
+++ b/SimplyBudgetWeb/Controllers/HistoryController.cs
@@ -37,6 +37,7 @@ public class HistoryController(BudgetWebContext context) : ControllerBase
             query = query.Where(x =>
                 (x.Description != null && x.Description.Contains(searchText)) ||
                 (x.Notes != null && x.Notes.Contains(searchText)) ||
+                x.Details!.Any(d => d.ExpenseCategory!.Description != null && d.ExpenseCategory.Description.Contains(searchText)) ||
                 (hasSearchAmount &&
                  (x.Details!.Any(d => Math.Abs(d.Amount) == searchAmountAbs) ||
                   Math.Abs(x.Details!.Sum(d => d.Amount)) == searchAmountAbs)));
@@ -94,6 +95,7 @@ public class HistoryController(BudgetWebContext context) : ControllerBase
             Id: d.ID,
             ExpenseCategoryId: d.ExpenseCategoryId,
             CategoryName: d.ExpenseCategory?.Name,
+            CategoryDescription: d.ExpenseCategory?.Description,
             Amount: d.Amount,
             IgnoreBudget: d.IgnoreBudget
         )).ToArray()
@@ -116,6 +118,7 @@ public record HistoryDetailDto(
     int Id,
     int ExpenseCategoryId,
     string? CategoryName,
+    string? CategoryDescription,
     int Amount,
     bool IgnoreBudget
 );

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -264,7 +264,8 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
         AssigneeId: p.AssigneeId,
         AssigneeName: p.Assignee?.Name,
         SuggestedCategoryId: p.SuggestedCategoryId,
-        SuggestedCategoryName: p.SuggestedCategory?.Name
+        SuggestedCategoryName: p.SuggestedCategory?.Name,
+        SuggestedCategoryDescription: p.SuggestedCategory?.Description
     );
 
     private bool TrySetOriginalVersion(PendingExpense pending, string? version)
@@ -293,6 +294,7 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
 
         return query.Where(x =>
             (x.Description != null && x.Description.Contains(searchText)) ||
+            (x.SuggestedCategory != null && x.SuggestedCategory.Description != null && x.SuggestedCategory.Description.Contains(searchText)) ||
             (hasSearchAmount && Math.Abs(x.Amount) == searchAmountAbs));
     }
 }
@@ -308,7 +310,8 @@ public record PendingExpenseDto(
     int? AssigneeId,
     string? AssigneeName,
     int? SuggestedCategoryId,
-    string? SuggestedCategoryName
+    string? SuggestedCategoryName,
+    string? SuggestedCategoryDescription
 );
 
 public record OldestPendingExpenseMonthDto(DateTime? Month);


### PR DESCRIPTION
Searching on the **Expenses** and **Pending Expenses** screens previously only matched the transaction description (plus notes on Expenses) and amounts. Expense category descriptions - already searchable on the Budget screen - were not included.

## Changes
- `HistoryController`: expose `CategoryDescription` on history detail DTOs and include category descriptions in the server-side search filter.
- `PendingExpensesController`: expose `SuggestedCategoryDescription` and match the suggested category description in the shared search filter (used by both `GetAll` and `DeleteAll`).
- Frontend: `History.vue` and `PendingExpenses.vue` client-side filters now also match category descriptions; types updated.
- Added controller tests covering the new search behavior.

Validated with `dotnet test` (110 passing), `pnpm build` (vue-tsc) and `pnpm lint`.