### PR TITLE
Add expense category creation to settings

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
@@ -83,6 +83,173 @@ public class ExpenseCategoriesControllerTests
     }
 
     [Test]
+    public async Task Create_AddsCategoryWithFixedBudget()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            await context.SetAsDefaultAsync(new Account { Name = "Checking" });
+            await context.SaveChangesAsync();
+        });
+
+        int createdId;
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new ExpenseCategoriesController(context);
+
+            var result = await controller.Create(new ExpenseCategoryRequest(
+                Name: "  Groceries  ", Description: "Food", CategoryName: "Living",
+                BudgetedAmount: 5000, BudgetedPercentage: 0, Cap: null, AccountId: null));
+
+            var created = result.Result as CreatedAtActionResult;
+            await Assert.That(created).IsNotNull();
+            var dto = (ExpenseCategoryDto)created!.Value!;
+            await Assert.That(dto.Name).IsEqualTo("Groceries");
+            await Assert.That(dto.BudgetedAmount).IsEqualTo(5000);
+            await Assert.That(dto.UsePercentage).IsFalse();
+            createdId = dto.Id;
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var stored = await context.ExpenseCategories.FindAsync(createdId);
+            await Assert.That(stored).IsNotNull();
+            await Assert.That(stored!.CategoryName).IsEqualTo("Living");
+            await Assert.That(stored.Description).IsEqualTo("Food");
+        });
+    }
+
+    [Test]
+    public async Task Create_AddsCategoryWithPercentageBudget()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            await context.SetAsDefaultAsync(new Account { Name = "Checking" });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Create(new ExpenseCategoryRequest(
+            Name: "Savings", Description: null, CategoryName: null,
+            BudgetedAmount: 0, BudgetedPercentage: 15, Cap: null, AccountId: null));
+
+        var created = result.Result as CreatedAtActionResult;
+        await Assert.That(created).IsNotNull();
+        var dto = (ExpenseCategoryDto)created!.Value!;
+        await Assert.That(dto.BudgetedPercentage).IsEqualTo(15);
+        await Assert.That(dto.UsePercentage).IsTrue();
+    }
+
+    [Test]
+    public async Task Create_AssignsDefaultAccount_WhenAccountIsNotSpecified()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int defaultAccountId = await mocker.InDbScopeAsync(async context =>
+        {
+            var other = new Account { Name = "Savings" };
+            var defaultAccount = new Account { Name = "Checking" };
+            context.Accounts.Add(other);
+            await context.SetAsDefaultAsync(defaultAccount);
+            await context.SaveChangesAsync();
+            return defaultAccount.ID;
+        });
+
+        int createdId;
+        using (var context = mocker.Get<BudgetWebContext>())
+        {
+            var controller = new ExpenseCategoriesController(context);
+            var result = await controller.Create(new ExpenseCategoryRequest(
+                Name: "Groceries", Description: null, CategoryName: null,
+                BudgetedAmount: 100, BudgetedPercentage: 0, Cap: null, AccountId: null));
+
+            var created = result.Result as CreatedAtActionResult;
+            await Assert.That(created).IsNotNull();
+            createdId = ((ExpenseCategoryDto)created!.Value!).Id;
+        }
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var stored = await context.ExpenseCategories.FindAsync(createdId);
+            await Assert.That(stored!.AccountID).IsEqualTo(defaultAccountId);
+        });
+    }
+
+    [Test]
+    public async Task Create_ReturnsBadRequest_WhenNameIsBlank()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Create(new ExpenseCategoryRequest(
+            Name: "   ", Description: null, CategoryName: null,
+            BudgetedAmount: 0, BudgetedPercentage: 0, Cap: null, AccountId: null));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+        await Assert.That(await context.ExpenseCategories.CountAsync()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Create_ReturnsBadRequest_WhenPercentageIsOutOfRange()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Create(new ExpenseCategoryRequest(
+            Name: "Savings", Description: null, CategoryName: null,
+            BudgetedAmount: 0, BudgetedPercentage: 150, Cap: null, AccountId: null));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+        await Assert.That(await context.ExpenseCategories.CountAsync()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Create_ReturnsBadRequest_WhenBothAmountAndPercentageAreSet()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Create(new ExpenseCategoryRequest(
+            Name: "Savings", Description: null, CategoryName: null,
+            BudgetedAmount: 100, BudgetedPercentage: 10, Cap: null, AccountId: null));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+    }
+
+    [Test]
+    public async Task Create_ReturnsBadRequest_WhenAccountDoesNotExist()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Create(new ExpenseCategoryRequest(
+            Name: "Groceries", Description: null, CategoryName: null,
+            BudgetedAmount: 100, BudgetedPercentage: 0, Cap: null, AccountId: 9999));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+    }
+
+    [Test]
     public async Task Update_RenamesCategory()
     {
         AutoMocker mocker = new();

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -151,6 +151,17 @@ const editCategoryForm = ref({
   budgetedPercentage: '0',
 })
 const deleteCategory = ref<ExpenseCategoryDto | null>(null)
+const addCategoryOpen = ref(false)
+const addCategorySaving = ref(false)
+const newCategoryForm = ref({
+  name: '',
+  description: '',
+  categoryName: '',
+  budgetType: 'fixed' as 'fixed' | 'percentage',
+  budgetedAmount: '0.00',
+  budgetedPercentage: '0',
+  accountId: null as number | null,
+})
 
 async function fetchCurrentUserProfile() {
   profileLoading.value = true
@@ -571,6 +582,69 @@ async function handleToggleHideCategory(category: ExpenseCategoryDto) {
   }
 }
 
+function resetNewCategoryForm() {
+  newCategoryForm.value = {
+    name: '',
+    description: '',
+    categoryName: '',
+    budgetType: 'fixed',
+    budgetedAmount: '0.00',
+    budgetedPercentage: '0',
+    accountId: null,
+  }
+}
+
+function openAddCategory() {
+  resetNewCategoryForm()
+  addCategoryOpen.value = true
+  if (!accountsLoaded.value) {
+    void fetchAccounts()
+  }
+}
+
+async function handleAddCategory() {
+  const name = newCategoryForm.value.name.trim()
+  if (!name) {
+    snackbar.enqueueSnackbar('Category name is required', { variant: 'error' })
+    return
+  }
+
+  const budgetType = newCategoryForm.value.budgetType
+  const budgetedAmount = dollarsToCents(newCategoryForm.value.budgetedAmount)
+  const budgetedPercentage = Number.parseInt(newCategoryForm.value.budgetedPercentage, 10)
+
+  if (budgetType === 'fixed' && (Number.isNaN(budgetedAmount) || budgetedAmount < 0)) {
+    snackbar.enqueueSnackbar('Budgeted amount must be 0 or greater', { variant: 'error' })
+    return
+  }
+
+  if (budgetType === 'percentage' && (!Number.isInteger(budgetedPercentage) || budgetedPercentage <= 0 || budgetedPercentage > 100)) {
+    snackbar.enqueueSnackbar('Budgeted percentage must be a whole number between 1 and 100', { variant: 'error' })
+    return
+  }
+
+  addCategorySaving.value = true
+  try {
+    await apiClient.post('/api/expense-categories', {
+      name,
+      description: newCategoryForm.value.description,
+      categoryName: newCategoryForm.value.categoryName,
+      budgetedAmount: budgetType === 'fixed' ? budgetedAmount : 0,
+      budgetedPercentage: budgetType === 'percentage' ? budgetedPercentage : 0,
+      cap: null,
+      accountId: newCategoryForm.value.accountId,
+    })
+    snackbar.enqueueSnackbar('Category added', { variant: 'success' })
+    addCategoryOpen.value = false
+    resetNewCategoryForm()
+    void fetchManageCategories()
+  } catch (err) {
+    snackbar.enqueueSnackbar(err instanceof Error ? err.message : 'Failed to add category', { variant: 'error' })
+  } finally {
+    addCategorySaving.value = false
+  }
+}
+
 async function handleDeleteCategory() {
   if (!deleteCategory.value) return
   try {
@@ -599,6 +673,12 @@ watch(addRuleOpen, (isOpen) => {
 watch(addExternalLinkOpen, (isOpen) => {
   if (!isOpen) {
     resetExternalLinkForm()
+  }
+})
+
+watch(addCategoryOpen, (isOpen) => {
+  if (!isOpen) {
+    resetNewCategoryForm()
   }
 })
 
@@ -880,13 +960,16 @@ watch(openPanel, (panel) => {
         <v-expansion-panel-text>
           <div class="d-flex justify-space-between align-center mb-4">
             <h5 class="text-h5">Expense Categories</h5>
-            <v-switch
-              v-model="showHiddenCategories"
-              label="Show hidden"
-              density="compact"
-              hide-details
-              color="primary"
-            />
+            <div class="d-flex align-center" style="gap: 16px;">
+              <v-switch
+                v-model="showHiddenCategories"
+                label="Show hidden"
+                density="compact"
+                hide-details
+                color="primary"
+              />
+              <v-btn color="primary" prepend-icon="mdi-plus" @click="openAddCategory">Add Category</v-btn>
+            </div>
           </div>
 
           <div v-if="categoriesLoading" class="d-flex justify-center pa-8">
@@ -1169,6 +1252,72 @@ watch(openPanel, (panel) => {
           <v-spacer />
           <v-btn @click="deleteExternalLink = null">Cancel</v-btn>
           <v-btn color="error" @click="handleDeleteExternalLink">Delete</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="addCategoryOpen" max-width="520">
+      <v-card>
+        <v-card-title>Add Expense Category</v-card-title>
+        <v-card-text class="d-flex flex-column" style="gap: 16px;">
+          <v-text-field
+            v-model="newCategoryForm.name"
+            label="Name"
+            autofocus
+            @keydown.enter="handleAddCategory"
+          />
+          <v-text-field
+            v-model="newCategoryForm.categoryName"
+            label="Group"
+            hint="Optional. Categories with the same group are shown together."
+            persistent-hint
+            @keydown.enter="handleAddCategory"
+          />
+          <v-text-field
+            v-model="newCategoryForm.description"
+            label="Description"
+            @keydown.enter="handleAddCategory"
+          />
+          <v-select
+            v-model="newCategoryForm.accountId"
+            :items="accounts"
+            item-title="name"
+            item-value="id"
+            label="Account"
+            clearable
+            hint="Leave blank to use the default account."
+            persistent-hint
+          />
+          <v-btn-toggle v-model="newCategoryForm.budgetType" mandatory density="compact" divided>
+            <v-btn value="fixed" size="small">Fixed</v-btn>
+            <v-btn value="percentage" size="small">Percentage</v-btn>
+          </v-btn-toggle>
+          <v-text-field
+            v-if="newCategoryForm.budgetType === 'fixed'"
+            v-model="newCategoryForm.budgetedAmount"
+            label="Budget"
+            type="number"
+            step="0.01"
+            min="0"
+            prefix="$"
+            @keydown.enter="handleAddCategory"
+          />
+          <v-text-field
+            v-else
+            v-model="newCategoryForm.budgetedPercentage"
+            label="Budget"
+            type="number"
+            step="1"
+            min="1"
+            max="100"
+            suffix="%"
+            @keydown.enter="handleAddCategory"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn :disabled="addCategorySaving" @click="addCategoryOpen = false">Cancel</v-btn>
+          <v-btn color="primary" :loading="addCategorySaving" @click="handleAddCategory">Add</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
+++ b/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
@@ -147,9 +147,18 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
     [HttpPost]
     public async Task<ActionResult<ExpenseCategoryDto>> Create([FromBody] ExpenseCategoryRequest request)
     {
+        if (Validate(request) is { } validationError)
+            return BadRequest(validationError);
+
+        if (request.AccountId is { } accountId &&
+            await context.Accounts.FindAsync(accountId) is null)
+        {
+            return BadRequest("The specified account does not exist.");
+        }
+
         var category = new ExpenseCategory
         {
-            Name = request.Name,
+            Name = request.Name?.Trim(),
             Description = request.Description,
             CategoryName = request.CategoryName,
             BudgetedAmount = request.BudgetedAmount,
@@ -224,8 +233,28 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         return NoContent();
     }
 
-    private async Task<HashSet<int>> GetIdsWithItemsAsync(IEnumerable<int> categoryIds)
+    /// <summary>
+    /// Validates the shared create/update payload. Returns an error message, or null when valid.
+    /// A category is budgeted either by a fixed amount or by a percentage of income, never both.
+    /// </summary>
+    private static string? Validate(ExpenseCategoryRequest request)
     {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            return "Name is required.";
+
+        if (request.BudgetedAmount < 0)
+            return "Budgeted amount must be 0 or greater.";
+
+        if (request.BudgetedPercentage is < 0 or > 100)
+            return "Budgeted percentage must be between 0 and 100.";
+
+        if (request.BudgetedAmount > 0 && request.BudgetedPercentage > 0)
+            return "A category cannot use both a budgeted amount and a budgeted percentage.";
+
+        return null;
+    }
+
+    private async Task<HashSet<int>> GetIdsWithItemsAsync(IEnumerable<int> categoryIds)    {
         var ids = categoryIds.ToList();
         if (ids.Count == 0) return [];
 


### PR DESCRIPTION
## Summary
Adds the ability to create new expense categories from the **Settings -> Expense Categories** panel. Previously that panel could only rename, hide/restore, and delete categories.

## Changes
- **`Settings.vue`**: new `Add Category` button in the Expense Categories panel header, opening a dialog with the same fields as the existing inline edit form (Name, Group, Description, Fixed/Percentage budget toggle) plus an optional Account selector that defaults to the default account when left blank. Client-side validation matches `handleSaveCategoryEdit`.
- **`ExpenseCategoriesController.Create`**: hardened the existing endpoint with validation - name is required (and trimmed), budgeted amount must be >= 0, budgeted percentage must be 0-100, amount and percentage are mutually exclusive, and a supplied `accountId` must exist.

Default-account assignment already works via `ExpenseCategory.BeforeCreate`, which `BudgetContext.SaveChangesAsync` invokes; a test now covers that behavior.

## Testing
- `dotnet test SimplyBudgetWeb.Core.Tests` - 134 passed (7 new `Create` tests).
- `npm run build` (vue-tsc typecheck + vite build) and `npm run lint` in `SimplyBudgetWeb.Web` - clean.