### PR TITLE
Add month-scoped SignalR budget refresh updates

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerRealtimeTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerRealtimeTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Mvc;
+
+using Moq;
+using Moq.AutoMock;
+
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class HistoryControllerRealtimeTests
+{
+    [Test]
+    public async Task Delete_NotifiesChangedMonth()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+        var notifier = new Mock<IBudgetMonthUpdateNotifier>();
+
+        var monthDate = new DateTime(2026, 5, 19);
+        int itemId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Home" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            var item = new ExpenseCategoryItem
+            {
+                Date = monthDate,
+                Description = "Home Depot",
+                Details =
+                [
+                    new ExpenseCategoryItemDetail
+                    {
+                        ExpenseCategoryId = category.ID,
+                        Amount = -1200,
+                    },
+                ],
+            };
+            context.ExpenseCategoryItems.Add(item);
+            await context.SaveChangesAsync();
+            return item.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new HistoryController(context, notifier.Object);
+
+        var result = await controller.Delete(itemId);
+
+        await Assert.That(result).IsTypeOf<NoContentResult>();
+        notifier.Verify(
+            x => x.NotifyMonthUpdated(monthDate, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/SimplyBudgetWeb.Core.Tests/Controllers/TransactionsControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/TransactionsControllerTests.cs
@@ -1,14 +1,46 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using Moq.AutoMock;
 using SimplyBudgetShared.Data;
 using SimplyBudgetWeb.Controllers;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
 
 namespace SimplyBudgetWeb.Core.Tests.Controllers;
 
 public class TransactionsControllerTests
 {
+    [Test]
+    public async Task AddTransaction_NotifiesChangedMonth()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+        var notifier = new Mock<IBudgetMonthUpdateNotifier>();
+
+        var categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries", CurrentBalance = 500_00 };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        var monthDate = new DateTime(2026, 1, 10);
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new TransactionsController(context, notifier.Object);
+            await controller.AddTransaction(new TransactionRequest(
+                Description: "Costco",
+                Date: monthDate,
+                Items: [new TransactionItemRequest(categoryId, 45_00)]));
+        }
+
+        notifier.Verify(
+            x => x.NotifyMonthUpdated(monthDate, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     [Test]
     public async Task AddTransaction_PersistsNotes()
     {

--- a/SimplyBudgetWeb.Web/package.json
+++ b/SimplyBudgetWeb.Web/package.json
@@ -14,6 +14,7 @@
     "@azure/msal-browser": "^5.19.0",
     "@mdi/font": "^7.4.47",
     "@microsoft/applicationinsights-web": "^3.4.1",
+    "@microsoft/signalr": "^10.0.11",
     "pinia": "^4.0.3",
     "vue": "^3.5.41",
     "vue-router": "^5.2.0",

--- a/SimplyBudgetWeb.Web/pnpm-lock.yaml
+++ b/SimplyBudgetWeb.Web/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@microsoft/applicationinsights-web':
         specifier: ^3.4.1
         version: 3.4.3(tslib@2.8.1)
+      '@microsoft/signalr':
+        specifier: ^10.0.11
+        version: 10.0.11
       pinia:
         specifier: ^4.0.3
         version: 4.0.3(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
@@ -734,6 +737,9 @@ packages:
   '@microsoft/dynamicproto-js@2.0.5':
     resolution: {integrity: sha512-V+Zr7PDKIEaItVwF/OyWQlKeugNRYg7KJJ+RhEIL2FMW6NlG8FN2l4XA9Z42hNtsjwJFlcUiF38pmM/AaXsF7g==}
 
+  '@microsoft/signalr@10.0.11':
+    resolution: {integrity: sha512-FulOJ2EEtKvLQcswe/U7v8pzyXyk7Jua5xgWJPPwyQU/2Z9ORvKcVjyO75VvLsem+CJ1ORRexJ+7Bz1FCei2aw==}
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
@@ -1199,6 +1205,10 @@ packages:
       vue: ^3.0.0
       vuetify: '>=3'
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1507,6 +1517,14 @@ packages:
     resolution: {integrity: sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==}
     engines: {node: '>=20'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  eventsource@2.0.2:
+    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
+
   exsolve@1.1.1:
     resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
 
@@ -1530,6 +1548,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-cookie@2.2.0:
+    resolution: {integrity: sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1974,6 +1995,15 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.54:
     resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
@@ -2090,12 +2120,18 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   readdirp@5.1.1:
     resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
@@ -2130,6 +2166,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -2173,6 +2212,9 @@ packages:
   serialize-javascript@7.1.0:
     resolution: {integrity: sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==}
     engines: {node: '>=20.0.0'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2282,6 +2324,13 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2357,6 +2406,10 @@ packages:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2414,6 +2467,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2537,8 +2593,14 @@ packages:
       webpack-plugin-vuetify:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2613,6 +2675,18 @@ packages:
 
   workbox-window@7.4.1:
     resolution: {integrity: sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==}
+
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -3480,6 +3554,18 @@ snapshots:
     dependencies:
       '@nevware21/ts-utils': 0.16.0
 
+  '@microsoft/signalr@10.0.11':
+    dependencies:
+      abort-controller: 3.0.0
+      eventsource: 2.0.2
+      fetch-cookie: 2.2.0
+      node-fetch: 2.7.0
+      ws: 7.5.13
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
@@ -3896,6 +3982,10 @@ snapshots:
       vue: 3.5.41(typescript@6.0.3)
       vuetify: 4.1.11(typescript@6.0.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@6.0.3))
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -4282,6 +4372,10 @@ snapshots:
 
   eta@4.6.0: {}
 
+  event-target-shim@5.0.1: {}
+
+  eventsource@2.0.2: {}
+
   exsolve@1.1.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -4295,6 +4389,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
       picomatch: 4.0.7
+
+  fetch-cookie@2.2.0:
+    dependencies:
+      set-cookie-parser: 2.7.2
+      tough-cookie: 4.1.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4708,6 +4807,10 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-releases@2.0.54: {}
 
   nostics@1.2.0: {}
@@ -4817,9 +4920,15 @@ snapshots:
 
   pretty-bytes@6.1.1: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
+
+  querystringify@2.2.0: {}
 
   readdirp@5.1.1: {}
 
@@ -4865,6 +4974,8 @@ snapshots:
       jsesc: 3.1.0
 
   require-from-string@2.0.2: {}
+
+  requires-port@1.0.0: {}
 
   resolve@1.22.12:
     dependencies:
@@ -4952,6 +5063,8 @@ snapshots:
   semver@7.8.5: {}
 
   serialize-javascript@7.1.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -5100,6 +5213,15 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.7)
       picomatch: 4.0.7
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
+  tr46@0.0.3: {}
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -5184,6 +5306,8 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   unplugin-utils@0.3.2:
@@ -5214,6 +5338,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
 
@@ -5324,7 +5453,14 @@ snapshots:
       typescript: 6.0.3
       vite-plugin-vuetify: 2.1.3(vite@8.2.2(@types/node@26.3.0)(terser@5.51.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(vuetify@4.1.11)
 
+  webidl-conversions@3.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -5485,6 +5621,8 @@ snapshots:
     dependencies:
       '@types/trusted-types': 2.0.7
       workbox-core: 7.4.1
+
+  ws@7.5.13: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -1,16 +1,19 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
+import { useAuthStore } from '@/stores/auth'
 import type { AccountDto, BudgetResponse, BudgetCategoryDto, ExpenseCategoryDto, ExpenseCategoryMonthlyExpensesDto } from '@/types'
 import { formatCents, formatMonth, parseMonth } from '@/utils/currency'
 import { useRouter } from 'vue-router'
 import AddTransactionDialog from '@/components/AddTransactionDialog.vue'
 import MonthPickerNav from '@/components/MonthPickerNav.vue'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
+import { createMonthUpdatesHubClient } from '@/services/monthUpdatesHub'
 
 const snackbar = useSnackbarStore()
 const router = useRouter()
+const authStore = useAuthStore()
 
 const { currentMonth } = useMonthQueryParam()
 const budget = ref<BudgetResponse | null>(null)
@@ -22,6 +25,8 @@ const categories = ref<ExpenseCategoryDto[]>([])
 const categoryChartDialogOpen = ref(false)
 const categoryChartLoading = ref(false)
 const categoryChart = ref<ExpenseCategoryMonthlyExpensesDto | null>(null)
+let realtimeRefreshInFlight = false
+let realtimeRefreshQueued = false
 
 const monthLabel = computed(() =>
   currentMonth.value.toLocaleString('default', { month: 'long', year: 'numeric' }),
@@ -71,20 +76,20 @@ const budgetLineLabel = computed(() => {
     : `${formatCents(chart.budgetedAmount)} budget`
 })
 
-async function fetchBudget() {
-  loading.value = true
+async function fetchBudget(background = false) {
+  if (!background) loading.value = true
   try {
     const month = formatMonth(currentMonth.value)
     budget.value = await apiClient.get<BudgetResponse>(`/api/budget?month=${month}-01`)
   } catch {
     snackbar.enqueueSnackbar('Failed to load budget', { variant: 'error' })
   } finally {
-    loading.value = false
+    if (!background) loading.value = false
   }
 }
 
-async function fetchAccountBalances() {
-  accountLoading.value = true
+async function fetchAccountBalances(background = false) {
+  if (!background) accountLoading.value = true
   try {
     const month = `${formatMonth(currentMonth.value)}-01`
     const params = new URLSearchParams({ month })
@@ -92,7 +97,7 @@ async function fetchAccountBalances() {
   } catch {
     snackbar.enqueueSnackbar('Failed to load account balances', { variant: 'error' })
   } finally {
-    accountLoading.value = false
+    if (!background) accountLoading.value = false
   }
 }
 
@@ -102,15 +107,47 @@ async function fetchCategories() {
   } catch { /* ignore */ }
 }
 
+async function refreshMonthInBackground() {
+  if (realtimeRefreshInFlight) {
+    realtimeRefreshQueued = true
+    return
+  }
+
+  realtimeRefreshInFlight = true
+  try {
+    do {
+      realtimeRefreshQueued = false
+      await Promise.all([fetchBudget(true), fetchAccountBalances(true)])
+    } while (realtimeRefreshQueued)
+  } finally {
+    realtimeRefreshInFlight = false
+  }
+}
+
+const monthUpdatesHub = createMonthUpdatesHubClient(
+  () => authStore.getToken(),
+  (month) => {
+    if (month === formatMonth(currentMonth.value)) {
+      void refreshMonthInBackground()
+    }
+  },
+)
+
 onMounted(() => {
   void fetchBudget()
   void fetchAccountBalances()
   void fetchCategories()
+  void monthUpdatesHub.start(formatMonth(currentMonth.value))
 })
 
 watch(currentMonth, () => {
   void fetchBudget()
   void fetchAccountBalances()
+  void monthUpdatesHub.setMonth(formatMonth(currentMonth.value))
+})
+
+onBeforeUnmount(() => {
+  void monthUpdatesHub.stop()
 })
 
 function onDialogSuccess() {

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { apiClient } from '@/services/apiClient'
 import { useSnackbarStore } from '@/stores/snackbar'
 import type { HistoryItemDto, HistoryItemUpdateRequest, ExpenseCategoryDto, AccountDto } from '@/types'
+import { useAuthStore } from '@/stores/auth'
 import { formatCents, formatMonth } from '@/utils/currency'
 import { useMonthQueryParam } from '@/composables/useMonthQueryParam'
 import { useExternalLinkRules } from '@/utils/externalLinks'
@@ -12,9 +13,11 @@ import MonthPickerNav from '@/components/MonthPickerNav.vue'
 import { useRoute } from 'vue-router'
 import CategorySelector from '@/components/CategorySelector.vue'
 import AddRuleDialog from '@/components/AddRuleDialog.vue'
+import { createMonthUpdatesHubClient } from '@/services/monthUpdatesHub'
 
 const snackbar = useSnackbarStore()
 const route = useRoute()
+const authStore = useAuthStore()
 const { loadExternalLinkRules, externalLinksFor } = useExternalLinkRules()
 
 const { currentMonth } = useMonthQueryParam()
@@ -32,6 +35,8 @@ const deleteItem = ref<HistoryItemDto | null>(null)
 const dialogOpen = ref(false)
 const addRuleOpen = ref(false)
 const ruleSourceItem = ref<HistoryItemDto | null>(null)
+let realtimeRefreshInFlight = false
+let realtimeRefreshQueued = false
 
 const monthLabel = computed(() =>
   currentMonth.value.toLocaleString('default', { month: 'long', year: 'numeric' }),
@@ -70,8 +75,8 @@ async function fetchCategories() {
   } catch { /* ignore */ }
 }
 
-async function fetchHistory() {
-  loading.value = true
+async function fetchHistory(background = false) {
+  if (!background) loading.value = true
   try {
     const month = `${formatMonth(currentMonth.value)}-01`
     const params = new URLSearchParams({ month })
@@ -80,12 +85,12 @@ async function fetchHistory() {
   } catch {
     snackbar.enqueueSnackbar('Failed to load history', { variant: 'error' })
   } finally {
-    loading.value = false
+    if (!background) loading.value = false
   }
 }
 
-async function fetchAccountBalances() {
-  accountLoading.value = true
+async function fetchAccountBalances(background = false) {
+  if (!background) accountLoading.value = true
   try {
     const month = `${formatMonth(currentMonth.value)}-01`
     const params = new URLSearchParams({ month })
@@ -93,9 +98,35 @@ async function fetchAccountBalances() {
   } catch {
     snackbar.enqueueSnackbar('Failed to load account balances', { variant: 'error' })
   } finally {
-    accountLoading.value = false
+    if (!background) accountLoading.value = false
   }
 }
+
+async function refreshMonthInBackground() {
+  if (realtimeRefreshInFlight) {
+    realtimeRefreshQueued = true
+    return
+  }
+
+  realtimeRefreshInFlight = true
+  try {
+    do {
+      realtimeRefreshQueued = false
+      await Promise.all([fetchHistory(true), fetchAccountBalances(true)])
+    } while (realtimeRefreshQueued)
+  } finally {
+    realtimeRefreshInFlight = false
+  }
+}
+
+const monthUpdatesHub = createMonthUpdatesHubClient(
+  () => authStore.getToken(),
+  (month) => {
+    if (month === formatMonth(currentMonth.value)) {
+      void refreshMonthInBackground()
+    }
+  },
+)
 
 async function handleDelete() {
   if (!deleteItem.value) return
@@ -158,14 +189,26 @@ async function saveNotes() {
   }
 }
 
-watch([currentMonth, categoryId], fetchHistory)
-watch(currentMonth, fetchAccountBalances)
+watch([currentMonth, categoryId], () => {
+  void fetchHistory()
+})
+watch(currentMonth, () => {
+  void fetchAccountBalances()
+})
+watch(currentMonth, () => {
+  void monthUpdatesHub.setMonth(formatMonth(currentMonth.value))
+})
+
+onBeforeUnmount(() => {
+  void monthUpdatesHub.stop()
+})
 
 onMounted(() => {
   void fetchCategories()
   void fetchHistory()
   void fetchAccountBalances()
   void loadExternalLinkRules()
+  void monthUpdatesHub.start(formatMonth(currentMonth.value))
 
   const rawCategoryId = route.query.categoryId
   const categoryIdQuery = Array.isArray(rawCategoryId) ? rawCategoryId[0] : rawCategoryId

--- a/SimplyBudgetWeb.Web/src/services/monthUpdatesHub.ts
+++ b/SimplyBudgetWeb.Web/src/services/monthUpdatesHub.ts
@@ -1,0 +1,89 @@
+import { HubConnection, HubConnectionBuilder, LogLevel } from '@microsoft/signalr'
+
+const hubPath = '/hubs/budget-month-updates'
+const monthUpdatedEvent = 'MonthUpdated'
+const subscribeMethod = 'SubscribeToMonth'
+const unsubscribeMethod = 'UnsubscribeFromMonth'
+
+export interface MonthUpdatesHubClient {
+  start(initialMonth: string): Promise<void>
+  setMonth(month: string): Promise<void>
+  stop(): Promise<void>
+}
+
+function getHubUrl(): string {
+  const baseUrl = (__API_BASE_URL__ || '').replace(/\/$/, '')
+  return `${baseUrl}${hubPath}`
+}
+
+export function createMonthUpdatesHubClient(
+  getAccessToken: () => Promise<string>,
+  onMonthUpdated: (month: string) => void | Promise<void>,
+): MonthUpdatesHubClient {
+  let connection: HubConnection | null = null
+  let desiredMonth: string | null = null
+  let activeMonth: string | null = null
+
+  function ensureConnection(): HubConnection {
+    if (connection) return connection
+
+    connection = new HubConnectionBuilder()
+      .withUrl(getHubUrl(), {
+        accessTokenFactory: getAccessToken,
+      })
+      .withAutomaticReconnect()
+      .configureLogging(LogLevel.Warning)
+      .build()
+
+    connection.on(monthUpdatedEvent, (month: string) => {
+      void onMonthUpdated(month)
+    })
+    connection.onreconnected(() => {
+      if (!connection || !desiredMonth) return
+      void connection.invoke(subscribeMethod, desiredMonth)
+      activeMonth = desiredMonth
+    })
+
+    return connection
+  }
+
+  async function setMonth(month: string): Promise<void> {
+    desiredMonth = month
+    if (!connection || connection.state !== 'Connected') return
+
+    if (activeMonth === month) return
+    if (activeMonth) {
+      await connection.invoke(unsubscribeMethod, activeMonth)
+    }
+
+    await connection.invoke(subscribeMethod, month)
+    activeMonth = month
+  }
+
+  async function start(initialMonth: string): Promise<void> {
+    const hubConnection = ensureConnection()
+    desiredMonth = initialMonth
+
+    if (hubConnection.state === 'Disconnected') {
+      await hubConnection.start()
+    }
+
+    await setMonth(initialMonth)
+  }
+
+  async function stop(): Promise<void> {
+    const hubConnection = connection
+    desiredMonth = null
+    activeMonth = null
+    connection = null
+    if (!hubConnection) return
+
+    await hubConnection.stop()
+  }
+
+  return {
+    start,
+    setMonth,
+    stop,
+  }
+}

--- a/SimplyBudgetWeb/Controllers/HistoryController.cs
+++ b/SimplyBudgetWeb/Controllers/HistoryController.cs
@@ -3,14 +3,19 @@ using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
 using SimplyBudgetWeb.Utilities;
 
 namespace SimplyBudgetWeb.Controllers;
 
 [ApiController]
 [Route("api/history")]
-public class HistoryController(BudgetWebContext context) : ControllerBase
+public class HistoryController(
+    BudgetWebContext context,
+    IBudgetMonthUpdateNotifier? budgetMonthUpdateNotifier = null) : ControllerBase
 {
+    private readonly IBudgetMonthUpdateNotifier budgetMonthUpdates = budgetMonthUpdateNotifier ?? NullBudgetMonthUpdateNotifier.Instance;
+
     [HttpGet]
     public async Task<HistoryItemDto[]> GetAll(
         [FromQuery] DateTime? month,
@@ -82,6 +87,7 @@ public class HistoryController(BudgetWebContext context) : ControllerBase
 
         context.ExpenseCategoryItems.Remove(item);
         await context.SaveChangesAsync();
+        await budgetMonthUpdates.NotifyMonthUpdated(item.Date);
         return NoContent();
     }
 

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -15,9 +15,12 @@ namespace SimplyBudgetWeb.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/pending-expenses")]
-public class PendingExpensesController(BudgetWebContext context) : ControllerBase
+public class PendingExpensesController(
+    BudgetWebContext context,
+    IBudgetMonthUpdateNotifier? budgetMonthUpdateNotifier = null) : ControllerBase
 {
     private const string ConcurrencyConflictMessage = "This pending expense was changed by another user. Refresh and try again.";
+    private readonly IBudgetMonthUpdateNotifier budgetMonthUpdates = budgetMonthUpdateNotifier ?? NullBudgetMonthUpdateNotifier.Instance;
 
     [HttpGet]
     public async Task<PendingExpenseDto[]> GetAll(
@@ -250,6 +253,7 @@ public class PendingExpensesController(BudgetWebContext context) : ControllerBas
             return Conflict(ConcurrencyConflictMessage);
         }
 
+        await budgetMonthUpdates.NotifyMonthUpdated(item.Date);
         return StatusCode(201);
     }
 

--- a/SimplyBudgetWeb/Controllers/TransactionsController.cs
+++ b/SimplyBudgetWeb/Controllers/TransactionsController.cs
@@ -1,13 +1,18 @@
 using Microsoft.AspNetCore.Mvc;
 using SimplyBudgetShared.Data;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
 
 namespace SimplyBudgetWeb.Controllers;
 
 [ApiController]
 [Route("api/transactions")]
-public class TransactionsController(BudgetWebContext context) : ControllerBase
+public class TransactionsController(
+    BudgetWebContext context,
+    IBudgetMonthUpdateNotifier? budgetMonthUpdateNotifier = null) : ControllerBase
 {
+    private readonly IBudgetMonthUpdateNotifier budgetMonthUpdates = budgetMonthUpdateNotifier ?? NullBudgetMonthUpdateNotifier.Instance;
+
     [HttpPost("transaction")]
     public async Task<IActionResult> AddTransaction([FromBody] TransactionRequest request)
     {
@@ -22,6 +27,7 @@ public class TransactionsController(BudgetWebContext context) : ControllerBase
             item.Notes = notes;
             await context.SaveChangesAsync();
         }
+        await budgetMonthUpdates.NotifyMonthUpdated(request.Date);
         return StatusCode(201);
     }
 
@@ -39,6 +45,7 @@ public class TransactionsController(BudgetWebContext context) : ControllerBase
             item.Notes = notes;
             await context.SaveChangesAsync();
         }
+        await budgetMonthUpdates.NotifyMonthUpdated(request.Date);
         return StatusCode(201);
     }
 
@@ -52,6 +59,7 @@ public class TransactionsController(BudgetWebContext context) : ControllerBase
         if (toCategory is null) return NotFound($"Category {request.ToCategoryId} not found.");
 
         await context.AddTransfer(request.Description, request.Date, request.Amount, fromCategory, toCategory);
+        await budgetMonthUpdates.NotifyMonthUpdated(request.Date);
         return StatusCode(201);
     }
 

--- a/SimplyBudgetWeb/Hubs/BudgetMonthHub.cs
+++ b/SimplyBudgetWeb/Hubs/BudgetMonthHub.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+
+using Microsoft.AspNetCore.SignalR;
+
+namespace SimplyBudgetWeb.Hubs;
+
+public class BudgetMonthHub : Hub
+{
+    public const string HubPath = "/hubs/budget-month-updates";
+    public const string MonthUpdatedEvent = "MonthUpdated";
+    public const string SubscribeMethod = "SubscribeToMonth";
+    public const string UnsubscribeMethod = "UnsubscribeFromMonth";
+
+    public Task SubscribeToMonth(string month)
+    {
+        var monthKey = NormalizeMonthKey(month);
+        return Groups.AddToGroupAsync(Context.ConnectionId, ToGroupName(monthKey));
+    }
+
+    public Task UnsubscribeFromMonth(string month)
+    {
+        var monthKey = NormalizeMonthKey(month);
+        return Groups.RemoveFromGroupAsync(Context.ConnectionId, ToGroupName(monthKey));
+    }
+
+    public static string ToMonthKey(DateTime date)
+        => date.ToString("yyyy-MM", CultureInfo.InvariantCulture);
+
+    public static string ToGroupName(string monthKey)
+        => $"month:{NormalizeMonthKey(monthKey)}";
+
+    private static string NormalizeMonthKey(string month)
+    {
+        if (string.IsNullOrWhiteSpace(month) ||
+            !DateTime.TryParseExact(month, "yyyy-MM", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedMonth))
+        {
+            throw new HubException("month must be in yyyy-MM format.");
+        }
+
+        return ToMonthKey(parsedMonth);
+    }
+}

--- a/SimplyBudgetWeb/Program.cs
+++ b/SimplyBudgetWeb/Program.cs
@@ -1,7 +1,9 @@
 using SimplyBudgetWeb.Core;
+using SimplyBudgetWeb.Hubs;
 using SimplyBudgetWeb.Middleware;
 using SimplyBudgetWeb.Services;
 
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Identity.Web;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -13,6 +15,7 @@ builder.AddServiceDefaults()
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddSignalR();
 
 // Add CORS for frontend in development
 builder.Services.AddCors(options =>
@@ -40,6 +43,35 @@ builder.Services.AddCors(options =>
 
 // Entra ID authentication via Microsoft.Identity.Web
 builder.Services.AddMicrosoftIdentityWebApiAuthentication(builder.Configuration, "AzureAd");
+builder.Services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+{
+    options.Events ??= new JwtBearerEvents();
+    var existingOnMessageReceived = options.Events.OnMessageReceived;
+
+    options.Events.OnMessageReceived = async context =>
+    {
+        if (existingOnMessageReceived is not null)
+        {
+            await existingOnMessageReceived(context);
+        }
+
+        if (!string.IsNullOrEmpty(context.Token))
+        {
+            return;
+        }
+
+        var accessToken = context.Request.Query["access_token"];
+        if (string.IsNullOrEmpty(accessToken))
+        {
+            return;
+        }
+
+        if (context.HttpContext.Request.Path.StartsWithSegments(BudgetMonthHub.HubPath))
+        {
+            context.Token = accessToken;
+        }
+    };
+});
 
 // Authorization: restrict to the SimplyBudgetUsers Entra security group
 builder.Services.AddAuthorization(options =>
@@ -59,6 +91,7 @@ builder.Services.AddAuthorization(options =>
 });
 
 builder.Services.AddScoped<CurrentUserSyncService>();
+builder.Services.AddScoped<IBudgetMonthUpdateNotifier, BudgetMonthUpdateNotifier>();
 
 var app = builder.Build();
 
@@ -97,6 +130,7 @@ app.UseAuthorization();
 app.UseMiddleware<CurrentUserSyncMiddleware>();
 
 app.MapControllers();
+app.MapHub<BudgetMonthHub>(BudgetMonthHub.HubPath);
 
 if (!app.Environment.IsDevelopment())
 {

--- a/SimplyBudgetWeb/Services/BudgetMonthUpdateNotifier.cs
+++ b/SimplyBudgetWeb/Services/BudgetMonthUpdateNotifier.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.SignalR;
+
+using SimplyBudgetShared.Utilities;
+using SimplyBudgetWeb.Hubs;
+
+namespace SimplyBudgetWeb.Services;
+
+public interface IBudgetMonthUpdateNotifier
+{
+    Task NotifyMonthUpdated(DateTime date, CancellationToken cancellationToken = default);
+    Task NotifyMonthsUpdated(IEnumerable<DateTime> dates, CancellationToken cancellationToken = default);
+}
+
+public sealed class BudgetMonthUpdateNotifier(IHubContext<BudgetMonthHub> hubContext) : IBudgetMonthUpdateNotifier
+{
+    public Task NotifyMonthUpdated(DateTime date, CancellationToken cancellationToken = default)
+        => NotifyMonthsUpdated([date], cancellationToken);
+
+    public async Task NotifyMonthsUpdated(IEnumerable<DateTime> dates, CancellationToken cancellationToken = default)
+    {
+        var months = dates
+            .Select(x => BudgetMonthHub.ToMonthKey(x.StartOfMonth()))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var month in months)
+        {
+            await hubContext.Clients
+                .Group(BudgetMonthHub.ToGroupName(month))
+                .SendAsync(BudgetMonthHub.MonthUpdatedEvent, month, cancellationToken);
+        }
+    }
+}
+
+public sealed class NullBudgetMonthUpdateNotifier : IBudgetMonthUpdateNotifier
+{
+    public static readonly NullBudgetMonthUpdateNotifier Instance = new();
+
+    private NullBudgetMonthUpdateNotifier()
+    {
+    }
+
+    public Task NotifyMonthUpdated(DateTime date, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task NotifyMonthsUpdated(IEnumerable<DateTime> dates, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary
- add a backend SignalR hub that supports month subscriptions and broadcasts month-level update events
- notify subscribed clients after month-changing operations (transactions, history delete, and pending-expense conversion)
- subscribe Budget and History pages to month updates and refresh month data in the background before updating UI
- add controller tests for realtime month notifications

## Validation
- dotnet run --project SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj
- pnpm --dir SimplyBudgetWeb.Web build