### PR TITLE
Allow rules to specify amount ranges

### DIFF
--- a/SimplyBudgetDesktop/ValueConverter/NullableCurrencyValueConverter.cs
+++ b/SimplyBudgetDesktop/ValueConverter/NullableCurrencyValueConverter.cs
@@ -1,0 +1,31 @@
+using SimplyBudgetShared.Utilities;
+using System;
+using System.Globalization;
+
+namespace SimplyBudget.ValueConverter;
+
+/// <summary>
+/// Converts an optional amount (in cents) to/from a currency string, treating an empty
+/// string as "no value" rather than zero.
+/// </summary>
+public class NullableCurrencyValueConverter : MarkupValueConverter<NullableCurrencyValueConverter>
+{
+    // ReSharper disable EmptyConstructor
+    public NullableCurrencyValueConverter() { }
+    // ReSharper restore EmptyConstructor
+
+    public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture)
+        => value is int intValue ? intValue.FormatCurrency() : "";
+
+    public override object? ConvertBack(object? value, Type? targetType, object? parameter, CultureInfo? culture)
+    {
+        var stringValue = value?.ToString();
+        if (string.IsNullOrWhiteSpace(stringValue))
+            return null;
+
+        if (decimal.TryParse(stringValue, NumberStyles.Currency, culture, out var parsed))
+            return (int)decimal.Round(parsed * 100);
+
+        return null;
+    }
+}

--- a/SimplyBudgetDesktop/ViewModels/ExpenseCategoryRuleViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/ExpenseCategoryRuleViewModel.cs
@@ -17,6 +17,12 @@ public partial class ExpenseCategoryRuleViewModel : ObservableObject
     private string? _notes;
 
     [ObservableProperty]
+    private int? _minimumAmount;
+
+    [ObservableProperty]
+    private int? _maximumAmount;
+
+    [ObservableProperty]
     private int? _expenseCategoryId;
 
     public ExpenseCategoryRuleViewModel()
@@ -32,6 +38,8 @@ public partial class ExpenseCategoryRuleViewModel : ObservableObject
         Name = rule.Name;
         RuleRegex = rule.RuleRegex;
         Notes = rule.Notes;
+        MinimumAmount = rule.MinimumAmount;
+        MaximumAmount = rule.MaximumAmount;
         ExpenseCategoryId = rule.ExpenseCategoryID;
     }
 }

--- a/SimplyBudgetDesktop/ViewModels/MainWindowViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/MainWindowViewModel.cs
@@ -132,7 +132,11 @@ public partial class MainWindowViewModel : ObservableObject,
                     var rules = context.ExpenseCategoryRules
                         .Where(x => x.RuleRegex != null && x.ExpenseCategoryID != null)
                         .ToList();
-                    var matchingRule = rules.Where(r => Regex.IsMatch(message.Description ?? "", r.RuleRegex ?? "", RegexOptions.IgnoreCase)).LastOrDefault();
+                    var transactionAmount = message.Items.Sum(x => x.Amount);
+                    var matchingRule = rules
+                        .Where(r => r.IsAmountInRange(transactionAmount) &&
+                                    Regex.IsMatch(message.Description ?? "", r.RuleRegex ?? "", RegexOptions.IgnoreCase))
+                        .LastOrDefault();
                     AddItem.LineItems.Clear();
                     AddItem.LineItems.AddRange(message.Items
                         .Select(x => new LineItemViewModel(AddItem.ExpenseCategories, Messenger)

--- a/SimplyBudgetDesktop/ViewModels/SettingsViewModel.cs
+++ b/SimplyBudgetDesktop/ViewModels/SettingsViewModel.cs
@@ -71,6 +71,8 @@ public partial class SettingsViewModel : CollectionViewModelBase<ExpenseCategory
                     existingRule.Name = ruleViewModel.Name;
                     existingRule.RuleRegex = ruleViewModel.RuleRegex;
                     existingRule.Notes = ruleViewModel.Notes;
+                    existingRule.MinimumAmount = ruleViewModel.MinimumAmount;
+                    existingRule.MaximumAmount = ruleViewModel.MaximumAmount;
                     existingRule.ExpenseCategoryID = ruleViewModel.ExpenseCategoryId;
                 }
                 //TODO Else?
@@ -82,6 +84,8 @@ public partial class SettingsViewModel : CollectionViewModelBase<ExpenseCategory
                     Name = ruleViewModel.Name,
                     RuleRegex = ruleViewModel.RuleRegex,
                     Notes = ruleViewModel.Notes,
+                    MinimumAmount = ruleViewModel.MinimumAmount,
+                    MaximumAmount = ruleViewModel.MaximumAmount,
                     ExpenseCategoryID = ruleViewModel.ExpenseCategoryId
                 };
                 context.ExpenseCategoryRules.Add(rule);

--- a/SimplyBudgetDesktop/Views/SettingsView.xaml
+++ b/SimplyBudgetDesktop/Views/SettingsView.xaml
@@ -6,6 +6,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d" 
              xmlns:vm="clr-namespace:SimplyBudget.ViewModels" xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+             xmlns:valueConverter="clr-namespace:SimplyBudget.ValueConverter"
              d:DataContext="{d:DesignInstance Type={x:Type vm:SettingsViewModel}}"
              d:DesignHeight="450" d:DesignWidth="800">
   <UserControl.Resources>
@@ -79,6 +80,8 @@
         <DataGridTextColumn Header="Name" Binding="{Binding Name}" />
         <DataGridTextColumn Header="Regex Rule" Binding="{Binding RuleRegex}" />
         <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" />
+        <DataGridTextColumn Header="Min Amount" Binding="{Binding MinimumAmount, Converter={valueConverter:NullableCurrencyValueConverter}}" />
+        <DataGridTextColumn Header="Max Amount" Binding="{Binding MaximumAmount, Converter={valueConverter:NullableCurrencyValueConverter}}" />
         <materialDesign:DataGridComboBoxColumn 
             Header="Expense Category" 
             ItemsSourceBinding="{Binding DataContext.ExpenseCategories, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGrid}}"

--- a/SimplyBudgetShared/Data/ExpenseCategoryRule.cs
+++ b/SimplyBudgetShared/Data/ExpenseCategoryRule.cs
@@ -14,6 +14,40 @@ public class ExpenseCategoryRule : BaseItem
     /// </summary>
     public string? Notes { get; set; }
 
+    /// <summary>
+    /// Optional inclusive minimum transaction amount (in cents) required for this rule to match.
+    /// </summary>
+    public int? MinimumAmount { get; set; }
+
+    /// <summary>
+    /// Optional inclusive maximum transaction amount (in cents) required for this rule to match.
+    /// </summary>
+    public int? MaximumAmount { get; set; }
+
     public int? ExpenseCategoryID { get; set; }
     public ExpenseCategory? ExpenseCategory { get; set; }
+
+    /// <summary>
+    /// Checks the (optional) amount range on this rule. Amounts are compared using their
+    /// magnitude so callers do not need to normalize debit/credit signs. When the rule
+    /// specifies a range but the amount is unknown, the rule does not match.
+    /// </summary>
+    public bool IsAmountInRange(int? amount)
+    {
+        if (MinimumAmount is null && MaximumAmount is null)
+            return true;
+
+        if (amount is null)
+            return false;
+
+        var magnitude = Math.Abs(amount.Value);
+
+        if (MinimumAmount is { } min && magnitude < Math.Abs(min))
+            return false;
+
+        if (MaximumAmount is { } max && magnitude > Math.Abs(max))
+            return false;
+
+        return true;
+    }
 }

--- a/SimplyBudgetShared/DataTransfer/BudgetDataExportPackage.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataExportPackage.cs
@@ -63,7 +63,9 @@ public record BudgetDataExportRule(
     string? Name,
     string? RuleRegex,
     int? ExpenseCategoryId,
-    string? Notes = null
+    string? Notes = null,
+    int? MinimumAmount = null,
+    int? MaximumAmount = null
 );
 
 public record BudgetDataExportMetadata(

--- a/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
+++ b/SimplyBudgetShared/DataTransfer/BudgetDataPortabilityService.cs
@@ -55,7 +55,7 @@ public static class BudgetDataPortabilityService
             Rules = await context.ExpenseCategoryRules
                 .AsNoTracking()
                 .OrderBy(x => x.ID)
-                .Select(x => new BudgetDataExportRule(x.ID, x.Name, x.RuleRegex, x.ExpenseCategoryID, x.Notes))
+                .Select(x => new BudgetDataExportRule(x.ID, x.Name, x.RuleRegex, x.ExpenseCategoryID, x.Notes, x.MinimumAmount, x.MaximumAmount))
                 .ToListAsync(cancellationToken),
             Metadata = await context.Metadatas
                 .AsNoTracking()
@@ -198,6 +198,8 @@ public static class BudgetDataPortabilityService
                     Name = x.Name,
                     RuleRegex = x.RuleRegex,
                     Notes = x.Notes,
+                    MinimumAmount = x.MinimumAmount,
+                    MaximumAmount = x.MaximumAmount,
                     ExpenseCategoryID = ResolveOptionalReference(categoryIdMap, x.ExpenseCategoryId, "category")
                 })
                 .ToList();

--- a/SimplyBudgetShared/Migrations/20260901061202_AddExpenseCategoryRuleAmountRange.Designer.cs
+++ b/SimplyBudgetShared/Migrations/20260901061202_AddExpenseCategoryRuleAmountRange.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetShared.Data;
 
@@ -10,9 +11,11 @@ using SimplyBudgetShared.Data;
 namespace SimplyBudgetShared.Migrations
 {
     [DbContext(typeof(BudgetContext))]
-    partial class BudgetContextModelSnapshot : ModelSnapshot
+    [Migration("20260901061202_AddExpenseCategoryRuleAmountRange")]
+    partial class AddExpenseCategoryRuleAmountRange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/SimplyBudgetShared/Migrations/20260901061202_AddExpenseCategoryRuleAmountRange.cs
+++ b/SimplyBudgetShared/Migrations/20260901061202_AddExpenseCategoryRuleAmountRange.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetShared.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExpenseCategoryRuleAmountRange : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaximumAmount",
+                table: "ExpenseCategoryRules",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MinimumAmount",
+                table: "ExpenseCategoryRules",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaximumAmount",
+                table: "ExpenseCategoryRules");
+
+            migrationBuilder.DropColumn(
+                name: "MinimumAmount",
+                table: "ExpenseCategoryRules");
+        }
+    }
+}

--- a/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
+++ b/SimplyBudgetSharedTests/Data/BudgetDataPortabilityServiceTests.cs
@@ -43,6 +43,8 @@ public class BudgetDataPortabilityServiceTests
             Name = "Grocery Rule",
             RuleRegex = "GROCERY",
             Notes = "Local grocery store",
+            MinimumAmount = 10_00,
+            MaximumAmount = 250_00,
             ExpenseCategoryID = groceries.ID
         });
         setupContext.Metadatas.Add(new Metadata { Key = "Version", Value = "test" });
@@ -66,6 +68,8 @@ public class BudgetDataPortabilityServiceTests
         Assert.AreEqual("February salary", exportPackage.Items.Single().Notes);
         Assert.AreEqual("Food and household essentials", exportPackage.Categories.Single().Description);
         Assert.AreEqual("Local grocery store", exportPackage.Rules.Single().Notes);
+        Assert.AreEqual(10_00, exportPackage.Rules.Single().MinimumAmount);
+        Assert.AreEqual(250_00, exportPackage.Rules.Single().MaximumAmount);
     }
 
     [TestMethod]
@@ -107,7 +111,7 @@ public class BudgetDataPortabilityServiceTests
             ],
             Rules =
             [
-                new BudgetDataExportRule(9000, "Market Rule", "MARKET", 100, "Farmers market")
+                new BudgetDataExportRule(9000, "Market Rule", "MARKET", 100, "Farmers market", 5_00, 75_00)
             ],
             Metadata =
             [
@@ -146,6 +150,8 @@ public class BudgetDataPortabilityServiceTests
         Assert.AreEqual(1, rules.Count);
         Assert.AreEqual("Groceries", rules[0].ExpenseCategory?.Name);
         Assert.AreEqual("Farmers market", rules[0].Notes);
+        Assert.AreEqual(5_00, rules[0].MinimumAmount);
+        Assert.AreEqual(75_00, rules[0].MaximumAmount);
 
         Assert.AreEqual(1, await assertContext.Metadatas.CountAsync());
         Assert.AreEqual(2, await assertContext.ExpenseCategoryItems.CountAsync());

--- a/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ImportControllerTests.cs
@@ -186,6 +186,47 @@ public class ImportControllerTests
     }
 
     [Test]
+    public async Task Save_WithAmountRangeRule_OnlyAppliesRuleWithinRange()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Gas" };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryRules.Add(new ExpenseCategoryRule
+            {
+                Name = "Small Costco purchases",
+                RuleRegex = "Costco",
+                ExpenseCategoryID = category.ID,
+                MinimumAmount = 10_00,
+                MaximumAmount = 50_00
+            });
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ImportController(context);
+
+        var items = new[]
+        {
+            new ImportItemDto(new DateTime(2026, 1, 1), "Costco", 45_00, true, true),
+            new ImportItemDto(new DateTime(2026, 1, 2), "Costco", 250_00, true, true),
+        };
+
+        var result = await controller.Save(items);
+
+        await Assert.That(((StatusCodeResult)result).StatusCode).IsEqualTo(201);
+        var saved = await context.PendingExpenses.OrderBy(x => x.Date).ToListAsync();
+        await Assert.That(saved[0].SuggestedCategoryId).IsEqualTo(categoryId);
+        await Assert.That(saved[1].SuggestedCategoryId).IsNull();
+    }
+
+    [Test]
     public async Task Save_CreditItem_DoesNotApplySuggestedCategoryRule()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Core.Tests/Controllers/RulesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/RulesControllerTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SimplyBudgetShared.Data;
+using SimplyBudgetWeb.Controllers;
+using SimplyBudgetWeb.Data;
+
+namespace SimplyBudgetWeb.Core.Tests.Controllers;
+
+public class RulesControllerTests
+{
+    [Test]
+    public async Task Create_PersistsAmountRange()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new RulesController(context);
+            var result = await controller.Create(new RuleRequest(
+                "Costco",
+                "Costco",
+                ExpenseCategoryId: null,
+                Notes: null,
+                MinimumAmount: 10_00,
+                MaximumAmount: 50_00));
+
+            await Assert.That(result.Result).IsTypeOf<CreatedAtActionResult>();
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var rule = await context.ExpenseCategoryRules.SingleAsync();
+            await Assert.That(rule.MinimumAmount).IsEqualTo(10_00);
+            await Assert.That(rule.MaximumAmount).IsEqualTo(50_00);
+        });
+    }
+
+    [Test]
+    public async Task Create_WithMinimumGreaterThanMaximum_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new RulesController(context);
+
+        var result = await controller.Create(new RuleRequest(
+            "Costco",
+            "Costco",
+            ExpenseCategoryId: null,
+            Notes: null,
+            MinimumAmount: 50_00,
+            MaximumAmount: 10_00));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+        await Assert.That(await context.ExpenseCategoryRules.AnyAsync()).IsFalse();
+    }
+
+    [Test]
+    public async Task Create_WithNegativeAmount_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new RulesController(context);
+
+        var result = await controller.Create(new RuleRequest(
+            "Costco",
+            "Costco",
+            ExpenseCategoryId: null,
+            Notes: null,
+            MinimumAmount: -1));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+    }
+
+    [Test]
+    public async Task Update_ChangesAmountRange()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int ruleId = await mocker.InDbScopeAsync(async context =>
+        {
+            var rule = new ExpenseCategoryRule
+            {
+                Name = "Costco",
+                RuleRegex = "Costco",
+                MinimumAmount = 10_00,
+                MaximumAmount = 50_00
+            };
+            context.ExpenseCategoryRules.Add(rule);
+            await context.SaveChangesAsync();
+            return rule.ID;
+        });
+
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new RulesController(context);
+            var result = await controller.Update(ruleId, new RuleRequest(
+                "Costco",
+                "Costco",
+                ExpenseCategoryId: null,
+                Notes: null,
+                MinimumAmount: null,
+                MaximumAmount: 100_00));
+
+            await Assert.That(result.Value!.MinimumAmount).IsNull();
+            await Assert.That(result.Value!.MaximumAmount).IsEqualTo(100_00);
+        }
+    }
+
+    [Test]
+    public async Task Update_WithMinimumGreaterThanMaximum_ReturnsBadRequest()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int ruleId = await mocker.InDbScopeAsync(async context =>
+        {
+            var rule = new ExpenseCategoryRule { Name = "Costco", RuleRegex = "Costco" };
+            context.ExpenseCategoryRules.Add(rule);
+            await context.SaveChangesAsync();
+            return rule.ID;
+        });
+
+        using var updateContext = mocker.Get<BudgetWebContext>();
+        var updateController = new RulesController(updateContext);
+
+        var badResult = await updateController.Update(ruleId, new RuleRequest(
+            "Costco",
+            "Costco",
+            ExpenseCategoryId: null,
+            Notes: null,
+            MinimumAmount: 50_00,
+            MaximumAmount: 10_00));
+
+        await Assert.That(badResult.Result).IsTypeOf<BadRequestObjectResult>();
+    }
+}

--- a/SimplyBudgetWeb.Core.Tests/Services/ExpenseCategoryRuleMatcherTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Services/ExpenseCategoryRuleMatcherTests.cs
@@ -122,4 +122,111 @@ public class ExpenseCategoryRuleMatcherTests
         await Assert.That(result.SuggestedCategoryId).IsEqualTo(42);
         await Assert.That(result.Notes).IsNull();
     }
+
+    [Test]
+    public async Task Match_WhenAmountBelowMinimum_RuleDoesNotMatch()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule
+            {
+                RuleRegex = "Costco",
+                ExpenseCategoryID = 42,
+                MinimumAmount = 5000
+            }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "Costco gas", isTransaction: true, amount: 4999);
+
+        await Assert.That(result.SuggestedCategoryId).IsNull();
+    }
+
+    [Test]
+    public async Task Match_WhenAmountAboveMaximum_RuleDoesNotMatch()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule
+            {
+                RuleRegex = "Costco",
+                ExpenseCategoryID = 42,
+                MaximumAmount = 5000
+            }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "Costco gas", isTransaction: true, amount: 5001);
+
+        await Assert.That(result.SuggestedCategoryId).IsNull();
+    }
+
+    [Test]
+    [Arguments(1000)]
+    [Arguments(5000)]
+    [Arguments(2500)]
+    public async Task Match_WhenAmountWithinInclusiveRange_RuleMatches(int amount)
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule
+            {
+                RuleRegex = "Costco",
+                ExpenseCategoryID = 42,
+                Notes = "Warehouse club",
+                MinimumAmount = 1000,
+                MaximumAmount = 5000
+            }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "Costco gas", isTransaction: true, amount: amount);
+
+        await Assert.That(result.SuggestedCategoryId).IsEqualTo(42);
+        await Assert.That(result.Notes).IsEqualTo("Warehouse club");
+    }
+
+    [Test]
+    public async Task Match_WhenAmountIsNegative_UsesMagnitudeForRange()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule
+            {
+                RuleRegex = "Costco",
+                ExpenseCategoryID = 42,
+                MinimumAmount = 1000,
+                MaximumAmount = 5000
+            }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "Costco gas", isTransaction: true, amount: -2500);
+
+        await Assert.That(result.SuggestedCategoryId).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Match_WhenRuleHasRangeAndAmountUnknown_RuleDoesNotMatch()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule { RuleRegex = "Costco", ExpenseCategoryID = 42, MinimumAmount = 1000 },
+            new ExpenseCategoryRule { RuleRegex = "Costco", ExpenseCategoryID = 7 }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "Costco gas", isTransaction: true);
+
+        await Assert.That(result.SuggestedCategoryId).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task Match_WhenRangedRuleExcluded_FallsBackToEarlierMatchingRule()
+    {
+        List<ExpenseCategoryRule> rules =
+        [
+            new ExpenseCategoryRule { RuleRegex = "Costco", ExpenseCategoryID = 7 },
+            new ExpenseCategoryRule { RuleRegex = "Costco", ExpenseCategoryID = 42, MinimumAmount = 10000 }
+        ];
+
+        var result = ExpenseCategoryRuleMatcher.Match(rules, "Costco gas", isTransaction: true, amount: 2500);
+
+        await Assert.That(result.SuggestedCategoryId).IsEqualTo(7);
+    }
 }

--- a/SimplyBudgetWeb.Data/Migrations/20260901061152_AddExpenseCategoryRuleAmountRange.Designer.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260901061152_AddExpenseCategoryRuleAmountRange.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SimplyBudgetWeb.Data;
 
@@ -11,9 +12,11 @@ using SimplyBudgetWeb.Data;
 namespace SimplyBudgetWeb.Data.Migrations
 {
     [DbContext(typeof(BudgetWebContext))]
-    partial class BudgetWebContextModelSnapshot : ModelSnapshot
+    [Migration("20260901061152_AddExpenseCategoryRuleAmountRange")]
+    partial class AddExpenseCategoryRuleAmountRange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SimplyBudgetWeb.Data/Migrations/20260901061152_AddExpenseCategoryRuleAmountRange.cs
+++ b/SimplyBudgetWeb.Data/Migrations/20260901061152_AddExpenseCategoryRuleAmountRange.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SimplyBudgetWeb.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExpenseCategoryRuleAmountRange : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaximumAmount",
+                schema: "SimplyBudget",
+                table: "ExpenseCategoryRules",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MinimumAmount",
+                schema: "SimplyBudget",
+                table: "ExpenseCategoryRules",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaximumAmount",
+                schema: "SimplyBudget",
+                table: "ExpenseCategoryRules");
+
+            migrationBuilder.DropColumn(
+                name: "MinimumAmount",
+                schema: "SimplyBudget",
+                table: "ExpenseCategoryRules");
+        }
+    }
+}

--- a/SimplyBudgetWeb.Web/src/components/AddRuleDialog.vue
+++ b/SimplyBudgetWeb.Web/src/components/AddRuleDialog.vue
@@ -20,13 +20,23 @@ const emit = defineEmits<{
 
 const snackbar = useSnackbarStore()
 const saving = ref(false)
-const form = ref({ name: '', ruleRegex: '', notes: '', expenseCategoryId: null as number | null })
+const form = ref({ name: '', ruleRegex: '', notes: '', minimumAmount: '', maximumAmount: '', expenseCategoryId: null as number | null })
+
+/** Converts a dollars text field into cents, treating blank input as "no limit". */
+function optionalDollarsToCents(value: string): number | null {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+  const parsed = Number.parseFloat(trimmed)
+  return Number.isNaN(parsed) ? null : Math.round(parsed * 100)
+}
 
 function resetForm() {
   form.value = {
     name: '',
     ruleRegex: props.description ?? '',
     notes: props.notes ?? '',
+    minimumAmount: '',
+    maximumAmount: '',
     expenseCategoryId: props.expenseCategoryId ?? null,
   }
 }
@@ -52,6 +62,8 @@ async function handleAdd() {
       name: form.value.name,
       ruleRegex: form.value.ruleRegex,
       notes: notes.length > 0 ? notes : null,
+      minimumAmount: optionalDollarsToCents(form.value.minimumAmount),
+      maximumAmount: optionalDollarsToCents(form.value.maximumAmount),
       expenseCategoryId: form.value.expenseCategoryId,
     })
     snackbar.enqueueSnackbar('Rule added', { variant: 'success' })
@@ -80,6 +92,24 @@ async function handleAdd() {
           persistent-hint
           v-model="form.notes"
         />
+        <div class="d-flex" style="gap: 16px;">
+          <v-text-field
+            label="Min Amount"
+            type="number"
+            prefix="$"
+            hint="Optional. Only match amounts at or above this."
+            persistent-hint
+            v-model="form.minimumAmount"
+          />
+          <v-text-field
+            label="Max Amount"
+            type="number"
+            prefix="$"
+            hint="Optional. Only match amounts at or below this."
+            persistent-hint
+            v-model="form.maximumAmount"
+          />
+        </div>
         <CategorySelector
           label="Target Category"
           :categories="categories"

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -11,7 +11,7 @@ import type {
   CalculatorTaxOptionsDto,
   CurrentUserDto,
 } from '@/types'
-import { formatCents } from '@/utils/currency'
+import { formatCents, centsToDollars } from '@/utils/currency'
 import { resetExternalLinkRulesCache } from '@/utils/externalLinks'
 import CategorySelector from '@/components/CategorySelector.vue'
 
@@ -58,7 +58,23 @@ const rulesLoaded = ref(false)
 const addRuleOpen = ref(false)
 const deleteRule = ref<RuleDto | null>(null)
 const editRule = ref<RuleDto | null>(null)
-const ruleForm = ref({ name: '', ruleRegex: '', notes: '', expenseCategoryId: null as number | null })
+const ruleForm = ref({ name: '', ruleRegex: '', notes: '', minimumAmount: '', maximumAmount: '', expenseCategoryId: null as number | null })
+
+/** Converts a dollars text field into cents, treating blank input as "no limit". */
+function optionalDollarsToCents(value: string): number | null {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+  const parsed = Number.parseFloat(trimmed)
+  return Number.isNaN(parsed) ? null : Math.round(parsed * 100)
+}
+
+function ruleAmountRangeText(rule: RuleDto): string | null {
+  if (rule.minimumAmount === null && rule.maximumAmount === null) return null
+  if (rule.minimumAmount !== null && rule.maximumAmount !== null)
+    return `${formatCents(rule.minimumAmount)} – ${formatCents(rule.maximumAmount)}`
+  if (rule.minimumAmount !== null) return `at least ${formatCents(rule.minimumAmount)}`
+  return `at most ${formatCents(rule.maximumAmount as number)}`
+}
 
 const externalLinks = ref<ExternalLinkRuleDto[]>([])
 const externalLinksLoading = ref(false)
@@ -331,7 +347,7 @@ async function fetchRuleCategories() {
 }
 
 function resetRuleForm() {
-  ruleForm.value = { name: '', ruleRegex: '', notes: '', expenseCategoryId: null }
+  ruleForm.value = { name: '', ruleRegex: '', notes: '', minimumAmount: '', maximumAmount: '', expenseCategoryId: null }
 }
 
 function openAddRule() {
@@ -345,6 +361,8 @@ function openEditRule(rule: RuleDto) {
     name: rule.name ?? '',
     ruleRegex: rule.ruleRegex ?? '',
     notes: rule.notes ?? '',
+    minimumAmount: rule.minimumAmount !== null ? centsToDollars(rule.minimumAmount) : '',
+    maximumAmount: rule.maximumAmount !== null ? centsToDollars(rule.maximumAmount) : '',
     expenseCategoryId: rule.expenseCategoryId ?? null,
   }
 }
@@ -355,6 +373,8 @@ async function handleAddRule() {
       name: ruleForm.value.name,
       ruleRegex: ruleForm.value.ruleRegex,
       notes: ruleForm.value.notes,
+      minimumAmount: optionalDollarsToCents(ruleForm.value.minimumAmount),
+      maximumAmount: optionalDollarsToCents(ruleForm.value.maximumAmount),
       expenseCategoryId: ruleForm.value.expenseCategoryId,
     })
     snackbar.enqueueSnackbar('Rule added', { variant: 'success' })
@@ -373,6 +393,8 @@ async function handleEditRule() {
       name: ruleForm.value.name,
       ruleRegex: ruleForm.value.ruleRegex,
       notes: ruleForm.value.notes,
+      minimumAmount: optionalDollarsToCents(ruleForm.value.minimumAmount),
+      maximumAmount: optionalDollarsToCents(ruleForm.value.maximumAmount),
       expenseCategoryId: ruleForm.value.expenseCategoryId,
     })
     snackbar.enqueueSnackbar('Rule updated', { variant: 'success' })
@@ -771,6 +793,7 @@ watch(openPanel, (panel) => {
                   <v-list-item-title>{{ rule.name }}</v-list-item-title>
                   <v-list-item-subtitle>Pattern: {{ rule.ruleRegex ?? '—' }}</v-list-item-subtitle>
                   <v-list-item-subtitle v-if="rule.notes">Notes: {{ rule.notes }}</v-list-item-subtitle>
+                  <v-list-item-subtitle v-if="ruleAmountRangeText(rule)">Amount: {{ ruleAmountRangeText(rule) }}</v-list-item-subtitle>
                   <template #append>
                     <div class="d-flex" style="gap: 4px;">
                       <v-btn icon="mdi-pencil" variant="text" aria-label="Edit rule" @click="openEditRule(rule)" />
@@ -949,6 +972,24 @@ watch(openPanel, (panel) => {
             persistent-hint
             v-model="ruleForm.notes"
           />
+          <div class="d-flex" style="gap: 16px;">
+            <v-text-field
+              label="Min Amount"
+              type="number"
+              prefix="$"
+              hint="Optional. Only match amounts at or above this."
+              persistent-hint
+              v-model="ruleForm.minimumAmount"
+            />
+            <v-text-field
+              label="Max Amount"
+              type="number"
+              prefix="$"
+              hint="Optional. Only match amounts at or below this."
+              persistent-hint
+              v-model="ruleForm.maximumAmount"
+            />
+          </div>
           <CategorySelector
             label="Target Category"
             :categories="categories"
@@ -979,6 +1020,24 @@ watch(openPanel, (panel) => {
             persistent-hint
             v-model="ruleForm.notes"
           />
+          <div class="d-flex" style="gap: 16px;">
+            <v-text-field
+              label="Min Amount"
+              type="number"
+              prefix="$"
+              hint="Optional. Only match amounts at or above this."
+              persistent-hint
+              v-model="ruleForm.minimumAmount"
+            />
+            <v-text-field
+              label="Max Amount"
+              type="number"
+              prefix="$"
+              hint="Optional. Only match amounts at or below this."
+              persistent-hint
+              v-model="ruleForm.maximumAmount"
+            />
+          </div>
           <CategorySelector
             label="Category"
             :categories="categories"

--- a/SimplyBudgetWeb.Web/src/types/index.ts
+++ b/SimplyBudgetWeb.Web/src/types/index.ts
@@ -91,6 +91,8 @@ export interface RuleDto {
   name: string | null
   ruleRegex: string | null
   notes: string | null
+  minimumAmount: number | null
+  maximumAmount: number | null
   expenseCategoryId: number | null
   categoryName: string | null
 }
@@ -245,6 +247,8 @@ export interface BudgetDataExportRuleDto {
   ruleRegex: string | null
   expenseCategoryId: number | null
   notes: string | null
+  minimumAmount: number | null
+  maximumAmount: number | null
 }
 
 export interface BudgetDataExportMetadataDto {

--- a/SimplyBudgetWeb/Controllers/ImportController.cs
+++ b/SimplyBudgetWeb/Controllers/ImportController.cs
@@ -109,7 +109,8 @@ public class ImportController(BudgetWebContext context) : ControllerBase
                 var match = ExpenseCategoryRuleMatcher.Match(
                     rules,
                     i.Description,
-                    isTransaction: i.IsDebit);
+                    isTransaction: i.IsDebit,
+                    amount: i.Amount);
                 return new PendingExpense
                 {
                     Date = i.Date,

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -196,7 +196,8 @@ public class PendingExpensesController(
             var match = ExpenseCategoryRuleMatcher.Match(
                 rules,
                 pendingExpense.Description,
-                isTransaction: pendingExpense.IsDebit);
+                isTransaction: pendingExpense.IsDebit,
+                amount: pendingExpense.Amount);
 
             pendingExpense.SuggestedCategoryId = match.SuggestedCategoryId;
 

--- a/SimplyBudgetWeb/Controllers/RulesController.cs
+++ b/SimplyBudgetWeb/Controllers/RulesController.cs
@@ -21,11 +21,16 @@ public class RulesController(BudgetWebContext context) : ControllerBase
     [HttpPost]
     public async Task<ActionResult<RuleDto>> Create([FromBody] RuleRequest request)
     {
+        if (ValidateAmountRange(request) is { } error)
+            return BadRequest(error);
+
         var rule = new ExpenseCategoryRule
         {
             Name = request.Name,
             RuleRegex = request.RuleRegex,
             Notes = request.Notes,
+            MinimumAmount = request.MinimumAmount,
+            MaximumAmount = request.MaximumAmount,
             ExpenseCategoryID = request.ExpenseCategoryId,
         };
         context.ExpenseCategoryRules.Add(rule);
@@ -41,9 +46,14 @@ public class RulesController(BudgetWebContext context) : ControllerBase
             .FirstOrDefaultAsync(r => r.ID == id);
         if (rule is null) return NotFound();
 
+        if (ValidateAmountRange(request) is { } error)
+            return BadRequest(error);
+
         rule.Name = request.Name;
         rule.RuleRegex = request.RuleRegex;
         rule.Notes = request.Notes;
+        rule.MinimumAmount = request.MinimumAmount;
+        rule.MaximumAmount = request.MaximumAmount;
         rule.ExpenseCategoryID = request.ExpenseCategoryId;
 
         await context.SaveChangesAsync();
@@ -61,11 +71,28 @@ public class RulesController(BudgetWebContext context) : ControllerBase
         return NoContent();
     }
 
+    /// <summary>
+    /// Amount ranges are optional, but when supplied they must be non-negative and
+    /// the minimum must not exceed the maximum.
+    /// </summary>
+    private static string? ValidateAmountRange(RuleRequest request)
+    {
+        if (request.MinimumAmount < 0 || request.MaximumAmount < 0)
+            return "Amount range values cannot be negative.";
+
+        if (request.MinimumAmount is { } min && request.MaximumAmount is { } max && min > max)
+            return "Minimum amount cannot be greater than maximum amount.";
+
+        return null;
+    }
+
     private static RuleDto ToDto(ExpenseCategoryRule r) => new(
         Id: r.ID,
         Name: r.Name,
         RuleRegex: r.RuleRegex,
         Notes: r.Notes,
+        MinimumAmount: r.MinimumAmount,
+        MaximumAmount: r.MaximumAmount,
         ExpenseCategoryId: r.ExpenseCategoryID,
         CategoryName: r.ExpenseCategory?.Name
     );
@@ -76,8 +103,16 @@ public record RuleDto(
     string? Name,
     string? RuleRegex,
     string? Notes,
+    int? MinimumAmount,
+    int? MaximumAmount,
     int? ExpenseCategoryId,
     string? CategoryName
 );
 
-public record RuleRequest(string? Name, string? RuleRegex, int? ExpenseCategoryId, string? Notes = null);
+public record RuleRequest(
+    string? Name,
+    string? RuleRegex,
+    int? ExpenseCategoryId,
+    string? Notes = null,
+    int? MinimumAmount = null,
+    int? MaximumAmount = null);

--- a/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatcher.cs
+++ b/SimplyBudgetWeb/Services/ExpenseCategoryRuleMatcher.cs
@@ -5,17 +5,23 @@ namespace SimplyBudgetWeb.Services;
 
 public static class ExpenseCategoryRuleMatcher
 {
-    public static int? GetSuggestedCategoryId(IEnumerable<ExpenseCategoryRule> rules, string? description, bool isTransaction)
-        => Match(rules, description, isTransaction).SuggestedCategoryId;
+    public static int? GetSuggestedCategoryId(IEnumerable<ExpenseCategoryRule> rules, string? description, bool isTransaction, int? amount = null)
+        => Match(rules, description, isTransaction, amount).SuggestedCategoryId;
 
     /// <summary>
-    /// Applies the rules to a transaction description. A rule matches on its regex alone, so a
-    /// rule may contribute notes without setting an expense category (and vice versa).
+    /// Applies the rules to a transaction description. A rule matches on its regex (and optional
+    /// amount range) alone, so a rule may contribute notes without setting an expense category
+    /// (and vice versa).
     /// </summary>
+    /// <param name="amount">
+    /// The transaction amount in cents, used to evaluate rules that specify an amount range.
+    /// Rules with an amount range never match when the amount is unknown.
+    /// </param>
     public static ExpenseCategoryRuleMatchResult Match(
         IEnumerable<ExpenseCategoryRule> rules,
         string? description,
-        bool isTransaction)
+        bool isTransaction,
+        int? amount = null)
     {
         if (!isTransaction)
             return ExpenseCategoryRuleMatchResult.None;
@@ -27,6 +33,9 @@ public static class ExpenseCategoryRuleMatcher
         foreach (var rule in rules)
         {
             if (string.IsNullOrWhiteSpace(rule.RuleRegex))
+                continue;
+
+            if (!rule.IsAmountInRange(amount))
                 continue;
 
             if (!Regex.IsMatch(descriptionToMatch, rule.RuleRegex, RegexOptions.IgnoreCase))


### PR DESCRIPTION
Expense category rules can now specify an optional minimum and/or maximum amount, so a rule only applies when the transaction amount falls inside that range.

## Changes
- `ExpenseCategoryRule` gains `MinimumAmount`/`MaximumAmount` (cents) plus an `IsAmountInRange` helper (inclusive, compared by magnitude; a rule with a range never matches when the amount is unknown). Migrations added for both the SQLite (desktop) and SQL Server (web) contexts.
- `ExpenseCategoryRuleMatcher.Match`/`GetSuggestedCategoryId` accept the transaction amount; CSV import and pending expense rule re-application pass it through.
- Rules API round-trips the range and rejects negative values or a minimum greater than the maximum.
- Web UI: min/max fields in the add/edit rule dialogs (Settings) and the `AddRuleDialog` used from History/Pending Expenses, plus an amount summary in the rules list.
- Desktop: new Min/Max Amount columns in the settings grid (with a nullable currency converter) and amount-aware rule matching when adding a transaction.
- Data export/import carries the range.

## Testing
- `dotnet test` SimplyBudgetWeb.Core.Tests (126 passed) and SimplyBudgetSharedTests (61 passed)
- `npm run build` and `npm run lint` in SimplyBudgetWeb.Web
- `dotnet ef migrations has-pending-model-changes` reports no pending changes

Fixes #201
