### PR TITLE
Fix expense category save getting stuck

### DIFF
--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -603,6 +603,8 @@ function openAddCategory() {
 }
 
 async function handleAddCategory() {
+  if (addCategorySaving.value) return
+
   const name = newCategoryForm.value.name.trim()
   if (!name) {
     snackbar.enqueueSnackbar('Category name is required', { variant: 'error' })
@@ -1256,7 +1258,7 @@ watch(openPanel, (panel) => {
       </v-card>
     </v-dialog>
 
-    <v-dialog v-model="addCategoryOpen" max-width="520">
+    <v-dialog v-model="addCategoryOpen" max-width="520" :persistent="addCategorySaving">
       <v-card>
         <v-card-title>Add Expense Category</v-card-title>
         <v-card-text class="d-flex flex-column" style="gap: 16px;">

--- a/SimplyBudgetWeb.Web/src/services/apiClient.ts
+++ b/SimplyBudgetWeb.Web/src/services/apiClient.ts
@@ -26,6 +26,46 @@ interface DeleteOptions {
 
 class ApiClient {
   private baseUrl = __API_BASE_URL__ || ''
+  private requestTimeoutMs = 30_000
+  private tokenTimeoutMs = 15_000
+
+  private async withTimeout<T>(
+    promiseFactory: () => Promise<T>,
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs)
+    })
+
+    try {
+      return await Promise.race([promiseFactory(), timeoutPromise]) as T
+    } finally {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+    }
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const abortController = new AbortController()
+    const timeoutId = setTimeout(() => abortController.abort(), this.requestTimeoutMs)
+
+    try {
+      return await fetch(this.baseUrl + url, {
+        ...init,
+        signal: abortController.signal,
+      })
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error('Request timed out. Please try again.')
+      }
+      throw error
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  }
 
   private async throwIfUnauthorized(response: Response): Promise<void> {
     if (response.status !== 401) return
@@ -47,9 +87,14 @@ class ApiClient {
 
   private async getHeaders(): Promise<HeadersInit> {
     if (getTokenFn) {
+      const tokenProvider = getTokenFn
       // Any failure here (including an unrecoverable session) propagates: all
       // API endpoints require auth, so an anonymous request would only 401.
-      const token = await getTokenFn()
+      const token = await this.withTimeout(
+        () => tokenProvider(),
+        this.tokenTimeoutMs,
+        'Authentication timed out. Please sign in again.',
+      )
       return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
     }
     return { 'Content-Type': 'application/json' }
@@ -63,7 +108,7 @@ class ApiClient {
 
   async get<T>(url: string): Promise<T> {
     const headers = await this.getHeaders()
-    const response = await fetch(this.baseUrl + url, { headers })
+    const response = await this.fetchWithTimeout(url, { headers })
     await this.throwIfUnauthorized(response)
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
     const text = await response.text()
@@ -72,7 +117,7 @@ class ApiClient {
 
   async post<T = void>(url: string, data?: unknown): Promise<T> {
     const headers = await this.getHeaders()
-    const response = await fetch(this.baseUrl + url, {
+    const response = await this.fetchWithTimeout(url, {
       method: 'POST', headers,
       body: this.buildJsonBody(data),
     })
@@ -88,7 +133,7 @@ class ApiClient {
 
   async download(url: string): Promise<{ blob: Blob; fileName: string | null }> {
     const headers = await this.getHeaders()
-    const response = await fetch(this.baseUrl + url, { headers })
+    const response = await this.fetchWithTimeout(url, { headers })
     await this.throwIfUnauthorized(response)
     if (!response.ok) {
       const error = await response.text()
@@ -103,7 +148,7 @@ class ApiClient {
 
   async put<T = void>(url: string, data?: unknown): Promise<T> {
     const headers = await this.getHeaders()
-    const response = await fetch(this.baseUrl + url, {
+    const response = await this.fetchWithTimeout(url, {
       method: 'PUT', headers,
       body: this.buildJsonBody(data),
     })
@@ -121,7 +166,7 @@ class ApiClient {
           'If-Match': options.ifMatch,
         }
       : headers
-    const response = await fetch(this.baseUrl + url, { method: 'DELETE', headers: requestHeaders })
+    const response = await this.fetchWithTimeout(url, { method: 'DELETE', headers: requestHeaders })
     await this.throwIfUnauthorized(response)
     if (!response.ok) {
       const error = await response.text()


### PR DESCRIPTION
## Summary\n- add API client timeouts for auth token acquisition and HTTP requests so save operations cannot spin indefinitely\n- return a clear timeout error message to the UI when a request stalls\n- guard add-category submit re-entry and keep the add dialog persistent while saving\n\n## Problem\nCreating a new expense category could remain in a perpetual **Saving...** state when auth/network calls stalled.\n\n## Validation\n- frontend production build succeeds (vite v8.2.2 building client environment for production...
transforming...
✓ 709 modules transformed.
rendering chunks...
computing gzip size...
dist/manifest.webmanifest                                   0.46 kB
dist/index.html                                             0.74 kB │ gzip:   0.36 kB
dist/assets/materialdesignicons-webfont-Dp5v-WZN.woff2    403.21 kB
dist/assets/materialdesignicons-webfont-PXm3-2wK.woff     587.98 kB
dist/assets/materialdesignicons-webfont-B7mPwVP_.ttf    1,307.66 kB
dist/assets/materialdesignicons-webfont-CSr8KVlo.eot    1,307.88 kB
dist/assets/index-3aKpL_aN.css                            670.36 kB │ gzip: 102.64 kB
dist/assets/workbox-window.prod.es5-Bd17z0YL.js             5.71 kB │ gzip:   2.25 kB │ map:    13.18 kB
dist/assets/index-QJuTFc6D.js                             791.76 kB │ gzip: 233.59 kB │ map: 3,549.74 kB

✓ built in 4.84s

PWA v1.3.0
mode      generateSW
precache  15 entries (2648.72 KiB)
files generated
  dist/sw.js.map
  dist/sw.js
  dist/workbox-35e397ac.js.map
  dist/workbox-35e397ac.js)