### PR TITLE
Allow setting rule notes when creating rules from expenses

### DIFF
--- a/SimplyBudgetWeb.Web/src/components/AddRuleDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/AddRuleDialog.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { apiClient } from '@/services/apiClient'
+import { useSnackbarStore } from '@/stores/snackbar'
+import type { ExpenseCategoryDto, RuleDto } from '@/types'
+import CategorySelector from '@/components/CategorySelector.vue'
+
+const props = defineProps<{
+  modelValue: boolean
+  categories: ExpenseCategoryDto[]
+  description?: string | null
+  notes?: string | null
+  expenseCategoryId?: number | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'created', rule: RuleDto): void
+}>()
+
+const snackbar = useSnackbarStore()
+const saving = ref(false)
+const form = ref({ name: '', ruleRegex: '', notes: '', expenseCategoryId: null as number | null })
+
+function resetForm() {
+  form.value = {
+    name: '',
+    ruleRegex: props.description ?? '',
+    notes: props.notes ?? '',
+    expenseCategoryId: props.expenseCategoryId ?? null,
+  }
+}
+
+watch(
+  () => props.modelValue,
+  (isOpen) => {
+    if (isOpen) resetForm()
+  },
+  { immediate: true },
+)
+
+function close() {
+  if (saving.value) return
+  emit('update:modelValue', false)
+}
+
+async function handleAdd() {
+  saving.value = true
+  try {
+    const notes = form.value.notes.trim()
+    const rule = await apiClient.post<RuleDto>('/api/rules', {
+      name: form.value.name,
+      ruleRegex: form.value.ruleRegex,
+      notes: notes.length > 0 ? notes : null,
+      expenseCategoryId: form.value.expenseCategoryId,
+    })
+    snackbar.enqueueSnackbar('Rule added', { variant: 'success' })
+    emit('created', rule)
+    emit('update:modelValue', false)
+  } catch {
+    snackbar.enqueueSnackbar('Failed to add rule', { variant: 'error' })
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <v-dialog :model-value="modelValue" max-width="500" @update:model-value="(val: boolean) => !val && close()">
+    <v-card>
+      <v-card-title>Add Rule</v-card-title>
+      <v-card-text class="d-flex flex-column" style="gap: 16px;">
+        <v-text-field label="Name" v-model="form.name" />
+        <v-text-field label="Regex Pattern" v-model="form.ruleRegex" />
+        <v-textarea
+          label="Notes"
+          rows="2"
+          auto-grow
+          hint="Added to matching pending expenses. A rule can add notes without setting a category."
+          persistent-hint
+          v-model="form.notes"
+        />
+        <CategorySelector
+          label="Target Category"
+          :categories="categories"
+          null-option-label="None"
+          :clearable="false"
+          v-model="form.expenseCategoryId"
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn :disabled="saving" @click="close">Cancel</v-btn>
+        <v-btn color="primary" :loading="saving" @click="handleAdd">Add</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -11,6 +11,7 @@ import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
 import { useRoute } from 'vue-router'
 import CategorySelector from '@/components/CategorySelector.vue'
+import AddRuleDialog from '@/components/AddRuleDialog.vue'
 
 const snackbar = useSnackbarStore()
 const route = useRoute()
@@ -29,6 +30,8 @@ const editNotesDraft = ref('')
 const savingNotes = ref(false)
 const deleteItem = ref<HistoryItemDto | null>(null)
 const dialogOpen = ref(false)
+const addRuleOpen = ref(false)
+const ruleSourceItem = ref<HistoryItemDto | null>(null)
 
 const monthLabel = computed(() =>
   currentMonth.value.toLocaleString('default', { month: 'long', year: 'numeric' }),
@@ -108,6 +111,18 @@ async function handleDelete() {
 
 function totalForItem(item: HistoryItemDto) {
   return item.details.reduce((sum, d) => sum + d.amount, 0)
+}
+
+function openAddRule(item: HistoryItemDto) {
+  ruleSourceItem.value = item
+  addRuleOpen.value = true
+}
+
+function ruleCategoryIdFor(item: HistoryItemDto | null) {
+  if (!item) return null
+  // Only prefill when the transaction maps to a single category; multi-category
+  // transactions have no obvious target for the rule.
+  return item.details.length === 1 ? item.details[0].expenseCategoryId : null
 }
 
 function openNotesEditor(item: HistoryItemDto) {
@@ -260,6 +275,11 @@ function onDialogSuccess() {
                   @click="openNotesEditor(item)"
                 />
                 <v-list-item
+                  prepend-icon="mdi-filter-plus-outline"
+                  title="Create rule"
+                  @click="openAddRule(item)"
+                />
+                <v-list-item
                   prepend-icon="mdi-delete"
                   title="Delete transaction"
                   base-color="error"
@@ -282,6 +302,14 @@ function onDialogSuccess() {
     />
 
     <AddTransactionDialog v-model="dialogOpen" :categories="categories" @success="onDialogSuccess" />
+
+    <AddRuleDialog
+      v-model="addRuleOpen"
+      :categories="categories"
+      :description="ruleSourceItem?.description"
+      :notes="ruleSourceItem?.notes"
+      :expense-category-id="ruleCategoryIdFor(ruleSourceItem)"
+    />
 
     <v-dialog :model-value="!!editNotesItem" max-width="560" @update:model-value="(val: boolean) => !val && closeNotesEditor()">
       <v-card>

--- a/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
+++ b/SimplyBudgetWeb.Web/src/pages/PendingExpenses.vue
@@ -9,7 +9,7 @@ import { useExternalLinkRules } from '@/utils/externalLinks'
 import { includesSearchText, tryParseSearchAmountInCents } from '@/utils/search'
 import ConvertPendingExpenseDialog from '@/components/ConvertPendingExpenseDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
-import CategorySelector from '@/components/CategorySelector.vue'
+import AddRuleDialog from '@/components/AddRuleDialog.vue'
 
 const snackbar = useSnackbarStore()
 const { loadExternalLinkRules, externalLinksFor } = useExternalLinkRules()
@@ -30,7 +30,7 @@ const reapplyingRules = ref(false)
 const editingNoteItemId = ref<number | null>(null)
 const noteDrafts = ref<Record<number, string>>({})
 const addRuleOpen = ref(false)
-const ruleForm = ref({ name: '', ruleRegex: '', expenseCategoryId: null as number | null })
+const ruleSourceItem = ref<PendingExpenseDto | null>(null)
 
 // "All" plus the real filter options; used for both the toolbar filter and the
 // page-level assignee filter.
@@ -215,38 +215,14 @@ function openConvert(item: PendingExpenseDto) {
   convertDialogOpen.value = true
 }
 
-function resetRuleForm() {
-  ruleForm.value = { name: '', ruleRegex: '', expenseCategoryId: null }
-}
-
 function openAddRule(item: PendingExpenseDto) {
-  resetRuleForm()
-  ruleForm.value.ruleRegex = item.description ?? ''
-  ruleForm.value.expenseCategoryId = item.suggestedCategoryId ?? null
+  ruleSourceItem.value = item
   addRuleOpen.value = true
-}
-
-function closeAddRule() {
-  addRuleOpen.value = false
-}
-
-async function handleAddRule() {
-  try {
-    await apiClient.post('/api/rules', {
-      name: ruleForm.value.name,
-      ruleRegex: ruleForm.value.ruleRegex,
-      expenseCategoryId: ruleForm.value.expenseCategoryId,
-    })
-    snackbar.enqueueSnackbar('Rule added', { variant: 'success' })
-    addRuleOpen.value = false
-  } catch {
-    snackbar.enqueueSnackbar('Failed to add rule', { variant: 'error' })
-  }
 }
 
 watch(addRuleOpen, (isOpen) => {
   if (!isOpen) {
-    resetRuleForm()
+    ruleSourceItem.value = null
   }
 })
 
@@ -463,27 +439,13 @@ onMounted(() => {
       @success="onConvertSuccess"
       @note-saved="onConvertNoteSaved"
     />
-    <v-dialog :model-value="addRuleOpen" max-width="500" @update:model-value="(val: boolean) => !val && closeAddRule()">
-      <v-card>
-        <v-card-title>Add Rule</v-card-title>
-        <v-card-text class="d-flex flex-column" style="gap: 16px;">
-          <v-text-field label="Name" v-model="ruleForm.name" />
-          <v-text-field label="Regex Pattern" v-model="ruleForm.ruleRegex" />
-          <CategorySelector
-            label="Target Category"
-            :categories="categories"
-            null-option-label="None"
-            :clearable="false"
-            v-model="ruleForm.expenseCategoryId"
-          />
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn @click="closeAddRule">Cancel</v-btn>
-          <v-btn color="primary" @click="handleAddRule">Add</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+    <AddRuleDialog
+      v-model="addRuleOpen"
+      :categories="categories"
+      :description="ruleSourceItem?.description"
+      :notes="ruleSourceItem?.notes"
+      :expense-category-id="ruleSourceItem?.suggestedCategoryId ?? null"
+    />
 
     <v-dialog :model-value="!!discardItem" max-width="480" @update:model-value="(val: boolean) => !val && (discardItem = null)">
       <v-card>


### PR DESCRIPTION
## Summary
- Adds a **Notes** field to the "Create rule" flow started from a pending expense, so notes can be set when the rule is created (previously only name, regex, and category were available).
- Adds a **Create rule** action to the item menu on the **Expenses** page, using the same dialog.

## Details
- New shared `AddRuleDialog.vue` component: name, regex pattern, notes (with the same hint used in Settings), and target category. It posts to `/api/rules` (which already supports `notes`), shows success/error snackbars, and has a loading state.
- `PendingExpenses.vue` now uses the shared dialog; regex prefills from the description, category from the suggested category, and notes from the pending expense's note.
- `History.vue` (Expenses page) gains a "Create rule" menu item; regex prefills from the description, notes from the transaction notes, and category from the transaction's category when it maps to exactly one.

## Verification
- `pnpm build` (vue-tsc + vite) passes
- `pnpm lint` passes
