### PR TITLE
Allow configuring expense category caps in Settings

### DIFF
--- a/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
+++ b/SimplyBudgetWeb.Core.Tests/Controllers/ExpenseCategoriesControllerTests.cs
@@ -102,13 +102,14 @@ public class ExpenseCategoriesControllerTests
 
             var result = await controller.Create(new ExpenseCategoryRequest(
                 Name: "  Groceries  ", Description: "Food", CategoryName: "Living",
-                BudgetedAmount: 5000, BudgetedPercentage: 0, Cap: null, AccountId: null));
+                BudgetedAmount: 5000, BudgetedPercentage: 0, Cap: 12000, AccountId: null));
 
             var created = result.Result as CreatedAtActionResult;
             await Assert.That(created).IsNotNull();
             var dto = (ExpenseCategoryDto)created!.Value!;
             await Assert.That(dto.Name).IsEqualTo("Groceries");
             await Assert.That(dto.BudgetedAmount).IsEqualTo(5000);
+            await Assert.That(dto.Cap).IsEqualTo(12000);
             await Assert.That(dto.UsePercentage).IsFalse();
             createdId = dto.Id;
         }
@@ -119,6 +120,7 @@ public class ExpenseCategoriesControllerTests
             await Assert.That(stored).IsNotNull();
             await Assert.That(stored!.CategoryName).IsEqualTo("Living");
             await Assert.That(stored.Description).IsEqualTo("Food");
+            await Assert.That(stored.Cap).IsEqualTo(12000);
         });
     }
 
@@ -235,6 +237,23 @@ public class ExpenseCategoriesControllerTests
     }
 
     [Test]
+    public async Task Create_ReturnsBadRequest_WhenCapIsNegative()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Create(new ExpenseCategoryRequest(
+            Name: "Groceries", Description: null, CategoryName: null,
+            BudgetedAmount: 100, BudgetedPercentage: 0, Cap: -1, AccountId: null));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+        await Assert.That(await context.ExpenseCategories.CountAsync()).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Create_ReturnsBadRequest_WhenAccountDoesNotExist()
     {
         AutoMocker mocker = new();
@@ -269,11 +288,40 @@ public class ExpenseCategoriesControllerTests
 
         var result = await controller.Update(categoryId, new ExpenseCategoryRequest(
             Name: "New Name", Description: "New Description", CategoryName: "New Group",
-            BudgetedAmount: 0, BudgetedPercentage: 0, Cap: null, AccountId: null));
+            BudgetedAmount: 0, BudgetedPercentage: 0, Cap: 25000, AccountId: null));
 
         await Assert.That(result.Value!.Name).IsEqualTo("New Name");
         await Assert.That(result.Value!.Description).IsEqualTo("New Description");
         await Assert.That(result.Value!.CategoryName).IsEqualTo("New Group");
+        await Assert.That(result.Value!.Cap).IsEqualTo(25000);
+    }
+
+    [Test]
+    public async Task Update_ReturnsBadRequest_WhenCapIsNegative()
+    {
+        AutoMocker mocker = new();
+        mocker.WithDbContext<BudgetWebContext>();
+
+        int categoryId = await mocker.InDbScopeAsync(async context =>
+        {
+            var category = new ExpenseCategory { Name = "Groceries", Cap = 1000 };
+            context.ExpenseCategories.Add(category);
+            await context.SaveChangesAsync();
+            return category.ID;
+        });
+
+        using var context = mocker.Get<BudgetWebContext>();
+        var controller = new ExpenseCategoriesController(context);
+
+        var result = await controller.Update(categoryId, new ExpenseCategoryRequest(
+            Name: "Groceries", Description: null, CategoryName: null,
+            BudgetedAmount: 100, BudgetedPercentage: 0, Cap: -100, AccountId: null));
+
+        await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+
+        var stored = await context.ExpenseCategories.FindAsync(categoryId);
+        await Assert.That(stored).IsNotNull();
+        await Assert.That(stored!.Cap).IsEqualTo(1000);
     }
 
     [Test]

--- a/SimplyBudgetWeb.Web/src/pages/Settings.vue
+++ b/SimplyBudgetWeb.Web/src/pages/Settings.vue
@@ -149,6 +149,7 @@ const editCategoryForm = ref({
   budgetType: 'fixed' as 'fixed' | 'percentage',
   budgetedAmount: '0.00',
   budgetedPercentage: '0',
+  cap: '',
 })
 const deleteCategory = ref<ExpenseCategoryDto | null>(null)
 const addCategoryOpen = ref(false)
@@ -160,8 +161,23 @@ const newCategoryForm = ref({
   budgetType: 'fixed' as 'fixed' | 'percentage',
   budgetedAmount: '0.00',
   budgetedPercentage: '0',
+  cap: '',
   accountId: null as number | null,
 })
+
+function parseOptionalNonNegativeDollars(value: string): { valid: boolean; value: number | null } {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return { valid: true, value: null }
+  }
+
+  const parsed = Number.parseFloat(trimmed)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return { valid: false, value: null }
+  }
+
+  return { valid: true, value: Math.round(parsed * 100) }
+}
 
 async function fetchCurrentUserProfile() {
   profileLoading.value = true
@@ -531,6 +547,7 @@ function startEditCategory(category: ExpenseCategoryDto) {
     budgetType: category.usePercentage ? 'percentage' : 'fixed',
     budgetedAmount: centsToDollars(category.budgetedAmount),
     budgetedPercentage: category.budgetedPercentage.toString(),
+    cap: category.cap === null ? '' : centsToDollars(category.cap),
   }
 }
 
@@ -538,6 +555,7 @@ async function handleSaveCategoryEdit(category: ExpenseCategoryDto) {
   const budgetType = editCategoryForm.value.budgetType
   const budgetedAmount = dollarsToCents(editCategoryForm.value.budgetedAmount)
   const budgetedPercentage = Number.parseInt(editCategoryForm.value.budgetedPercentage, 10)
+  const parsedCap = parseOptionalNonNegativeDollars(editCategoryForm.value.cap)
 
   if (budgetType === 'fixed' && (Number.isNaN(budgetedAmount) || budgetedAmount < 0)) {
     snackbar.enqueueSnackbar('Budgeted amount must be 0 or greater', { variant: 'error' })
@@ -549,6 +567,11 @@ async function handleSaveCategoryEdit(category: ExpenseCategoryDto) {
     return
   }
 
+  if (!parsedCap.valid) {
+    snackbar.enqueueSnackbar('Cap must be a valid amount that is 0 or greater', { variant: 'error' })
+    return
+  }
+
   try {
     await apiClient.put(`/api/expense-categories/${category.id}`, {
       name: editCategoryForm.value.name,
@@ -556,7 +579,7 @@ async function handleSaveCategoryEdit(category: ExpenseCategoryDto) {
       categoryName: editCategoryForm.value.categoryName,
       budgetedAmount: budgetType === 'fixed' ? budgetedAmount : 0,
       budgetedPercentage: budgetType === 'percentage' ? budgetedPercentage : 0,
-      cap: category.cap,
+      cap: parsedCap.value,
       accountId: category.accountId,
     })
     snackbar.enqueueSnackbar('Category updated', { variant: 'success' })
@@ -590,6 +613,7 @@ function resetNewCategoryForm() {
     budgetType: 'fixed',
     budgetedAmount: '0.00',
     budgetedPercentage: '0',
+    cap: '',
     accountId: null,
   }
 }
@@ -612,6 +636,7 @@ async function handleAddCategory() {
   const budgetType = newCategoryForm.value.budgetType
   const budgetedAmount = dollarsToCents(newCategoryForm.value.budgetedAmount)
   const budgetedPercentage = Number.parseInt(newCategoryForm.value.budgetedPercentage, 10)
+  const parsedCap = parseOptionalNonNegativeDollars(newCategoryForm.value.cap)
 
   if (budgetType === 'fixed' && (Number.isNaN(budgetedAmount) || budgetedAmount < 0)) {
     snackbar.enqueueSnackbar('Budgeted amount must be 0 or greater', { variant: 'error' })
@@ -623,6 +648,11 @@ async function handleAddCategory() {
     return
   }
 
+  if (!parsedCap.valid) {
+    snackbar.enqueueSnackbar('Cap must be a valid amount that is 0 or greater', { variant: 'error' })
+    return
+  }
+
   addCategorySaving.value = true
   try {
     await apiClient.post('/api/expense-categories', {
@@ -631,7 +661,7 @@ async function handleAddCategory() {
       categoryName: newCategoryForm.value.categoryName,
       budgetedAmount: budgetType === 'fixed' ? budgetedAmount : 0,
       budgetedPercentage: budgetType === 'percentage' ? budgetedPercentage : 0,
-      cap: null,
+      cap: parsedCap.value,
       accountId: newCategoryForm.value.accountId,
     })
     snackbar.enqueueSnackbar('Category added', { variant: 'success' })
@@ -1044,6 +1074,19 @@ watch(openPanel, (panel) => {
                       style="max-width: 160px;"
                       @keydown.enter="handleSaveCategoryEdit(category)"
                     />
+                    <v-text-field
+                      v-model="editCategoryForm.cap"
+                      label="Cap"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      density="compact"
+                      hide-details
+                      prefix="$"
+                      :disabled="editCategoryForm.budgetType !== 'fixed'"
+                      style="max-width: 160px;"
+                      @keydown.enter="handleSaveCategoryEdit(category)"
+                    />
                   </div>
                   <div v-else class="d-flex align-center" style="gap: 8px;">
                     <span>{{ category.name }}</span>
@@ -1053,6 +1096,7 @@ watch(openPanel, (panel) => {
                 <v-list-item-subtitle v-if="editCategoryId !== category.id">
                   <div>{{ category.categoryName ?? 'No group' }}</div>
                   <div v-if="category.description">{{ category.description }}</div>
+                  <div v-if="category.cap !== null">Cap: {{ formatCents(category.cap) }}</div>
                 </v-list-item-subtitle>
                 <template #append>
                   <div v-if="editCategoryId === category.id" class="d-flex" style="gap: 4px;">
@@ -1311,6 +1355,18 @@ watch(openPanel, (panel) => {
             min="1"
             max="100"
             suffix="%"
+            @keydown.enter="handleAddCategory"
+          />
+          <v-text-field
+            v-model="newCategoryForm.cap"
+            label="Cap"
+            type="number"
+            step="0.01"
+            min="0"
+            prefix="$"
+            hint="Optional maximum running balance for fixed-budget categories."
+            persistent-hint
+            :disabled="newCategoryForm.budgetType !== 'fixed'"
             @keydown.enter="handleAddCategory"
           />
         </v-card-text>

--- a/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
+++ b/SimplyBudgetWeb/Controllers/ExpenseCategoriesController.cs
@@ -180,6 +180,9 @@ public class ExpenseCategoriesController(
     [HttpPut("{id}")]
     public async Task<ActionResult<ExpenseCategoryDto>> Update(int id, [FromBody] ExpenseCategoryRequest request)
     {
+        if (Validate(request) is { } validationError)
+            return BadRequest(validationError);
+
         var category = await context.ExpenseCategories.FindAsync(id);
         if (category is null) return NotFound();
 
@@ -260,6 +263,9 @@ public class ExpenseCategoriesController(
 
         if (request.BudgetedAmount > 0 && request.BudgetedPercentage > 0)
             return "A category cannot use both a budgeted amount and a budgeted percentage.";
+
+        if (request.Cap is < 0)
+            return "Cap must be 0 or greater.";
 
         return null;
     }


### PR DESCRIPTION
## Summary
- add cap input to expense category add/edit flows in Settings
- show configured cap in the category list subtitle
- validate cap values client-side and server-side (must be 0 or greater)
- apply the same request validation on category updates and add controller test coverage

## Validation
- dotnet test --project SimplyBudgetWeb.Core.Tests/SimplyBudgetWeb.Core.Tests.csproj --no-build --configuration Release --verbosity minimal
- pnpm --dir SimplyBudgetWeb.Web run build