### PR TITLE
Implement month-scoped API memory caching for budget, expense, and pending expenses

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerRealtimeTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerRealtimeTests.cs
@@ -18,6 +18,7 @@ public class HistoryControllerRealtimeTests
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
         var notifier = new Mock<IBudgetMonthUpdateNotifier>();
+        var cache = new Mock<IBudgetMonthDataCache>();
 
         var monthDate = new DateTime(2026, 5, 19);
         int itemId = await mocker.InDbScopeAsync(async context =>
@@ -45,11 +46,12 @@ public class HistoryControllerRealtimeTests
         });
 
         using var context = mocker.Get<BudgetWebContext>();
-        var controller = new HistoryController(context, notifier.Object);
+        var controller = new HistoryController(context, notifier.Object, cache.Object);
 
         var result = await controller.Delete(itemId);
 
         await Assert.That(result).IsTypeOf<NoContentResult>();
+        cache.Verify(x => x.InvalidateMonth(monthDate), Times.Once);
         notifier.Verify(
             x => x.NotifyMonthUpdated(monthDate, It.IsAny<CancellationToken>()),
             Times.Once);

--- a/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/HistoryControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetWeb.Controllers;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
 
 namespace SimplyBudgetWeb.Core.Tests.Controllers;
 
@@ -201,16 +202,18 @@ public class HistoryControllerTests
     {
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
+        var cache = new Mock<IBudgetMonthDataCache>();
 
-        var itemId = await mocker.InDbScopeAsync(async context =>
+        var (itemId, itemDate) = await mocker.InDbScopeAsync(async context =>
         {
+            var date = new DateTime(2026, 1, 10);
             var category = new ExpenseCategory { Name = "Groceries" };
             context.ExpenseCategories.Add(category);
             await context.SaveChangesAsync();
 
             var item = new ExpenseCategoryItem
             {
-                Date = new DateTime(2026, 1, 10),
+                Date = date,
                 Description = "Costco",
                 Notes = "Original note",
                 Details = [new ExpenseCategoryItemDetail { Amount = -1234, ExpenseCategoryId = category.ID }],
@@ -218,12 +221,12 @@ public class HistoryControllerTests
             context.ExpenseCategoryItems.Add(item);
             await context.SaveChangesAsync();
 
-            return item.ID;
+            return (item.ID, date);
         });
 
         using (var context = mocker.Get<BudgetWebContext>())
         {
-            var controller = new HistoryController(context);
+            var controller = new HistoryController(context, budgetMonthDataCache: cache.Object);
             var result = await controller.Update(itemId, new HistoryItemUpdateRequest("  Updated note  "));
 
             var dto = (result.Value as HistoryItemDto) ?? ((OkObjectResult?)result.Result)?.Value as HistoryItemDto;
@@ -236,6 +239,8 @@ public class HistoryControllerTests
             var stored = await context.ExpenseCategoryItems.SingleAsync(x => x.ID == itemId);
             await Assert.That(stored.Notes).IsEqualTo("Updated note");
         });
+
+        cache.Verify(x => x.InvalidateMonth(itemDate), Times.Once);
     }
 
     [Test]

--- a/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/PendingExpensesControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetWeb.Controllers;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
 
 namespace SimplyBudgetWeb.Core.Tests.Controllers;
 
@@ -243,11 +244,13 @@ public class PendingExpensesControllerTests
     {
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
+        var cache = new Mock<IBudgetMonthDataCache>();
 
+        var pendingDate = new DateTime(2026, 1, 1);
         var (pendingId, assigneeId, version) = await mocker.InDbScopeAsync(async context =>
         {
             var assignee = new PendingExpenseAssignee { Name = "Jordan", ObjectId = "jordan-oid" };
-            var pending = new PendingExpense { Date = new DateTime(2026, 1, 1), Description = "Costco", Amount = 100 };
+            var pending = new PendingExpense { Date = pendingDate, Description = "Costco", Amount = 100 };
             context.PendingExpenseAssignees.Add(assignee);
             context.PendingExpenses.Add(pending);
             await context.SaveChangesAsync();
@@ -256,7 +259,7 @@ public class PendingExpensesControllerTests
 
         using (var context = mocker.Get<BudgetWebContext>())
         {
-            var controller = new PendingExpensesController(context);
+            var controller = new PendingExpensesController(context, budgetMonthDataCache: cache.Object);
             var result = await controller.Update(pendingId, new PendingExpenseUpdateRequest(assigneeId, "Needs review", version));
 
             var dto = (result.Value as PendingExpenseDto) ?? ((OkObjectResult)result.Result!).Value as PendingExpenseDto;
@@ -272,6 +275,8 @@ public class PendingExpensesControllerTests
             await Assert.That(pending.AssigneeId).IsEqualTo(assigneeId);
             await Assert.That(pending.Notes).IsEqualTo("Needs review");
         });
+
+        cache.Verify(x => x.InvalidateMonth(pendingDate), Times.Once);
     }
 
     [Test]

--- a/SimplyBudgetWeb.Core.Tests/Controllers/TransactionsControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/TransactionsControllerTests.cs
@@ -17,6 +17,7 @@ public class TransactionsControllerTests
         AutoMocker mocker = new();
         mocker.WithDbContext<BudgetWebContext>();
         var notifier = new Mock<IBudgetMonthUpdateNotifier>();
+        var cache = new Mock<IBudgetMonthDataCache>();
 
         var categoryId = await mocker.InDbScopeAsync(async context =>
         {
@@ -29,13 +30,14 @@ public class TransactionsControllerTests
         var monthDate = new DateTime(2026, 1, 10);
         using (var context = mocker.Get<BudgetWebContext>())
         {
-            var controller = new TransactionsController(context, notifier.Object);
+            var controller = new TransactionsController(context, notifier.Object, cache.Object);
             await controller.AddTransaction(new TransactionRequest(
                 Description: "Costco",
                 Date: monthDate,
                 Items: [new TransactionItemRequest(categoryId, 45_00)]));
         }
 
+        cache.Verify(x => x.InvalidateMonth(monthDate), Times.Once);
         notifier.Verify(
             x => x.NotifyMonthUpdated(monthDate, It.IsAny<CancellationToken>()),
             Times.Once);

--- a/SimplyBudgetWeb.Core.Tests/Services/BudgetMonthDataCacheTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Services/BudgetMonthDataCacheTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Caching.Memory;
+
+using SimplyBudgetWeb.Services;
+
+namespace SimplyBudgetWeb.Core.Tests.Services;
+
+public class BudgetMonthDataCacheTests
+{
+    [Test]
+    public async Task GetOrCreateAsync_UsesMonthAsPartOfCacheKey()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var cache = new BudgetMonthDataCache(memoryCache);
+
+        int factoryCallCount = 0;
+
+        Task<string> CreateValue()
+        {
+            factoryCallCount++;
+            return Task.FromResult($"value-{factoryCallCount}");
+        }
+
+        var januaryFirst = await cache.GetOrCreateAsync("budget", new DateTime(2026, 1, 1), "default", CreateValue);
+        var januarySecond = await cache.GetOrCreateAsync("budget", new DateTime(2026, 1, 10), "default", CreateValue);
+        var february = await cache.GetOrCreateAsync("budget", new DateTime(2026, 2, 1), "default", CreateValue);
+
+        await Assert.That(januaryFirst).IsEqualTo("value-1");
+        await Assert.That(januarySecond).IsEqualTo("value-1");
+        await Assert.That(february).IsEqualTo("value-2");
+    }
+
+    [Test]
+    public async Task InvalidateMonth_OnlyRemovesThatMonthCacheEntries()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var cache = new BudgetMonthDataCache(memoryCache);
+
+        int januaryFactoryCallCount = 0;
+        int februaryFactoryCallCount = 0;
+
+        Task<string> CreateJanuaryValue()
+        {
+            januaryFactoryCallCount++;
+            return Task.FromResult($"jan-{januaryFactoryCallCount}");
+        }
+
+        Task<string> CreateFebruaryValue()
+        {
+            februaryFactoryCallCount++;
+            return Task.FromResult($"feb-{februaryFactoryCallCount}");
+        }
+
+        _ = await cache.GetOrCreateAsync("history", new DateTime(2026, 1, 1), "default", CreateJanuaryValue);
+        _ = await cache.GetOrCreateAsync("history", new DateTime(2026, 2, 1), "default", CreateFebruaryValue);
+
+        cache.InvalidateMonth(new DateTime(2026, 1, 15));
+
+        var januaryAfterInvalidation = await cache.GetOrCreateAsync("history", new DateTime(2026, 1, 20), "default", CreateJanuaryValue);
+        var februaryAfterInvalidation = await cache.GetOrCreateAsync("history", new DateTime(2026, 2, 20), "default", CreateFebruaryValue);
+
+        await Assert.That(januaryAfterInvalidation).IsEqualTo("jan-2");
+        await Assert.That(februaryAfterInvalidation).IsEqualTo("feb-1");
+    }
+
+    [Test]
+    public async Task InvalidateMonth_RemovesAllMonthsEntries()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var cache = new BudgetMonthDataCache(memoryCache);
+
+        int factoryCallCount = 0;
+
+        Task<string> CreateValue()
+        {
+            factoryCallCount++;
+            return Task.FromResult($"all-{factoryCallCount}");
+        }
+
+        _ = await cache.GetOrCreateAsync(
+            scope: "pending-expenses",
+            month: null,
+            cacheVariant: "default",
+            valueFactory: CreateValue);
+
+        cache.InvalidateMonth(new DateTime(2026, 1, 1));
+
+        var valueAfterInvalidation = await cache.GetOrCreateAsync(
+            scope: "pending-expenses",
+            month: null,
+            cacheVariant: "default",
+            valueFactory: CreateValue);
+
+        await Assert.That(valueAfterInvalidation).IsEqualTo("all-2");
+    }
+}

--- a/SimplyBudgetWeb/Controllers/BudgetController.cs
+++ b/SimplyBudgetWeb/Controllers/BudgetController.cs
@@ -3,17 +3,32 @@ using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
 
 namespace SimplyBudgetWeb.Controllers;
 
 [ApiController]
 [Route("api/budget")]
-public class BudgetController(BudgetWebContext context) : ControllerBase
+public class BudgetController(
+    BudgetWebContext context,
+    IBudgetMonthDataCache? budgetMonthDataCache = null) : ControllerBase
 {
+    private readonly IBudgetMonthDataCache monthDataCache = budgetMonthDataCache ?? NullBudgetMonthDataCache.Instance;
+
     [HttpGet]
     public async Task<BudgetResponse> Get([FromQuery] DateTime? month)
     {
         var monthDate = (month ?? DateTime.Today).StartOfMonth();
+
+        return await monthDataCache.GetOrCreateAsync(
+            scope: "budget",
+            month: monthDate,
+            cacheVariant: "default",
+            valueFactory: () => GetBudget(monthDate));
+    }
+
+    private async Task<BudgetResponse> GetBudget(DateTime monthDate)
+    {
         var start = monthDate.StartOfMonth();
         var end = monthDate.EndOfMonth();
         var estimatedMonthlyIncome = await CalculateEstimatedMonthlyIncome(monthDate);

--- a/SimplyBudgetWeb/Controllers/HistoryController.cs
+++ b/SimplyBudgetWeb/Controllers/HistoryController.cs
@@ -12,9 +12,11 @@ namespace SimplyBudgetWeb.Controllers;
 [Route("api/history")]
 public class HistoryController(
     BudgetWebContext context,
-    IBudgetMonthUpdateNotifier? budgetMonthUpdateNotifier = null) : ControllerBase
+    IBudgetMonthUpdateNotifier? budgetMonthUpdateNotifier = null,
+    IBudgetMonthDataCache? budgetMonthDataCache = null) : ControllerBase
 {
     private readonly IBudgetMonthUpdateNotifier budgetMonthUpdates = budgetMonthUpdateNotifier ?? NullBudgetMonthUpdateNotifier.Instance;
+    private readonly IBudgetMonthDataCache monthDataCache = budgetMonthDataCache ?? NullBudgetMonthDataCache.Instance;
 
     [HttpGet]
     public async Task<HistoryItemDto[]> GetAll(
@@ -24,42 +26,51 @@ public class HistoryController(
         [FromQuery] int? accountId)
     {
         var monthDate = (month ?? DateTime.Today).StartOfMonth();
-        var start = monthDate.StartOfMonth();
-        var end = monthDate.EndOfMonth();
+        var searchText = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+        var cacheVariant = BuildCacheVariant(searchText, categoryId, accountId);
 
-        var query = context.ExpenseCategoryItems
-            .Include(x => x.Details!)
-                .ThenInclude(d => d.ExpenseCategory)
-            .Where(x => x.Date >= start && x.Date <= end)
-            .AsQueryable();
+        return await monthDataCache.GetOrCreateAsync(
+            scope: "history",
+            month: monthDate,
+            cacheVariant: cacheVariant,
+            valueFactory: async () =>
+            {
+                var start = monthDate.StartOfMonth();
+                var end = monthDate.EndOfMonth();
 
-        if (!string.IsNullOrWhiteSpace(search))
-        {
-            var searchText = search.Trim();
-            var hasSearchAmount = SearchAmountParser.TryParseAmountInCents(searchText, out var searchAmountInCents);
-            var searchAmountAbs = Math.Abs(searchAmountInCents);
+                var query = context.ExpenseCategoryItems
+                    .Include(x => x.Details!)
+                        .ThenInclude(d => d.ExpenseCategory)
+                    .Where(x => x.Date >= start && x.Date <= end)
+                    .AsQueryable();
 
-            query = query.Where(x =>
-                (x.Description != null && x.Description.Contains(searchText)) ||
-                (x.Notes != null && x.Notes.Contains(searchText)) ||
-                x.Details!.Any(d => d.ExpenseCategory!.Description != null && d.ExpenseCategory.Description.Contains(searchText)) ||
-                (hasSearchAmount &&
-                 (x.Details!.Any(d => Math.Abs(d.Amount) == searchAmountAbs) ||
-                  Math.Abs(x.Details!.Sum(d => d.Amount)) == searchAmountAbs)));
-        }
+                if (searchText is not null)
+                {
+                    var hasSearchAmount = SearchAmountParser.TryParseAmountInCents(searchText, out var searchAmountInCents);
+                    var searchAmountAbs = Math.Abs(searchAmountInCents);
 
-        if (categoryId.HasValue)
-            query = query.Where(x => x.Details!.Any(d => d.ExpenseCategoryId == categoryId.Value));
+                    query = query.Where(x =>
+                        (x.Description != null && x.Description.Contains(searchText)) ||
+                        (x.Notes != null && x.Notes.Contains(searchText)) ||
+                        x.Details!.Any(d => d.ExpenseCategory!.Description != null && d.ExpenseCategory.Description.Contains(searchText)) ||
+                        (hasSearchAmount &&
+                         (x.Details!.Any(d => Math.Abs(d.Amount) == searchAmountAbs) ||
+                          Math.Abs(x.Details!.Sum(d => d.Amount)) == searchAmountAbs)));
+                }
 
-        if (accountId.HasValue)
-            query = query.Where(x => x.Details!.Any(d => d.ExpenseCategory!.AccountID == accountId.Value));
+                if (categoryId.HasValue)
+                    query = query.Where(x => x.Details!.Any(d => d.ExpenseCategoryId == categoryId.Value));
 
-        var items = await query
-            .OrderBy(x => x.Date)
-            .ThenBy(x => x.ID)
-            .ToListAsync();
+                if (accountId.HasValue)
+                    query = query.Where(x => x.Details!.Any(d => d.ExpenseCategory!.AccountID == accountId.Value));
 
-        return items.Select(ToDto).ToArray();
+                var items = await query
+                    .OrderBy(x => x.Date)
+                    .ThenBy(x => x.ID)
+                    .ToListAsync();
+
+                return items.Select(ToDto).ToArray();
+            });
     }
 
     [HttpPut("{id}")]
@@ -74,6 +85,7 @@ public class HistoryController(
 
         item.Notes = NormalizeNotes(request.Notes);
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateMonth(item.Date);
         return ToDto(item);
     }
 
@@ -87,9 +99,13 @@ public class HistoryController(
 
         context.ExpenseCategoryItems.Remove(item);
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateMonth(item.Date);
         await budgetMonthUpdates.NotifyMonthUpdated(item.Date);
         return NoContent();
     }
+
+    private static string BuildCacheVariant(string? search, int? categoryId, int? accountId)
+        => $"search={search ?? string.Empty};categoryId={categoryId?.ToString() ?? string.Empty};accountId={accountId?.ToString() ?? string.Empty}";
 
     private static HistoryItemDto ToDto(ExpenseCategoryItem item) => new(
         Id: item.ID,

--- a/SimplyBudgetWeb/Controllers/ImportController.cs
+++ b/SimplyBudgetWeb/Controllers/ImportController.cs
@@ -11,8 +11,12 @@ namespace SimplyBudgetWeb.Controllers;
 
 [ApiController]
 [Route("api/import")]
-public class ImportController(BudgetWebContext context) : ControllerBase
+public class ImportController(
+    BudgetWebContext context,
+    IBudgetMonthDataCache? budgetMonthDataCache = null) : ControllerBase
 {
+    private readonly IBudgetMonthDataCache monthDataCache = budgetMonthDataCache ?? NullBudgetMonthDataCache.Instance;
+
     [HttpPost("parse")]
     public async Task<ActionResult<ImportItemDto[]>> Parse([FromBody] ImportRequest request)
     {
@@ -127,6 +131,7 @@ public class ImportController(BudgetWebContext context) : ControllerBase
 
         context.PendingExpenses.AddRange(pendingExpenses);
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateMonths(pendingExpenses.Select(x => x.Date));
 
         return StatusCode(201);
     }

--- a/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
+++ b/SimplyBudgetWeb/Controllers/PendingExpensesController.cs
@@ -17,10 +17,12 @@ namespace SimplyBudgetWeb.Controllers;
 [Route("api/pending-expenses")]
 public class PendingExpensesController(
     BudgetWebContext context,
-    IBudgetMonthUpdateNotifier? budgetMonthUpdateNotifier = null) : ControllerBase
+    IBudgetMonthUpdateNotifier? budgetMonthUpdateNotifier = null,
+    IBudgetMonthDataCache? budgetMonthDataCache = null) : ControllerBase
 {
     private const string ConcurrencyConflictMessage = "This pending expense was changed by another user. Refresh and try again.";
     private readonly IBudgetMonthUpdateNotifier budgetMonthUpdates = budgetMonthUpdateNotifier ?? NullBudgetMonthUpdateNotifier.Instance;
+    private readonly IBudgetMonthDataCache monthDataCache = budgetMonthDataCache ?? NullBudgetMonthDataCache.Instance;
 
     [HttpGet]
     public async Task<PendingExpenseDto[]> GetAll(
@@ -28,31 +30,42 @@ public class PendingExpensesController(
         [FromQuery] string? search = null,
         [FromQuery] int? assigneeId = null)
     {
-        var query = context.PendingExpenses
-            .Include(x => x.Assignee)
-            .Include(x => x.SuggestedCategory)
-            .AsQueryable();
+        var monthDate = month?.StartOfMonth();
+        var searchText = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+        var cacheVariant = BuildCacheVariant(searchText, assigneeId);
 
-        if (month.HasValue)
-        {
-            var start = month.Value.StartOfMonth();
-            var end = start.EndOfMonth();
-            query = query.Where(x => x.Date >= start && x.Date <= end);
-        }
+        return await monthDataCache.GetOrCreateAsync(
+            scope: "pending-expenses",
+            month: monthDate,
+            cacheVariant: cacheVariant,
+            valueFactory: async () =>
+            {
+                var query = context.PendingExpenses
+                    .Include(x => x.Assignee)
+                    .Include(x => x.SuggestedCategory)
+                    .AsQueryable();
 
-        if (!string.IsNullOrWhiteSpace(search))
-            query = ApplySearchFilter(query, search);
+                if (monthDate.HasValue)
+                {
+                    var start = monthDate.Value;
+                    var end = start.EndOfMonth();
+                    query = query.Where(x => x.Date >= start && x.Date <= end);
+                }
 
-        if (assigneeId.HasValue)
-            query = query.Where(x => x.AssigneeId == assigneeId.Value);
+                if (searchText is not null)
+                    query = ApplySearchFilter(query, searchText);
 
-        // Oldest first: pending expenses are worked off like a queue.
-        var items = await query
-            .OrderBy(x => x.Date)
-            .ThenBy(x => x.ID)
-            .ToListAsync();
+                if (assigneeId.HasValue)
+                    query = query.Where(x => x.AssigneeId == assigneeId.Value);
 
-        return items.Select(ToDto).ToArray();
+                // Oldest first: pending expenses are worked off like a queue.
+                var items = await query
+                    .OrderBy(x => x.Date)
+                    .ThenBy(x => x.ID)
+                    .ToListAsync();
+
+                return items.Select(ToDto).ToArray();
+            });
     }
 
     [HttpGet("oldest-month")]
@@ -112,6 +125,7 @@ public class PendingExpensesController(
         {
             return Conflict(ConcurrencyConflictMessage);
         }
+        monthDataCache.InvalidateMonth(pending.Date);
 
         // AssigneeId may have changed since the initial .Include(x => x.Assignee) load, so the
         // Assignee navigation may now be stale (pointing at the old assignee, or non-null when
@@ -145,6 +159,7 @@ public class PendingExpensesController(
         {
             return Conflict(ConcurrencyConflictMessage);
         }
+        monthDataCache.InvalidateMonth(pending.Date);
         return NoContent();
     }
 
@@ -160,6 +175,7 @@ public class PendingExpensesController(
         [FromQuery] int? assigneeId = null)
     {
         var query = context.PendingExpenses.AsQueryable();
+        var searchText = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
 
         if (month.HasValue)
         {
@@ -168,14 +184,19 @@ public class PendingExpensesController(
             query = query.Where(x => x.Date >= start && x.Date <= end);
         }
 
-        if (!string.IsNullOrWhiteSpace(search))
-            query = ApplySearchFilter(query, search);
+        if (searchText is not null)
+            query = ApplySearchFilter(query, searchText);
 
         if (assigneeId.HasValue)
             query = query.Where(x => x.AssigneeId == assigneeId.Value);
 
-        context.PendingExpenses.RemoveRange(query);
+        var itemsToDelete = await query
+            .AsTracking()
+            .ToListAsync();
+
+        context.PendingExpenses.RemoveRange(itemsToDelete);
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateMonths(itemsToDelete.Select(x => x.Date));
         return NoContent();
     }
 
@@ -207,6 +228,7 @@ public class PendingExpensesController(
         }
 
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateMonths(pendingExpenses.Select(x => x.Date));
         return Ok(new ReapplyPendingExpenseRulesResponse(pendingExpenses.Count));
     }
 
@@ -254,9 +276,14 @@ public class PendingExpensesController(
             return Conflict(ConcurrencyConflictMessage);
         }
 
-        await budgetMonthUpdates.NotifyMonthUpdated(item.Date);
+        var changedMonths = new[] { pending.Date, item.Date };
+        monthDataCache.InvalidateMonths(changedMonths);
+        await budgetMonthUpdates.NotifyMonthsUpdated(changedMonths);
         return StatusCode(201);
     }
+
+    private static string BuildCacheVariant(string? search, int? assigneeId)
+        => $"search={search ?? string.Empty};assigneeId={assigneeId?.ToString() ?? string.Empty}";
 
     private static PendingExpenseDto ToDto(PendingExpense p) => new(
         Id: p.ID,

--- a/SimplyBudgetWeb/Controllers/TransactionsController.cs
+++ b/SimplyBudgetWeb/Controllers/TransactionsController.cs
@@ -9,9 +9,11 @@ namespace SimplyBudgetWeb.Controllers;
 [Route("api/transactions")]
 public class TransactionsController(
     BudgetWebContext context,
-    IBudgetMonthUpdateNotifier? budgetMonthUpdateNotifier = null) : ControllerBase
+    IBudgetMonthUpdateNotifier? budgetMonthUpdateNotifier = null,
+    IBudgetMonthDataCache? budgetMonthDataCache = null) : ControllerBase
 {
     private readonly IBudgetMonthUpdateNotifier budgetMonthUpdates = budgetMonthUpdateNotifier ?? NullBudgetMonthUpdateNotifier.Instance;
+    private readonly IBudgetMonthDataCache monthDataCache = budgetMonthDataCache ?? NullBudgetMonthDataCache.Instance;
 
     [HttpPost("transaction")]
     public async Task<IActionResult> AddTransaction([FromBody] TransactionRequest request)
@@ -27,6 +29,7 @@ public class TransactionsController(
             item.Notes = notes;
             await context.SaveChangesAsync();
         }
+        monthDataCache.InvalidateMonth(request.Date);
         await budgetMonthUpdates.NotifyMonthUpdated(request.Date);
         return StatusCode(201);
     }
@@ -45,6 +48,7 @@ public class TransactionsController(
             item.Notes = notes;
             await context.SaveChangesAsync();
         }
+        monthDataCache.InvalidateMonth(request.Date);
         await budgetMonthUpdates.NotifyMonthUpdated(request.Date);
         return StatusCode(201);
     }
@@ -59,6 +63,7 @@ public class TransactionsController(
         if (toCategory is null) return NotFound($"Category {request.ToCategoryId} not found.");
 
         await context.AddTransfer(request.Description, request.Date, request.Amount, fromCategory, toCategory);
+        monthDataCache.InvalidateMonth(request.Date);
         await budgetMonthUpdates.NotifyMonthUpdated(request.Date);
         return StatusCode(201);
     }

--- a/SimplyBudgetWeb/Program.cs
+++ b/SimplyBudgetWeb/Program.cs
@@ -15,6 +15,7 @@ builder.AddServiceDefaults()
 // Add services to the container.
 builder.Services.AddControllers();
 builder.Services.AddSignalR();
+builder.Services.AddMemoryCache();
 
 // Swagger is only mapped in Development, so avoid paying to build the generator and its
 // document/schema services on a production cold start.
@@ -99,6 +100,7 @@ builder.Services.AddAuthorization(options =>
 
 builder.Services.AddScoped<CurrentUserSyncService>();
 builder.Services.AddScoped<IBudgetMonthUpdateNotifier, BudgetMonthUpdateNotifier>();
+builder.Services.AddSingleton<IBudgetMonthDataCache, BudgetMonthDataCache>();
 
 var app = builder.Build();
 

--- a/SimplyBudgetWeb/Services/BudgetMonthDataCache.cs
+++ b/SimplyBudgetWeb/Services/BudgetMonthDataCache.cs
@@ -1,0 +1,125 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+
+using SimplyBudgetShared.Utilities;
+
+namespace SimplyBudgetWeb.Services;
+
+public interface IBudgetMonthDataCache
+{
+    Task<T> GetOrCreateAsync<T>(
+        string scope,
+        DateTime? month,
+        string cacheVariant,
+        Func<Task<T>> valueFactory,
+        CancellationToken cancellationToken = default);
+
+    void InvalidateMonth(DateTime month);
+    void InvalidateMonths(IEnumerable<DateTime> months);
+}
+
+public sealed class BudgetMonthDataCache(IMemoryCache cache) : IBudgetMonthDataCache
+{
+    private const string AllMonthsKey = "all-months";
+    private static readonly TimeSpan CacheEntryLifetime = TimeSpan.FromMinutes(5);
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> monthTokens = new(StringComparer.Ordinal);
+
+    public Task<T> GetOrCreateAsync<T>(
+        string scope,
+        DateTime? month,
+        string cacheVariant,
+        Func<Task<T>> valueFactory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+        ArgumentNullException.ThrowIfNull(valueFactory);
+
+        var monthKey = ToMonthKey(month);
+        var normalizedVariant = string.IsNullOrWhiteSpace(cacheVariant)
+            ? "default"
+            : cacheVariant.Trim();
+        var cacheKey = $"screen:{scope}:month:{monthKey}:variant:{normalizedVariant}";
+
+        return cache.GetOrCreateAsync(cacheKey, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = CacheEntryLifetime;
+            entry.AddExpirationToken(new CancellationChangeToken(GetToken(monthKey).Token));
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return await valueFactory();
+        })!;
+    }
+
+    public void InvalidateMonth(DateTime month)
+    {
+        InvalidateMonthKey(ToMonthKey(month.StartOfMonth()));
+        InvalidateMonthKey(AllMonthsKey);
+    }
+
+    public void InvalidateMonths(IEnumerable<DateTime> months)
+    {
+        ArgumentNullException.ThrowIfNull(months);
+
+        var monthKeys = months
+            .Select(x => ToMonthKey(x.StartOfMonth()))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (monthKeys.Length == 0)
+            return;
+
+        foreach (var monthKey in monthKeys)
+            InvalidateMonthKey(monthKey);
+
+        InvalidateMonthKey(AllMonthsKey);
+    }
+
+    private CancellationTokenSource GetToken(string monthKey)
+        => monthTokens.GetOrAdd(monthKey, _ => new CancellationTokenSource());
+
+    private void InvalidateMonthKey(string monthKey)
+    {
+        if (!monthTokens.TryRemove(monthKey, out var tokenSource))
+            return;
+
+        tokenSource.Cancel();
+        tokenSource.Dispose();
+    }
+
+    private static string ToMonthKey(DateTime? month)
+        => month.HasValue ? ToMonthKey(month.Value) : AllMonthsKey;
+
+    private static string ToMonthKey(DateTime month)
+        => month.ToString("yyyy-MM", CultureInfo.InvariantCulture);
+}
+
+public sealed class NullBudgetMonthDataCache : IBudgetMonthDataCache
+{
+    public static readonly NullBudgetMonthDataCache Instance = new();
+
+    private NullBudgetMonthDataCache()
+    {
+    }
+
+    public async Task<T> GetOrCreateAsync<T>(
+        string scope,
+        DateTime? month,
+        string cacheVariant,
+        Func<Task<T>> valueFactory,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await valueFactory();
+    }
+
+    public void InvalidateMonth(DateTime month)
+    {
+    }
+
+    public void InvalidateMonths(IEnumerable<DateTime> months)
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `IBudgetMonthDataCache`/`BudgetMonthDataCache` service backed by `IMemoryCache` with keys that include `yyyy-MM` month scope
- cache API reads for budget (`/api/budget`), history/expense (`/api/history`), and pending expenses (`/api/pending-expenses`) using month-aware keys plus query-filter variants
- invalidate month cache entries when that month is updated from transactions, history edits/deletes, pending expense updates/deletes/reapply/convert, and import save
- update controller tests and add dedicated cache service tests for month-key behavior and month invalidation

## Validation
- `dotnet test --project SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj --configuration Release --verbosity minimal`