### PR TITLE
Fix budget averages to divide by full month window

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/BudgetControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/BudgetControllerTests.cs
@@ -195,4 +195,62 @@ public class BudgetControllerTests
 
         await Assert.That(aprilBudget.EstimatedMonthlyIncome).IsEqualTo(6000);
     }
+
+    [Test]
+    public async Task Get_CategoryAverages_DivideByRequestedMonthCount()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory
+            {
+                Name = "Taxes",
+                Description = "Tax payments",
+            };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+
+            context.ExpenseCategoryItems.AddRange(
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2025, 10, 7),
+                    Description = "October tax payment",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = -3000,
+                            ExpenseCategoryId = category.ID,
+                        },
+                    ],
+                },
+                new ExpenseCategoryItem
+                {
+                    Date = new DateTime(2025, 12, 10),
+                    Description = "December tax payment",
+                    Details =
+                    [
+                        new ExpenseCategoryItemDetail
+                        {
+                            Amount = -3000,
+                            ExpenseCategoryId = category.ID,
+                        },
+                    ],
+                });
+            await context.SaveChangesAsync();
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
+        var controller = new BudgetController(context);
+
+        var aprilBudget = await controller.Get(new DateTime(2026, 4, 1));
+        var category = aprilBudget.Categories.Single();
+
+        await Assert.That(category.ThreeMonthAverage).IsEqualTo(0);
+        await Assert.That(category.SixMonthAverage).IsEqualTo(1000);
+        await Assert.That(category.TwelveMonthAverage).IsEqualTo(500);
+    }
 }

--- a/SimplyBudgetWeb/Controllers/BudgetController.cs
+++ b/SimplyBudgetWeb/Controllers/BudgetController.cs
@@ -119,14 +119,13 @@ public class BudgetController(
     private static int CalculateAverage(IList<ExpenseCategoryItemDetail> categoryItems, DateTime month, int numMonths)
     {
         var rangeStart = month.AddMonths(-numMonths);
-        var items = categoryItems
+        int totalSpend = categoryItems
             .Where(x => !x.IgnoreBudget && x.Amount < 0 &&
                 x.ExpenseCategoryItem?.Date >= rangeStart &&
                 x.ExpenseCategoryItem?.Date < month)
-            .GroupBy(x => x.ExpenseCategoryItem?.Date.StartOfMonth())
-            .Select(g => g.Sum(x => -x.Amount))
-            .ToList();
-        return items.Any() ? (int)items.Average() : 0;
+            .Sum(x => -x.Amount);
+
+        return totalSpend / numMonths;
     }
 }
 


### PR DESCRIPTION
## Summary\n- fix category average calculations to divide by the requested month count (3/6/12), including months with no spending\n- add a regression test to cover sparse historical spending months\n\n## Why\nThe budget chips were showing total/sparse-month averages instead of true monthly averages across the selected window.