### PR TITLE
Reduce backend cold start time

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -471,10 +471,13 @@ jobs:
           exit $exitCode
 
 
-  # Build and push Docker image for backend
+  # Build and push Docker image for backend.
+  # Depends on deploy-database so the schema is already migrated before the new image goes live.
+  # That ordering is what allows RunMigrationsOnStartup to stay off in production, keeping
+  # EF model build + MigrateAsync (and any Azure SQL resume) off the cold-start path.
   deploy-backend:
     runs-on: ubuntu-latest
-    needs: [build, ui-tests, get-infrastructure-outputs]
+    needs: [build, ui-tests, get-infrastructure-outputs, deploy-database]
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && needs.get-infrastructure-outputs.outputs.deploy_ready == 'true'
     environment: production
     steps:

--- a/Infra/modules/container_app/main.tf
+++ b/Infra/modules/container_app/main.tf
@@ -68,15 +68,20 @@ resource "azurerm_container_app" "app" {
         path             = "/alive"
         port             = 8081
         transport        = "HTTP"
-        interval_seconds = 10
+        interval_seconds = 2
       }
 
+      # The startup probe gates how quickly a cold (scaled-from-zero) replica can start
+      # serving. A long interval adds pure latency even when the app is ready immediately, so
+      # poll frequently and get the failure budget from the threshold instead.
+      # "/health" must stay cheap and dependency-free (no database check) - adding a
+      # dependency check here would put Azure SQL resume time on the critical startup path.
       startup_probe {
         path                    = "/health"
         port                    = 8081
         transport               = "HTTP"
-        interval_seconds        = 5
-        failure_count_threshold = 15 # 5 * 15 = 75 seconds
+        interval_seconds        = 2
+        failure_count_threshold = 40 # 2 * 40 = 80 seconds
       }
     }
   }

--- a/Infra/modules/container_app/variables.tf
+++ b/Infra/modules/container_app/variables.tf
@@ -35,7 +35,17 @@ variable "memory" {
 }
 
 variable "min_replicas" {
-  description = "Minimum number of replicas."
+  description = <<-EOT
+    Minimum number of replicas.
+
+    Deliberately 0: scale-to-zero is the main cost lever for this low-traffic app, and the
+    cooldown period (see cooldown_period_seconds) already keeps the app warm through a normal
+    session. The cost of that choice is a cold start after an idle period, which is mitigated in
+    the app itself (ReadyToRun publish, chiseled base image, no migrate-on-startup, post-start
+    warm-up of the database connection and Entra ID metadata) and by a fast startup probe.
+
+    Set to 1 to eliminate cold starts entirely at the cost of running a replica 24/7.
+  EOT
   type        = number
   default     = 0
 }

--- a/SimplyBudgetWeb.AppHost/AppHost.cs
+++ b/SimplyBudgetWeb.AppHost/AppHost.cs
@@ -83,10 +83,13 @@ var frontendApp = builder.AddJavaScriptApp(Resources.Frontend, "../SimplyBudgetW
 
 if (builder.ExecutionContext.IsPublishMode)
 {
-    // Enable migrations on startup for Azure deployments
-    // Applying migrations on startup is not recommended for production scenarios.
+    // Note: migrations are intentionally NOT applied on startup. The deploy pipeline's
+    // "deploy-database" job runs an EF migrations bundle before "deploy-backend" publishes the
+    // new image. Running MigrateAsync in the app would force the EF model to be built and a
+    // database round trip - potentially waiting on a serverless Azure SQL resume - on every cold
+    // start of a scaled-to-zero replica.
     // See: https://learn.microsoft.com/ef/core/managing-schemas/migrations/applying?tabs=dotnet-core-cli&WT.mc_id=DT-MVP-5003472
-    backend.WithEnvironment("RunMigrationsOnStartup", "true");
+    backend.WithEnvironment("RunMigrationsOnStartup", "false");
 }
 
 builder.Build().Run();

--- a/SimplyBudgetWeb.Core/DependencyInjection.cs
+++ b/SimplyBudgetWeb.Core/DependencyInjection.cs
@@ -35,4 +35,19 @@ public static class DependencyInjection
 
         return builder;
     }
+
+    /// <summary>
+    /// Registers the post-start warm-up that primes the database connection and Entra ID metadata
+    /// so the first request after a cold start doesn't have to. Enabled by default; set
+    /// <c>WarmUpOnStartup</c> to <c>false</c> to disable.
+    /// </summary>
+    public static TBuilder AddStartupWarmup<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        if (builder.Configuration.GetValue("WarmUpOnStartup", defaultValue: true))
+        {
+            builder.Services.AddHostedService<StartupWarmupService>();
+        }
+
+        return builder;
+    }
 }

--- a/SimplyBudgetWeb.Core/StartupWarmupService.cs
+++ b/SimplyBudgetWeb.Core/StartupWarmupService.cs
@@ -1,0 +1,123 @@
+using SimplyBudgetWeb.Data;
+
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace SimplyBudgetWeb.Core;
+
+/// <summary>
+/// Warms up the expensive work that would otherwise be paid by the first user request after a
+/// cold start: building the EF Core model, opening the first SQL connection (which may also have
+/// to wait for a serverless Azure SQL database to resume), and downloading the Entra ID OpenID
+/// Connect discovery/JWKS documents needed to validate the first bearer token.
+/// </summary>
+/// <remarks>
+/// The warm-up deliberately runs only after <see cref="IHostApplicationLifetime.ApplicationStarted"/>
+/// so it can never delay the host from listening or hold the startup health probe red. Every step
+/// is best-effort: failures are logged and swallowed, because a failed warm-up should degrade the
+/// first request to its normal (slow) path rather than take the application down.
+/// </remarks>
+internal sealed class StartupWarmupService(
+    IServiceProvider serviceProvider,
+    IConfiguration configuration,
+    IHostApplicationLifetime lifetime,
+    ILogger<StartupWarmupService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await WaitForApplicationStartedAsync(stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        // Run the independent warm-up paths concurrently; neither depends on the other.
+        await Task.WhenAll(
+            WarmUpDatabaseAsync(stoppingToken),
+            WarmUpOpenIdConnectMetadataAsync(stoppingToken));
+    }
+
+    private async Task WaitForApplicationStartedAsync(CancellationToken stoppingToken)
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var startedRegistration = lifetime.ApplicationStarted.Register(() => started.TrySetResult());
+        using var stoppingRegistration = stoppingToken.Register(() => started.TrySetCanceled(stoppingToken));
+        await started.Task;
+    }
+
+    private async Task WarmUpDatabaseAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var startedAt = TimeProvider.System.GetTimestamp();
+
+            using var scope = serviceProvider.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<BudgetWebContext>();
+
+            // Opening the connection forces the EF model to be built and primes the connection
+            // pool, including any wait for a serverless Azure SQL database to resume.
+            await dbContext.Database.OpenConnectionAsync(cancellationToken);
+            await dbContext.Database.CloseConnectionAsync();
+
+            logger.LogInformation(
+                "Database warm-up completed in {ElapsedMilliseconds}ms",
+                (long)TimeProvider.System.GetElapsedTime(startedAt).TotalMilliseconds);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutting down.
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Database warm-up failed; the first request will pay this cost instead");
+        }
+    }
+
+    private async Task WarmUpOpenIdConnectMetadataAsync(CancellationToken cancellationToken)
+    {
+        // Entra ID is not necessarily configured locally (the AppHost defaults the client and
+        // tenant ids to empty strings), and warming an unconfigured authority would only produce
+        // a misleading warning on every local run.
+        if (string.IsNullOrWhiteSpace(configuration["AzureAd:TenantId"]) ||
+            string.IsNullOrWhiteSpace(configuration["AzureAd:ClientId"]))
+        {
+            return;
+        }
+
+        try
+        {
+            var startedAt = TimeProvider.System.GetTimestamp();
+
+            var jwtOptions = serviceProvider
+                .GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+                .Get(JwtBearerDefaults.AuthenticationScheme);
+
+            if (jwtOptions.ConfigurationManager is null)
+            {
+                return;
+            }
+
+            await jwtOptions.ConfigurationManager.GetConfigurationAsync(cancellationToken);
+
+            logger.LogInformation(
+                "OpenID Connect metadata warm-up completed in {ElapsedMilliseconds}ms",
+                (long)TimeProvider.System.GetElapsedTime(startedAt).TotalMilliseconds);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutting down.
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "OpenID Connect metadata warm-up failed; the first authenticated request will pay this cost instead");
+        }
+    }
+}

--- a/SimplyBudgetWeb.ServiceDefaults/Extensions.cs
+++ b/SimplyBudgetWeb.ServiceDefaults/Extensions.cs
@@ -128,4 +128,36 @@ public static class Extensions
 
         return app;
     }
+
+    /// <summary>
+    /// Logs how long the process took to reach key startup milestones. These numbers are the
+    /// baseline for cold-start work: on a scale-to-zero host the gap between process start and
+    /// <c>ApplicationStarted</c> is the window during which startup probes are still failing.
+    /// </summary>
+    public static WebApplication LogStartupTimings(this WebApplication app)
+    {
+        var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Startup");
+
+        logger.LogInformation(
+            "Startup milestone: host built {ElapsedMilliseconds}ms after process start",
+            (long)ElapsedSinceProcessStart().TotalMilliseconds);
+
+        var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+        lifetime.ApplicationStarted.Register(() =>
+            logger.LogInformation(
+                "Startup milestone: application started and accepting requests {ElapsedMilliseconds}ms after process start",
+                (long)ElapsedSinceProcessStart().TotalMilliseconds));
+
+        return app;
+    }
+
+    /// <summary>
+    /// Time since the OS process started, which includes host construction and runtime startup
+    /// that a <see cref="System.Diagnostics.Stopwatch"/> created inside <c>Main</c> would miss.
+    /// </summary>
+    public static TimeSpan ElapsedSinceProcessStart()
+    {
+        using var process = System.Diagnostics.Process.GetCurrentProcess();
+        return DateTime.UtcNow - process.StartTime.ToUniversalTime();
+    }
 }

--- a/SimplyBudgetWeb/Program.cs
+++ b/SimplyBudgetWeb/Program.cs
@@ -9,13 +9,20 @@ using Microsoft.Identity.Web;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults()
-    .AddDatabase();
+    .AddDatabase()
+    .AddStartupWarmup();
 
 // Add services to the container.
 builder.Services.AddControllers();
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 builder.Services.AddSignalR();
+
+// Swagger is only mapped in Development, so avoid paying to build the generator and its
+// document/schema services on a production cold start.
+if (builder.Environment.IsDevelopment())
+{
+    builder.Services.AddEndpointsApiExplorer();
+    builder.Services.AddSwaggerGen();
+}
 
 // Add CORS for frontend in development
 builder.Services.AddCors(options =>
@@ -94,6 +101,8 @@ builder.Services.AddScoped<CurrentUserSyncService>();
 builder.Services.AddScoped<IBudgetMonthUpdateNotifier, BudgetMonthUpdateNotifier>();
 
 var app = builder.Build();
+
+app.LogStartupTimings();
 
 app.MapDefaultEndpoints();
 

--- a/SimplyBudgetWeb/SimplyBudgetWeb.csproj
+++ b/SimplyBudgetWeb/SimplyBudgetWeb.csproj
@@ -8,6 +8,42 @@
     <EnableDefaultRazorComponentItems>false</EnableDefaultRazorComponentItems>
   </PropertyGroup>
 
+  <PropertyGroup Label="Cold start">
+    <!--
+    The backend runs as an Azure Container App with min_replicas = 0, so every request after an
+    idle period pays a full cold start. These settings target that path.
+
+    Native AOT is deliberately not used: EF Core relational providers and migrations, MVC
+    controllers, SignalR and Microsoft.Identity.Web are all reflection-heavy and unsupported (or
+    untested) under AOT. ReadyToRun gives most of the startup-JIT win with none of that risk.
+    Trimming is likewise avoided for the same compatibility reasons.
+
+    ReadyToRun requires a RuntimeIdentifier, so it is only applied to the RID-specific publish
+    used for the container image; the plain "dotnet publish" in CI keeps working unchanged.
+    -->
+    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != ''">true</PublishReadyToRun>
+    <!--
+    Composite R2R can start marginally faster but produces a substantially larger image, and
+    image pull time is itself part of the cold start on a scaled-to-zero replica.
+    -->
+    <PublishReadyToRunComposite>false</PublishReadyToRunComposite>
+
+    <!--
+    The container is provisioned with a single CPU (see Infra/modules/container_app), where
+    workstation GC starts faster and uses less memory than the ASP.NET Core default of server GC.
+    -->
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+
+    <!--
+    Chiseled base image: much smaller than the default runtime-deps image, which shortens the
+    ACR pull that precedes every cold start. The "-extra" variant is used (rather than plain
+    chiseled) because it ships ICU and tzdata - the app still relies on culture-aware parsing and
+    formatting, so InvariantGlobalization is intentionally NOT enabled.
+    -->
+    <ContainerFamily>noble-chiseled-extra</ContainerFamily>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SimplyBudgetWeb.Core\SimplyBudgetWeb.Core.csproj" />
     <ProjectReference Include="..\SimplyBudgetWeb.Data\SimplyBudgetWeb.Data.csproj" />


### PR DESCRIPTION
## Why

The backend runs as an Azure Container App with `min_replicas = 0`, so every request after an idle period pays a full cold start: ACR image pull → host start → startup probe polling → all the first-request work that was never done at startup (EF model build, first SQL connection, Entra OIDC metadata fetch).

This PR attacks each of those. Nothing here changes application behaviour.

## On Native AOT

**Deliberately not used.** EF Core relational providers and migrations, MVC controllers, SignalR, Swashbuckle and `Microsoft.Identity.Web` are all reflection-heavy and unsupported (or untested) under AOT. Trimming is avoided for the same reason.

**ReadyToRun** is the equivalent lever here — it removes most startup JIT with none of the compatibility risk. Rationale is recorded inline in `SimplyBudgetWeb.csproj` so it doesn't get re-litigated.

## Changes

### Defer / remove work from the startup path

- **New `StartupWarmupService`** — primes the EF model + SQL connection pool and the Entra ID OIDC discovery/JWKS documents so the first user request doesn't. It runs *only* after `ApplicationStarted`, so it can never delay the host from listening or hold the startup probe red. Both steps run concurrently, are best-effort, and log-and-continue on failure (a failed warm-up degrades the first request to its normal slow path rather than taking the app down). Skips the Entra step when the tenant/client id aren't configured, to avoid noise locally.
- **No more migrate-on-startup in production.** The pipeline already builds and applies an EF migrations bundle; `deploy-backend` now `needs: deploy-database` so the schema is migrated *before* the new image goes live. This takes `MigrateAsync` — and any serverless Azure SQL resume it triggers — off every cold start.
- **Swagger services only registered in Development**, where they were already the only place they're mapped.

### Get health probes green sooner

In `Infra/modules/container_app/main.tf`:

| Probe | Before | After |
|---|---|---|
| startup (`/health`) | every 5s, 15 failures (75s) | every **2s**, 40 failures (80s) |
| readiness (`/alive`) | every 10s | every **2s** |

A slow poll interval adds pure latency even when the app is ready instantly. Same overall failure budget, just polled more often. Added a comment that `/health` must stay dependency-free — adding a DB check there would put Azure SQL resume time back on the critical startup path.

### Publish / image

- `PublishReadyToRun` for the RID-specific container publish only (R2R needs a RID; the plain `dotnet publish` in CI is unaffected). Composite R2R left off — it bloats the image, and image size *is* part of the cold start.
- `ContainerFamily=noble-chiseled-extra` — much smaller base image, shorter ACR pull. The `-extra` variant keeps ICU/tzdata, so **`InvariantGlobalization` is intentionally not enabled**: the app still uses culture-aware parsing/formatting (`SearchAmountParser`, `ExtensionMethods`).
- Workstation GC — the container has a single CPU, where it starts faster and uses less memory than the ASP.NET Core default of server GC.

### Measurability

`LogStartupTimings()` logs host-built and application-started milestones relative to *process* start (not `Main`), so cold-start regressions are visible straight from container logs.

Also documented the `min_replicas = 0` keep-warm tradeoff in the Terraform variable, including what to change to eliminate cold starts entirely.

## Verification

- `dotnet build` clean; `SimplyBudgetWeb.Core.Tests` **127/127 passing**.
- Container publish validated end-to-end to a local archive — image builds on `mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled-extra`; confirmed `PublishReadyToRun=true`, `ServerGarbageCollection=false` evaluated, and `System.GC.Server: false` in the published `runtimeconfig.json`.
- Ran the backend standalone against a deliberately unreachable database to exercise the failure path:

```
Startup milestone: host built 195ms after process start
Now listening on: http://127.0.0.1:5399
Application started. Press Ctrl+C to shut down.
Startup milestone: application started and accepting requests 377ms after process start
warn: StartupWarmupService  OpenID Connect metadata warm-up failed; the first authenticated request will pay this cost instead
warn: StartupWarmupService  Database warm-up failed; the first request will pay this cost instead
```

  Note the ordering — warm-up starts strictly *after* the app is accepting requests. With both warm-ups failing, `/health` and `/alive` still returned **200 Healthy**.
- `terraform fmt -check -recursive Infra` clean for all touched files (`providers.tf` was already unformatted on `main`).

## Not included

EF Core compiled models (`dotnet ef dbcontext optimize`) were intentionally left out of this PR.

## Follow-up

The remaining lever is measurement in production: with these landed, compare revision-start → first-green-`/health` and check whether ACR **artifact streaming** and region colocation are worth enabling for the image pull.
