### PR TITLE
Fix budget category amounts being clipped to one line

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/Budget.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Budget.vue
@@ -237,9 +237,9 @@ function openCategoryHistory(category: BudgetCategoryDto) {
                 class="border-b category-clickable-row"
                 @click="openCategoryHistory(cat)"
               >
-                <v-list-item-subtitle>
+                <div class="budget-category-content">
                   <div class="budget-category-name mb-1">{{ cat.name ?? '(unnamed)' }}</div>
-                  <div v-if="cat.description" class="mb-1">{{ cat.description }}</div>
+                  <div v-if="cat.description" class="budget-category-description mb-1">{{ cat.description }}</div>
                   <div class="budget-chip-row d-flex flex-wrap mt-1" style="gap: 4px;">
                     <v-chip size="small">Budget: {{ cat.usePercentage ? `${cat.budgetedPercentage}%` : formatCents(cat.budgetedAmount) }}</v-chip>
                     <v-chip size="small" color="error" variant="outlined">Spent: {{ formatCents(cat.monthlyExpenses) }}</v-chip>
@@ -248,7 +248,7 @@ function openCategoryHistory(category: BudgetCategoryDto) {
                     <v-chip size="small" variant="outlined" class="avg-spend-chip">6mo avg: {{ formatCents(cat.sixMonthAverage) }}</v-chip>
                     <v-chip size="small" variant="outlined" class="avg-spend-chip">12mo avg: {{ formatCents(cat.twelveMonthAverage) }}</v-chip>
                   </div>
-                </v-list-item-subtitle>
+                </div>
                 <template #append>
                   <v-btn
                     icon="mdi-chart-bar"
@@ -339,11 +339,22 @@ function openCategoryHistory(category: BudgetCategoryDto) {
   cursor: pointer;
 }
 
+.budget-category-content {
+  white-space: normal;
+  overflow: visible;
+}
+
 .budget-category-name {
   font-size: 0.8125rem;
   font-weight: 600;
   line-height: 1.25rem;
   color: rgba(var(--v-theme-on-surface), 0.87);
+}
+
+.budget-category-description {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: rgba(var(--v-theme-on-surface), 0.6);
 }
 
 .expense-chart {


### PR DESCRIPTION
Fixes the budget screen no longer showing amounts for each expense category.

## Problem
After #235 the category rows only rendered a truncated name (e.g. `Charitable Giving...`). The description and the Budget / Spent / Balance / 3mo / 6mo / 12mo average chips were all invisible.

## Cause
#235 removed `<v-list-item-title>` and moved the category name inside `<v-list-item-subtitle>`. Without a title, the `<v-list>` default `lines: "one"` applies `v-list--one-line`, which sets `-webkit-line-clamp: 1` plus `text-overflow: ellipsis` on `.v-list-item-subtitle`. That clamped the name, description, and the entire chip row into a single ellipsized line.

## Fix
Render the category name, description, and chip row in the list item's default slot (a plain `div`) instead of inside `v-list-item-subtitle`, so nothing is clamped. Kept the emphasized name styling and existing chip behavior (including red coloring for negative balances) from #235, and added a `.budget-category-description` class to preserve the previous muted subtitle look.

## Validation
- `pnpm run build` (vue-tsc + vite) passes
- `pnpm run lint` passes
