### PR TITLE
Invalidate budget cache when editing expense categories

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetWeb.Controllers;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
 
 namespace SimplyBudgetWeb.Core.Tests.Controllers;
 
@@ -273,6 +274,31 @@ public class ExpenseCategoriesControllerTests
         await Assert.That(result.Value!.Name).IsEqualTo("New Name");
         await Assert.That(result.Value!.Description).IsEqualTo("New Description");
         await Assert.That(result.Value!.CategoryName).IsEqualTo("New Group");
+    }
+
+    [Test]
+    public async Task Update_InvalidatesBudgetMonthCache()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+        var cache = new Mock<IBudgetMonthDataCache>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries", BudgetedAmount = 5000 };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context, budgetMonthDataCache: cache.Object);
+
+        _ = await controller.Update(categoryId, new ExpenseCategoryRequest(
+            Name: "Groceries", Description: null, CategoryName: null,
+            BudgetedAmount: 7500, BudgetedPercentage: 0, Cap: null, AccountId: null));
+
+        cache.Verify(x => x.InvalidateAllMonths(), Times.Once);
     }
 
     [Test]

--- a/SimplyBudgetWeb.Core.Tests/Services/BudgetMonthDataCacheTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Services/BudgetMonthDataCacheTests.cs
@@ -92,4 +92,47 @@ public class BudgetMonthDataCacheTests
 
         await Assert.That(valueAfterInvalidation).IsEqualTo("all-2");
     }
+
+    [Test]
+    public async Task InvalidateAllMonths_RemovesEntriesForEveryMonth()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var cache = new BudgetMonthDataCache(memoryCache);
+
+        int januaryFactoryCallCount = 0;
+        int februaryFactoryCallCount = 0;
+        int allMonthsFactoryCallCount = 0;
+
+        Task<string> CreateJanuaryValue()
+        {
+            januaryFactoryCallCount++;
+            return Task.FromResult($"jan-{januaryFactoryCallCount}");
+        }
+
+        Task<string> CreateFebruaryValue()
+        {
+            februaryFactoryCallCount++;
+            return Task.FromResult($"feb-{februaryFactoryCallCount}");
+        }
+
+        Task<string> CreateAllMonthsValue()
+        {
+            allMonthsFactoryCallCount++;
+            return Task.FromResult($"all-{allMonthsFactoryCallCount}");
+        }
+
+        _ = await cache.GetOrCreateAsync("budget", new DateTime(2026, 1, 1), "default", CreateJanuaryValue);
+        _ = await cache.GetOrCreateAsync("budget", new DateTime(2026, 2, 1), "default", CreateFebruaryValue);
+        _ = await cache.GetOrCreateAsync("pending-expenses", null, "default", CreateAllMonthsValue);
+
+        cache.InvalidateAllMonths();
+
+        var januaryAfterInvalidation = await cache.GetOrCreateAsync("budget", new DateTime(2026, 1, 20), "default", CreateJanuaryValue);
+        var februaryAfterInvalidation = await cache.GetOrCreateAsync("budget", new DateTime(2026, 2, 20), "default", CreateFebruaryValue);
+        var allMonthsAfterInvalidation = await cache.GetOrCreateAsync("pending-expenses", null, "default", CreateAllMonthsValue);
+
+        await Assert.That(januaryAfterInvalidation).IsEqualTo("jan-2");
+        await Assert.That(februaryAfterInvalidation).IsEqualTo("feb-2");
+        await Assert.That(allMonthsAfterInvalidation).IsEqualTo("all-2");
+    }
 }

--- a/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
+++ b/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
@@ -3,14 +3,19 @@ using Microsoft.EntityFrameworkCore;
 using SimplyBudgetShared.Data;
 using SimplyBudgetShared.Utilities;
 using SimplyBudgetWeb.Data;
+using SimplyBudgetWeb.Services;
 using SimplyBudgetWeb.Utilities;
 
 namespace SimplyBudgetWeb.Controllers;
 
 [ApiController]
 [Route("api/expense-categories")]
-public class ExpenseCategoriesController(BudgetWebContext context) : ControllerBase
+public class ExpenseCategoriesController(
+    BudgetWebContext context,
+    IBudgetMonthDataCache? budgetMonthDataCache = null) : ControllerBase
 {
+    private readonly IBudgetMonthDataCache monthDataCache = budgetMonthDataCache ?? NullBudgetMonthDataCache.Instance;
+
     [HttpGet]
     public async Task<ExpenseCategoryDto[]> GetAll(
         [FromQuery] bool includeHidden = false,
@@ -168,6 +173,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         };
         context.ExpenseCategories.Add(category);
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateAllMonths();
         return CreatedAtAction(nameof(GetById), new { id = category.ID }, ToDto(category, hasItems: false));
     }
 
@@ -186,6 +192,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
         category.AccountID = request.AccountId;
 
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateAllMonths();
         return ToDto(category, await context.HasItemsAsync(category));
     }
 
@@ -201,6 +208,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
 
         category.IsHidden = true;
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateAllMonths();
         return ToDto(category, await context.HasItemsAsync(category));
     }
 
@@ -212,6 +220,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
 
         category.IsHidden = false;
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateAllMonths();
         return ToDto(category, await context.HasItemsAsync(category));
     }
 
@@ -230,6 +239,7 @@ public class ExpenseCategoriesController(BudgetWebContext context) : ControllerB
 
         context.ExpenseCategories.Remove(category);
         await context.SaveChangesAsync();
+        monthDataCache.InvalidateAllMonths();
         return NoContent();
     }
 

--- a/SimplyBudgetWeb/Services/BudgetMonthDataCache.cs
+++ b/SimplyBudgetWeb/Services/BudgetMonthDataCache.cs
@@ -19,6 +19,7 @@ public interface IBudgetMonthDataCache
 
     void InvalidateMonth(DateTime month);
     void InvalidateMonths(IEnumerable<DateTime> months);
+    void InvalidateAllMonths();
 }
 
 public sealed class BudgetMonthDataCache(IMemoryCache cache) : IBudgetMonthDataCache
@@ -77,6 +78,12 @@ public sealed class BudgetMonthDataCache(IMemoryCache cache) : IBudgetMonthDataC
         InvalidateMonthKey(AllMonthsKey);
     }
 
+    public void InvalidateAllMonths()
+    {
+        foreach (var monthKey in monthTokens.Keys)
+            InvalidateMonthKey(monthKey);
+    }
+
     private CancellationTokenSource GetToken(string monthKey)
         => monthTokens.GetOrAdd(monthKey, _ => new CancellationTokenSource());
 
@@ -120,6 +127,10 @@ public sealed class NullBudgetMonthDataCache : IBudgetMonthDataCache
     }
 
     public void InvalidateMonths(IEnumerable<DateTime> months)
+    {
+    }
+
+    public void InvalidateAllMonths()
     {
     }
 }


### PR DESCRIPTION
## Summary
- invalidate the month-based budget cache whenever expense categories are created, updated, hidden/restored, or deleted
- add an InvalidateAllMonths() method to the budget month cache interface and implement it for memory and null cache implementations
- add regression coverage for category-update invalidation and all-month cache invalidation behavior

## Why
Editing category budget amounts in Settings could leave the budget API serving a stale cached response for up to five minutes, so Budget would not reflect the change immediately.