### PR TITLE
Fix category filter being dropped on History load

### DIFF
--- a/SimplyBudgetWeb.Web/src/components/CategorySelector.vue
+++ b/SimplyBudgetWeb.Web/src/components/CategorySelector.vue
@@ -52,6 +52,12 @@ const items = computed<CategoryOption[]>(() => {
 
 const validCategoryIds = computed(() => new Set(props.categories.map(category => category.id)))
 
+function isPendingSelectedCategory(value: number) {
+  return validCategoryIds.value.size === 0
+    && typeof props.modelValue === 'number'
+    && props.modelValue === value
+}
+
 function updateValue(value: CategorySelectorValue) {
   if (value === null) {
     emit('update:modelValue', null)
@@ -59,12 +65,13 @@ function updateValue(value: CategorySelectorValue) {
   }
 
   if (typeof value === 'number') {
-    emit('update:modelValue', validCategoryIds.value.has(value) ? value : null)
+    emit('update:modelValue', validCategoryIds.value.has(value) || isPendingSelectedCategory(value) ? value : null)
     return
   }
 
   const parsedValue = Number(value)
-  if (Number.isInteger(parsedValue) && validCategoryIds.value.has(parsedValue)) {
+  if (Number.isInteger(parsedValue)
+    && (validCategoryIds.value.has(parsedValue) || isPendingSelectedCategory(parsedValue))) {
     emit('update:modelValue', parsedValue)
     return
   }

--- a/SimplyBudgetWeb.Web/src/pages/History.vue
+++ b/SimplyBudgetWeb.Web/src/pages/History.vue
@@ -20,9 +20,15 @@ const route = useRoute()
 const authStore = useAuthStore()
 const { loadExternalLinkRules, externalLinksFor } = useExternalLinkRules()
 
+function parseCategoryIdQuery(value: unknown): number | null {
+  const raw = Array.isArray(value) ? value[0] : value
+  const parsedCategoryId = Number(raw)
+  return Number.isInteger(parsedCategoryId) ? parsedCategoryId : null
+}
+
 const { currentMonth } = useMonthQueryParam()
 const search = ref('')
-const categoryId = ref<number | null>(null)
+const categoryId = ref<number | null>(parseCategoryIdQuery(route.query.categoryId))
 const items = ref<HistoryItemDto[]>([])
 const categories = ref<ExpenseCategoryDto[]>([])
 const accounts = ref<AccountDto[]>([])
@@ -209,13 +215,6 @@ onMounted(() => {
   void fetchAccountBalances()
   void loadExternalLinkRules()
   void monthUpdatesHub.start(formatMonth(currentMonth.value))
-
-  const rawCategoryId = route.query.categoryId
-  const categoryIdQuery = Array.isArray(rawCategoryId) ? rawCategoryId[0] : rawCategoryId
-  const parsedCategoryId = Number(categoryIdQuery)
-  if (Number.isFinite(parsedCategoryId)) {
-    categoryId.value = parsedCategoryId
-  }
 })
 
 function onDialogSuccess() {


### PR DESCRIPTION
## Summary
- initialize the History page category filter from `categoryId` query before the first `/api/history` request
- keep `CategorySelector` from clearing an already-selected category while categories are still loading
- remove duplicate on-mounted query parsing now that initialization is deterministic

## User impact
Clicking a budget category now opens History already filtered, and refreshing that page keeps the selected category filter instead of reverting to all transactions.